### PR TITLE
P0: Daily Puzzle atomic ladder publish + Daily Fritz hand lifecycle hardening

### DIFF
--- a/.github/workflows/gen-puzzles.yml
+++ b/.github/workflows/gen-puzzles.yml
@@ -33,3 +33,13 @@ jobs:
           # This ensures that each 6-hour run makes progress on missing dates without
           # wasting time re-generating thousands of existing puzzles.
           bash scripts/gen-puzzles.sh --from "$FROM" --days 365
+
+      - name: Verify today Pacific ladder is publish-ready
+        env:
+          SUPABASE_URL: https://fisfadjqllojdzibcdfx.supabase.co
+          SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+        run: |
+          export TZ=America/Los_Angeles
+          TODAY=$(date +%F)
+          echo "Diagnosing ladder readiness for $TODAY (Pacific)..."
+          npx tsx server/src/seedDailyPuzzleLadder.ts --date "$TODAY" --diagnose

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -31,6 +31,7 @@
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.4.24",
         "globals": "^16.5.0",
+        "playwright": "^1.60.0",
         "postcss": "^8.5.14",
         "prettier": "^3.8.1",
         "tailwindcss": "^3.4.17",
@@ -3877,6 +3878,53 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/client/package.json
+++ b/client/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
+    "qa:daily-fritz:hand-lifecycle": "node scripts/dailyFritzHandLifecycleQa.mjs",
     "test:bot": "ts-node --esm src/bot/botHeuristics.behaviorTests.ts",
     "benchmark:tier": "ts-node --esm src/bot/benchmark.ts ladder 200",
     "test:bot:tier": "ts-node --esm src/bot/tierDifficulty.behaviorTests.ts",
@@ -42,6 +43,7 @@
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.4.24",
     "globals": "^16.5.0",
+    "playwright": "^1.60.0",
     "postcss": "^8.5.14",
     "prettier": "^3.8.1",
     "tailwindcss": "^3.4.17",

--- a/client/scripts/dailyFritzHandLifecycleQa.mjs
+++ b/client/scripts/dailyFritzHandLifecycleQa.mjs
@@ -1,0 +1,197 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { chromium } from 'playwright';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const clientRoot = path.resolve(__dirname, '..');
+const repoRoot = path.resolve(clientRoot, '..');
+const artifactsDir = path.resolve(repoRoot, 'docs/qa-artifacts/daily-fritz-hand-lifecycle');
+const storageStatePath = path.resolve(clientRoot, '.auth/daily-fritz-qa.json');
+const reportPath = path.resolve(repoRoot, 'docs/daily-fritz-hand-lifecycle-qa-report.md');
+
+const requestedAppUrl = (process.env.DAILY_FRITZ_QA_APP_URL || process.env.TOURNAMENT_QA_APP_URL || '')
+  .trim()
+  .replace(/\/$/, '');
+const browserChannel = process.env.DAILY_FRITZ_QA_BROWSER_CHANNEL?.trim() || 'chrome';
+const headless = process.env.DAILY_FRITZ_QA_HEADLESS === '0' ? false : true;
+
+const results = [];
+
+function ensureDir(dirPath) {
+  fs.mkdirSync(dirPath, { recursive: true });
+}
+
+function record(id, label, passed, detail) {
+  results.push({ id, label, passed, detail });
+  const mark = passed ? 'PASS' : 'FAIL';
+  console.log(`[${mark}] ${id} — ${label}${detail ? `: ${detail}` : ''}`);
+}
+
+async function openDailyFritzMatch(page, appUrl) {
+  await page.goto(`${appUrl}/#/daily-fritz`, { waitUntil: 'domcontentloaded' });
+  await page.getByRole('heading', { name: 'Daily Fritz' }).waitFor({ state: 'visible', timeout: 20000 });
+  await page.locator('.df-pvf-start-btn').waitFor({ state: 'visible', timeout: 20000 });
+  await page.locator('.df-pvf-start-btn').click();
+  await page.locator('.bot-match-screen.bot-match-mode-daily-fritz').waitFor({ state: 'visible', timeout: 30000 });
+}
+
+async function isPlayerTurn(page) {
+  return page.locator('.wl-player-pill.is-you.is-active-turn').isVisible().catch(() => false);
+}
+
+async function tryOnePlayerMove(page) {
+  const playable = page.locator('.hand-container button.domino-tile:not(.unplayable):not(.disabled)');
+  if ((await playable.count()) === 0) return false;
+  await playable.first().click();
+  await page.waitForTimeout(300);
+  const zone = page.locator('.placement-zone.active').first();
+  if (await zone.isVisible().catch(() => false)) {
+    await zone.click();
+  }
+  await page.waitForTimeout(600);
+  return true;
+}
+
+async function playUntilHandOver(page, maxMoves = 30, maxMs = 120000) {
+  const started = Date.now();
+  for (let i = 0; i < maxMoves; i += 1) {
+    if (await page.getByTestId('hand-over-modal').isVisible().catch(() => false)) return true;
+    if (Date.now() - started > maxMs) break;
+    if (!(await isPlayerTurn(page))) {
+      await page.waitForTimeout(700);
+      continue;
+    }
+    const moved = await tryOnePlayerMove(page);
+    if (!moved) await page.waitForTimeout(500);
+  }
+  return page.getByTestId('hand-over-modal').isVisible().catch(() => false);
+}
+
+async function readProgressWidth(page) {
+  return page.getByTestId('hand-over-progress-track').evaluate((el) => {
+    const fill = el.querySelector('.hand-over-modal__progress-fill');
+    if (!fill) return null;
+    const width = getComputedStyle(fill).width;
+    const trackWidth = getComputedStyle(el).width;
+    const fillPx = Number.parseFloat(width);
+    const trackPx = Number.parseFloat(trackWidth);
+    if (!Number.isFinite(fillPx) || !Number.isFinite(trackPx) || trackPx <= 0) return null;
+    return fillPx / trackPx;
+  });
+}
+
+async function main() {
+  const appUrl = requestedAppUrl || 'http://127.0.0.1:5173';
+  ensureDir(artifactsDir);
+
+  const browser = await chromium.launch({ channel: browserChannel, headless });
+  const contextOptions = { viewport: { width: 1440, height: 960 } };
+  const context = fs.existsSync(storageStatePath)
+    ? await browser.newContext({ ...contextOptions, storageState: storageStatePath })
+    : await browser.newContext(contextOptions);
+  await context.addInitScript(() => {
+    window.localStorage.setItem('hasSeenWelcome', '1');
+  });
+
+  const page = await context.newPage();
+  try {
+    await openDailyFritzMatch(page, appUrl);
+    const startHandNumber = await page.locator('.wl-hand-number, .pvf-hand-pill').first().innerText().catch(() => '1');
+    await page.screenshot({ path: path.join(artifactsDir, 'df-hand-before-end.png'), fullPage: true });
+
+    const handOverReached = await playUntilHandOver(page);
+    record('DF-HAND-01', 'Hand-over modal appears after a completed hand', handOverReached, handOverReached ? '' : 'modal not visible');
+    if (!handOverReached) {
+      await page.screenshot({ path: path.join(artifactsDir, 'df-hand-modal-missing.png'), fullPage: true });
+      throw new Error('Hand-over modal never appeared');
+    }
+
+    await page.screenshot({ path: path.join(artifactsDir, 'df-hand-modal-visible.png'), fullPage: true });
+    const progressVisible = await page.getByTestId('hand-over-progress-track').isVisible();
+    record('DF-HAND-02', 'Yellow countdown progress track is visible', progressVisible);
+
+    const widthA = await readProgressWidth(page);
+    await page.waitForTimeout(1200);
+    const widthB = await readProgressWidth(page);
+    const countdownMoves =
+      widthA != null && widthB != null ? widthB < widthA - 0.02 || widthB < 0.95 : false;
+    record(
+      'DF-HAND-03',
+      'Countdown bar animates downward',
+      countdownMoves,
+      `widthA=${widthA?.toFixed?.(2) ?? 'n/a'} widthB=${widthB?.toFixed?.(2) ?? 'n/a'}`,
+    );
+
+    const advancedCleanly = await page
+      .waitForFunction(
+        () => !document.querySelector('[data-testid="hand-over-modal"]'),
+        undefined,
+        { timeout: 12000 },
+      )
+      .then(() => true)
+      .catch(() => false);
+    record('DF-HAND-04', 'Hand advances cleanly after countdown', advancedCleanly);
+    await page.waitForTimeout(800);
+    await page.screenshot({ path: path.join(artifactsDir, 'df-hand-after-advance.png'), fullPage: true });
+
+    let drawSmoke = false;
+    for (let i = 0; i < 12; i += 1) {
+      if (!(await isPlayerTurn(page))) {
+        await page.waitForTimeout(600);
+        continue;
+      }
+      const drawBtn = page.locator('button').filter({ hasText: /^Draw$/i });
+      if (await drawBtn.isVisible().catch(() => false)) {
+        await drawBtn.click();
+        await page.waitForTimeout(500);
+        drawSmoke = await page.locator('.hand-container .domino-tile.new-draw').first().isVisible().catch(() => false);
+        if (drawSmoke) break;
+      }
+      await tryOnePlayerMove(page);
+    }
+    record(
+      'DF-HAND-05',
+      'Draw feedback visible (flying tile or new-draw pulse)',
+      drawSmoke,
+      drawSmoke ? 'new-draw pulse' : 'no forced draw scenario in sampled moves',
+    );
+    if (drawSmoke) {
+      await page.screenshot({ path: path.join(artifactsDir, 'df-hand-draw-pulse.png'), fullPage: true });
+    }
+
+    const endHandNumber = await page.locator('.wl-hand-number, .pvf-hand-pill').first().innerText().catch(() => startHandNumber);
+    record(
+      'DF-HAND-06',
+      'Hand index advances after modal',
+      advancedCleanly && endHandNumber !== startHandNumber,
+      `start=${startHandNumber} end=${endHandNumber}`,
+    );
+  } finally {
+    await context.close();
+    await browser.close();
+  }
+
+  const passed = results.filter((r) => r.passed).length;
+  const failed = results.length - passed;
+  const lines = [
+    '# Daily Fritz Hand Lifecycle QA',
+    '',
+    `App: ${requestedAppUrl || 'http://127.0.0.1:5173'}`,
+    `Result: ${failed === 0 ? 'PASS' : 'FAIL'} (${passed}/${results.length})`,
+    '',
+    '| ID | Scenario | Result | Detail |',
+    '| --- | --- | --- | --- |',
+    ...results.map((r) => `| ${r.id} | ${r.label} | ${r.passed ? 'PASS' : 'FAIL'} | ${r.detail || ''} |`),
+    '',
+    `Artifacts: ${artifactsDir}`,
+  ];
+  fs.writeFileSync(reportPath, `${lines.join('\n')}\n`);
+  console.log(`Report written to ${reportPath}`);
+  if (failed > 0) process.exitCode = 1;
+}
+
+void main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/client/src/bot/BotMatchScreen.tsx
+++ b/client/src/bot/BotMatchScreen.tsx
@@ -104,18 +104,29 @@ import {
   type DailyFritzStartResponse,
 } from '../dailyFritz/api';
 import { formatOrdinalPlace } from '../dailyFritz/format';
+import {
+  getDailyFritzMatchStorageKey,
+  loadPersistedDailyFritzMatchSnapshot,
+  persistDailyFritzMatchSnapshot,
+} from '../dailyFritz/storage';
 import { buildShareText } from '../dailyFritz/shareCard';
 import { DailyFritzFinalResultOverlay } from '../dailyFritz/DailyFritzFinalResultOverlay';
 import type { DailyFritzSetOverlayViewModel } from '../dailyFritz/setOverlayViewModel';
 import {
   canApplyNextHand,
+  DAILY_FRITZ_HAND_AUTO_ADVANCE_MS,
+  DAILY_FRITZ_HAND_REVEAL_DELAY_MS,
   emitHandLifecycleDebugLog,
+  getDailyFritzWatchdogDelayMs,
   isDailyFritzAdvanceLocked,
   isDailyFritzSetTerminal,
+  logDailyFritzHandBreadcrumb,
   logHandLifecycle,
   resolveDailyFritzNextHandCache,
+  resolveHandRevealScheduleMode,
   shouldAllowBotAction,
   shouldApplyBotActionResult,
+  shouldDailyFritzWatchdogAdvance,
   shouldShowHandRevealForHand,
   warnHandLifecycleStuck,
   type HandLifecyclePhase,
@@ -774,7 +785,10 @@ export default function BotMatchScreen({
 }: BotMatchScreenProps) {
   const dailyFritzStorageKey =
     mode === 'daily-fritz' && dailyFritzPackage
-      ? `racehorse:daily-fritz:v2:${dailyFritzPackage.attempt_id}:game:${dailyFritzPackage.current_game_number ?? 1}`
+      ? getDailyFritzMatchStorageKey(
+          dailyFritzPackage.attempt_id,
+          dailyFritzPackage.current_game_number ?? 1,
+        )
       : null;
   const [shareCopied, setShareCopied] = useState(false);
   const dailyFritzShareText = useMemo(
@@ -839,31 +853,18 @@ export default function BotMatchScreen({
       : `local-${Date.now()}-${Math.random().toString(16).slice(2)}`;
   const loadPersistedDailyFritzMatch = () => {
     if (!dailyFritzStorageKey || typeof window === 'undefined') return null;
-    try {
-      const raw = window.sessionStorage.getItem(dailyFritzStorageKey);
-      if (!raw) return null;
-      const parsed = JSON.parse(raw) as {
-        attemptId?: string;
-        currentHandIndex?: number;
-        match?: BotMatchState;
-        movesUsed?: number;
-        moveLog?: MoveEntry[];
-      };
-      if (parsed.attemptId !== dailyFritzPackage?.attempt_id || !parsed.match) return null;
-      const persistedHandIndex = Number(parsed.currentHandIndex);
-      const serverHandIndex = Number(dailyFritzPackage?.current_hand_index ?? 0);
-      if (!Number.isFinite(persistedHandIndex) || persistedHandIndex !== serverHandIndex) {
-        return null;
-      }
-      return parsed;
-    } catch {
-      return null;
-    }
+    return loadPersistedDailyFritzMatchSnapshot({
+      storageKey: dailyFritzStorageKey,
+      attemptId: dailyFritzPackage?.attempt_id,
+      currentHandIndex: Number(dailyFritzPackage?.current_hand_index ?? 0),
+      primaryStorage: window.localStorage,
+      fallbackStorage: window.sessionStorage,
+    });
   };
   const initialPersistedDailyFritzMatch = loadPersistedDailyFritzMatch();
   const DRAW_STEP_MS = 700;
-  const DAILY_FRITZ_REVEAL_DELAY_MS = 1400;
-  const DAILY_FRITZ_AUTO_ADVANCE_MS = 5000;
+  const DAILY_FRITZ_REVEAL_DELAY_MS = DAILY_FRITZ_HAND_REVEAL_DELAY_MS;
+  const DAILY_FRITZ_AUTO_ADVANCE_MS = DAILY_FRITZ_HAND_AUTO_ADVANCE_MS;
   const HAND_LIFECYCLE_DEBUG_ENDPOINT =
     'http://127.0.0.1:7933/ingest/9cab376f-7897-4cfa-8543-b458c17de979';
   const HAND_LIFECYCLE_DEBUG_SESSION = '65d5db';
@@ -1099,6 +1100,9 @@ export default function BotMatchScreen({
   const scoreToastHideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const scoreToastClearTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const handRevealTimerRef = useRef<ReturnType<typeof window.setTimeout> | null>(null);
+  const pendingHandRevealRef = useRef<{ handNumber: number; reveal: BotHandReveal } | null>(null);
+  const handRevealRef = useRef<BotHandReveal | null>(null);
+  handRevealRef.current = handReveal;
   const handAutoAdvanceTimerRef = useRef<ReturnType<typeof window.setTimeout> | null>(null);
   const handAdvanceRetryTimerRef = useRef<ReturnType<typeof window.setTimeout> | null>(null);
   const advanceHandRef = useRef<() => void>(() => {});
@@ -2447,20 +2451,32 @@ export default function BotMatchScreen({
 
   useEffect(() => {
     if (!isDailyFritzMode || !dailyFritzStorageKey || typeof window === 'undefined') return;
+    const flushPending = () => {
+      const pending = dailyFritzStoragePendingRef.current;
+      if (!pending) return;
+      try {
+        persistDailyFritzMatchSnapshot(window.localStorage, pending.key, pending.payload);
+        dailyFritzStoragePendingRef.current = null;
+      } catch {
+        // localStorage may be unavailable; keep the pending snapshot in memory
+        // so the pagehide handler can take one more best-effort pass.
+      }
+    };
     if (match.gameOver) {
       if (dailyFritzStorageTimerRef.current) {
         clearTimeout(dailyFritzStorageTimerRef.current);
         dailyFritzStorageTimerRef.current = null;
       }
       const finalSnapshot = {
-        attemptId: dailyFritzPackage?.attempt_id ?? null,
+        attemptId: dailyFritzPackage?.attempt_id ?? undefined,
         currentHandIndex: dailyFritzHandIndex,
         match,
         movesUsed,
         moveLog,
       };
       dailyFritzStoragePendingRef.current = { key: dailyFritzStorageKey, payload: finalSnapshot };
-      window.sessionStorage.setItem(dailyFritzStorageKey, JSON.stringify(finalSnapshot));
+      persistDailyFritzMatchSnapshot(window.localStorage, dailyFritzStorageKey, finalSnapshot);
+      dailyFritzStoragePendingRef.current = null;
       return;
     }
     if (dailyFritzStorageTimerRef.current) clearTimeout(dailyFritzStorageTimerRef.current);
@@ -2468,7 +2484,7 @@ export default function BotMatchScreen({
     // JSON.stringify — the expensive part — by 1 s so rapid tile plays don't
     // serialize on every move.
     const snapshot = {
-      attemptId: dailyFritzPackage?.attempt_id ?? null,
+      attemptId: dailyFritzPackage?.attempt_id ?? undefined,
       currentHandIndex: dailyFritzHandIndex,
       match,
       movesUsed,
@@ -2478,7 +2494,7 @@ export default function BotMatchScreen({
     // latest state even if the debounce timer hasn't fired yet.
     dailyFritzStoragePendingRef.current = { key: dailyFritzStorageKey, payload: snapshot };
     dailyFritzStorageTimerRef.current = setTimeout(() => {
-      window.sessionStorage.setItem(dailyFritzStorageKey, JSON.stringify(snapshot));
+      persistDailyFritzMatchSnapshot(window.localStorage, dailyFritzStorageKey, snapshot);
       dailyFritzStoragePendingRef.current = null;
       dailyFritzStorageTimerRef.current = null;
     }, 1000);
@@ -2487,6 +2503,7 @@ export default function BotMatchScreen({
         clearTimeout(dailyFritzStorageTimerRef.current);
         dailyFritzStorageTimerRef.current = null;
       }
+      flushPending();
     };
   }, [dailyFritzHandIndex, dailyFritzPackage?.attempt_id, dailyFritzStorageKey, isDailyFritzMode, match, moveLog, movesUsed]);
 
@@ -2498,9 +2515,10 @@ export default function BotMatchScreen({
       const pending = dailyFritzStoragePendingRef.current;
       if (!pending) return;
       try {
-        window.sessionStorage.setItem(pending.key, JSON.stringify(pending.payload));
+        persistDailyFritzMatchSnapshot(window.localStorage, pending.key, pending.payload);
+        dailyFritzStoragePendingRef.current = null;
       } catch {
-        // sessionStorage may be unavailable during unload — fail silently
+        // localStorage may be unavailable during unload — fail silently
       }
     };
     window.addEventListener('pagehide', flush);
@@ -3352,7 +3370,10 @@ export default function BotMatchScreen({
       handLifecyclePhaseRef.current = 'resolving-hand';
       if (isDailyFritzMode) {
         lastDailyFlowLabelRef.current = 'hand-complete';
-        dailyFritzMinAdvanceAtRef.current = Date.now() + DAILY_FRITZ_REVEAL_DELAY_MS + DAILY_FRITZ_AUTO_ADVANCE_MS;
+        dailyFritzMinAdvanceAtRef.current =
+          Date.now()
+          + (resolveHandRevealScheduleMode(true) === 'immediate' ? 0 : DAILY_FRITZ_REVEAL_DELAY_MS)
+          + DAILY_FRITZ_AUTO_ADVANCE_MS;
         console.log('[daily-flow] hand complete detected', {
           handNumber: result.state.handNumber,
           winner: result.handEnded.winner,
@@ -3433,17 +3454,28 @@ export default function BotMatchScreen({
       const handEndedData = result.handEnded;
       const yourRemainingTiles = result.state.players.you.hand;
       const botRemainingTiles = result.state.players.bot.hand;
-      if (handRevealTimerRef.current) clearTimeout(handRevealTimerRef.current);
-      handRevealTimerRef.current = window.setTimeout(() => {
+      const revealPayload: BotHandReveal = {
+        winner: handEndedData.winner,
+        reason: handEndedData.reason,
+        pointsAwarded: handEndedData.pointsAwarded,
+        loserPips: handEndedData.loserPips,
+        calcText: handEndedData.calcText,
+        yourRemainingTiles,
+        botRemainingTiles,
+      };
+      pendingHandRevealRef.current = {
+        handNumber: result.state.handNumber,
+        reveal: revealPayload,
+      };
+      const showReveal = () => {
         const live = matchRef.current;
         if (!shouldShowHandRevealForHand(live.handNumber, result.state.handNumber)) {
           handRevealTimerRef.current = null;
-          if (import.meta.env.DEV) {
-            console.log('[hand-over] reveal skipped — stale hand timer', {
-              liveHandNumber: live.handNumber,
-              endedHandNumber: result.state.handNumber,
-            });
-          }
+          logDailyFritzHandBreadcrumb('reveal-skipped', {
+            liveHandNumber: live.handNumber,
+            endedHandNumber: result.state.handNumber,
+            mode: isDailyFritzMode ? 'daily-fritz' : mode,
+          });
           return;
         }
         if (isDailyFritzMode) {
@@ -3452,19 +3484,18 @@ export default function BotMatchScreen({
             handNumber: result.state.handNumber,
             handTransitionInFlight: handTransitionInFlightRef.current,
             prefetchReady: dailyFritzNextHandRef.current?.result != null,
+            schedule: resolveHandRevealScheduleMode(true),
           });
         }
-        setHandReveal({
-          winner: handEndedData.winner,
-          reason: handEndedData.reason,
-          pointsAwarded: handEndedData.pointsAwarded,
-          loserPips: handEndedData.loserPips,
-          calcText: handEndedData.calcText,
-          yourRemainingTiles,
-          botRemainingTiles,
-        });
+        setHandReveal(revealPayload);
         handRevealTimerRef.current = null;
-      }, DAILY_FRITZ_REVEAL_DELAY_MS);
+      };
+      if (handRevealTimerRef.current) clearTimeout(handRevealTimerRef.current);
+      if (resolveHandRevealScheduleMode(isDailyFritzMode) === 'immediate') {
+        showReveal();
+      } else {
+        handRevealTimerRef.current = window.setTimeout(showReveal, DAILY_FRITZ_REVEAL_DELAY_MS);
+      }
       if (result.handEnded.reason === 'blocked') {
         queueSound(() => playBlockedSound(isMuted), 0);
       }
@@ -3534,13 +3565,24 @@ export default function BotMatchScreen({
     }
 
     const boneyardEl = boneyardRef.current ?? guidedBoneyardAnchorRef.current;
-    if (!boneyardEl) return;
-    const from = boneyardEl.getBoundingClientRect();
     const targetEl =
       drawer === 'you'
         ? handAreaRef.current
         : opponentPillRef.current ?? guidedFritzAnchorRef.current;
-    if (!targetEl) return;
+    if (!boneyardEl || !targetEl) {
+      logDailyFritzHandBreadcrumb('draw-fallback', {
+        drawer,
+        hasBoneyardRef: Boolean(boneyardEl),
+        hasTargetRef: Boolean(targetEl),
+        handSize: drawer === 'you' ? nextState.players.you.hand.length : nextState.players.bot.hand.length,
+        usedPulse: drawer === 'you',
+      });
+      if (drawer === 'bot') {
+        showBoardToast(`${opponentLabel} drew a tile`, 'bot');
+      }
+      return;
+    }
+    const from = boneyardEl.getBoundingClientRect();
     const to = targetEl.getBoundingClientRect();
     const id = ++flyingTileIdRef.current;
     setFlyingTiles((prev) => [
@@ -3562,7 +3604,7 @@ export default function BotMatchScreen({
         ? document.body.querySelector('.flying-tile-overlay')
         : null,
     });
-  }, []);
+  }, [opponentLabel, showBoardToast]);
 
   const scheduleDrawStepAnimation = useCallback(
     (drawer: BotPlayerId, nextState: BotMatchState) => {
@@ -5360,6 +5402,7 @@ export default function BotMatchScreen({
       setHandAdvanceError(null);
       setShowManualHandAdvance(false);
       setHandReveal(null);
+      pendingHandRevealRef.current = null;
       dailyFritzMinAdvanceAtRef.current = null;
       traceHandLifecycle('dealing-next-hand', { source }, 'D');
       let applied = false;
@@ -5395,6 +5438,7 @@ export default function BotMatchScreen({
       } else {
         traceHandLifecycle('error', { source, reason: 'setMatch-noop' }, 'D');
         setHandAdvanceError('Could not start the next hand. Tap Continue to retry.');
+        logDailyFritzHandBreadcrumb('manual-advance-shown', { reason: 'setMatch-noop', source });
         setShowManualHandAdvance(true);
       }
     },
@@ -5565,12 +5609,24 @@ export default function BotMatchScreen({
           });
           // #endregion
           if (failureAttempt < 2) {
+            logDailyFritzHandBreadcrumb('manual-advance-shown', {
+              reason: 'next-hand-fetch-retry',
+              source,
+              failureAttempt,
+              error: errMsg,
+            });
             setShowManualHandAdvance(true);
             traceHandLifecycle('error', { source, error: errMsg, failureAttempt, willRetry: true }, 'C');
             scheduleHandAdvanceRetry(2500, 'next-hand-fetch-failed');
             return;
           }
           setHandAdvanceError(formatDailyFritzNextHandUserMessage(errMsg));
+          logDailyFritzHandBreadcrumb('manual-advance-shown', {
+            reason: 'next-hand-fetch-failed',
+            source,
+            failureAttempt,
+            error: errMsg,
+          });
           setShowManualHandAdvance(true);
           traceHandLifecycle('error', { source, error: errMsg, failureAttempt }, 'C');
           if (import.meta.env.DEV) {
@@ -5750,7 +5806,7 @@ export default function BotMatchScreen({
         // #endregion
       }
     };
-  }, [handReveal, match.gameOver, match.handNumber, isGuidedMode, isGuidedV2Mode, isDailyFritzMode, traceHandLifecycle]);
+  }, [handReveal, match.gameOver, isGuidedMode, isGuidedV2Mode, isDailyFritzMode, traceHandLifecycle]);
 
   useEffect(() => {
     if (!handReveal || match.gameOver || isGuidedMode || isGuidedV2Mode) {
@@ -5780,6 +5836,12 @@ export default function BotMatchScreen({
         data: { visibleMs, stallMs, inFlight: handTransitionInFlightRef.current },
       });
       // #endregion
+      logDailyFritzHandBreadcrumb('manual-advance-shown', {
+        reason: 'hand-reveal-stall',
+        visibleMs,
+        stallMs,
+        inFlight: handTransitionInFlightRef.current,
+      });
       setShowManualHandAdvance(true);
     }, stallMs);
     return () => window.clearTimeout(warnId);
@@ -5836,29 +5898,55 @@ export default function BotMatchScreen({
   }, [match.handOver, match.gameOver, handReveal, advanceHand, isDailyFritzMode, isGuidedV1MinimalMode, isGuidedV1OnlineMode]);
 
   // ── Daily Fritz watchdog ──────────────────────────────────────────────────
-  // If the game gets stuck in hand-over, recover whether the reveal is still
-  // hidden or already visible. This covers retryable next-hand fetch errors,
-  // hung prefetches, timer misses, and guard races.
+  // Restores a missing reveal when possible; only advances after the countdown gate.
   useEffect(() => {
     if (!isDailyFritzMode) return;
     if (!match.handOver || match.gameOver) return;
 
-    const watchdogMs = handReveal !== null ? 12_000 : 10_000;
+    const watchdogMs = getDailyFritzWatchdogDelayMs(handReveal !== null);
     const id = window.setTimeout(() => {
-      // Still stuck after the buffer window — attempt recovery.
-      if (!matchRef.current.handOver || matchRef.current.gameOver) return;
-      console.log('[daily-flow] watchdog fired — resetting guard and calling advanceHand', {
-        handNumber: match.handNumber,
+      const live = matchRef.current;
+      if (!live.handOver || live.gameOver) return;
+
+      if (!handRevealRef.current && pendingHandRevealRef.current) {
+        const pending = pendingHandRevealRef.current;
+        if (shouldShowHandRevealForHand(live.handNumber, pending.handNumber)) {
+          logDailyFritzHandBreadcrumb('reveal-restored', {
+            handNumber: pending.handNumber,
+            source: 'watchdog',
+          });
+          setHandReveal(pending.reveal);
+          return;
+        }
+      }
+
+      if (!shouldDailyFritzWatchdogAdvance({
+        handOver: live.handOver,
+        gameOver: live.gameOver,
+        handRevealVisible: handRevealRef.current !== null,
+        minAdvanceAt: dailyFritzMinAdvanceAtRef.current,
+        nowMs: Date.now(),
+      })) {
+        console.log('[daily-flow] watchdog skipped — reveal/countdown not finished', {
+          handNumber: live.handNumber,
+          revealVisible: handRevealRef.current !== null,
+          minAdvanceAt: dailyFritzMinAdvanceAtRef.current,
+        });
+        return;
+      }
+
+      console.log('[daily-flow] watchdog fired — advancing after reveal window', {
+        handNumber: live.handNumber,
         handTransitionInFlight: handTransitionInFlightRef.current,
         lastLabel: lastDailyFlowLabelRef.current,
-        revealVisible: handReveal !== null,
+        revealVisible: handRevealRef.current !== null,
       });
       handTransitionInFlightRef.current = false;
       advanceHandRef.current();
     }, watchdogMs);
 
     return () => window.clearTimeout(id);
-  }, [isDailyFritzMode, match.handOver, match.gameOver, handReveal]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [isDailyFritzMode, match.handOver, match.gameOver, handReveal]);
 
   useEffect(() => {
     if (match.currentPlayer !== 'you' || match.handOver || match.gameOver || drawSequenceActiveRef.current) return;

--- a/client/src/bot/BotMatchScreen.tsx
+++ b/client/src/bot/BotMatchScreen.tsx
@@ -104,11 +104,6 @@ import {
   type DailyFritzStartResponse,
 } from '../dailyFritz/api';
 import { formatOrdinalPlace } from '../dailyFritz/format';
-import {
-  getDailyFritzMatchStorageKey,
-  loadPersistedDailyFritzMatchSnapshot,
-  persistDailyFritzMatchSnapshot,
-} from '../dailyFritz/storage';
 import { buildShareText } from '../dailyFritz/shareCard';
 import { DailyFritzFinalResultOverlay } from '../dailyFritz/DailyFritzFinalResultOverlay';
 import type { DailyFritzSetOverlayViewModel } from '../dailyFritz/setOverlayViewModel';
@@ -785,10 +780,7 @@ export default function BotMatchScreen({
 }: BotMatchScreenProps) {
   const dailyFritzStorageKey =
     mode === 'daily-fritz' && dailyFritzPackage
-      ? getDailyFritzMatchStorageKey(
-          dailyFritzPackage.attempt_id,
-          dailyFritzPackage.current_game_number ?? 1,
-        )
+      ? `racehorse:daily-fritz:v2:${dailyFritzPackage.attempt_id}:game:${dailyFritzPackage.current_game_number ?? 1}`
       : null;
   const [shareCopied, setShareCopied] = useState(false);
   const dailyFritzShareText = useMemo(
@@ -853,13 +845,26 @@ export default function BotMatchScreen({
       : `local-${Date.now()}-${Math.random().toString(16).slice(2)}`;
   const loadPersistedDailyFritzMatch = () => {
     if (!dailyFritzStorageKey || typeof window === 'undefined') return null;
-    return loadPersistedDailyFritzMatchSnapshot({
-      storageKey: dailyFritzStorageKey,
-      attemptId: dailyFritzPackage?.attempt_id,
-      currentHandIndex: Number(dailyFritzPackage?.current_hand_index ?? 0),
-      primaryStorage: window.localStorage,
-      fallbackStorage: window.sessionStorage,
-    });
+    try {
+      const raw = window.sessionStorage.getItem(dailyFritzStorageKey);
+      if (!raw) return null;
+      const parsed = JSON.parse(raw) as {
+        attemptId?: string;
+        currentHandIndex?: number;
+        match?: BotMatchState;
+        movesUsed?: number;
+        moveLog?: MoveEntry[];
+      };
+      if (parsed.attemptId !== dailyFritzPackage?.attempt_id || !parsed.match) return null;
+      const persistedHandIndex = Number(parsed.currentHandIndex);
+      const serverHandIndex = Number(dailyFritzPackage?.current_hand_index ?? 0);
+      if (!Number.isFinite(persistedHandIndex) || persistedHandIndex !== serverHandIndex) {
+        return null;
+      }
+      return parsed;
+    } catch {
+      return null;
+    }
   };
   const initialPersistedDailyFritzMatch = loadPersistedDailyFritzMatch();
   const DRAW_STEP_MS = 700;
@@ -2451,32 +2456,20 @@ export default function BotMatchScreen({
 
   useEffect(() => {
     if (!isDailyFritzMode || !dailyFritzStorageKey || typeof window === 'undefined') return;
-    const flushPending = () => {
-      const pending = dailyFritzStoragePendingRef.current;
-      if (!pending) return;
-      try {
-        persistDailyFritzMatchSnapshot(window.localStorage, pending.key, pending.payload);
-        dailyFritzStoragePendingRef.current = null;
-      } catch {
-        // localStorage may be unavailable; keep the pending snapshot in memory
-        // so the pagehide handler can take one more best-effort pass.
-      }
-    };
     if (match.gameOver) {
       if (dailyFritzStorageTimerRef.current) {
         clearTimeout(dailyFritzStorageTimerRef.current);
         dailyFritzStorageTimerRef.current = null;
       }
       const finalSnapshot = {
-        attemptId: dailyFritzPackage?.attempt_id ?? undefined,
+        attemptId: dailyFritzPackage?.attempt_id ?? null,
         currentHandIndex: dailyFritzHandIndex,
         match,
         movesUsed,
         moveLog,
       };
       dailyFritzStoragePendingRef.current = { key: dailyFritzStorageKey, payload: finalSnapshot };
-      persistDailyFritzMatchSnapshot(window.localStorage, dailyFritzStorageKey, finalSnapshot);
-      dailyFritzStoragePendingRef.current = null;
+      window.sessionStorage.setItem(dailyFritzStorageKey, JSON.stringify(finalSnapshot));
       return;
     }
     if (dailyFritzStorageTimerRef.current) clearTimeout(dailyFritzStorageTimerRef.current);
@@ -2484,7 +2477,7 @@ export default function BotMatchScreen({
     // JSON.stringify — the expensive part — by 1 s so rapid tile plays don't
     // serialize on every move.
     const snapshot = {
-      attemptId: dailyFritzPackage?.attempt_id ?? undefined,
+      attemptId: dailyFritzPackage?.attempt_id ?? null,
       currentHandIndex: dailyFritzHandIndex,
       match,
       movesUsed,
@@ -2494,7 +2487,7 @@ export default function BotMatchScreen({
     // latest state even if the debounce timer hasn't fired yet.
     dailyFritzStoragePendingRef.current = { key: dailyFritzStorageKey, payload: snapshot };
     dailyFritzStorageTimerRef.current = setTimeout(() => {
-      persistDailyFritzMatchSnapshot(window.localStorage, dailyFritzStorageKey, snapshot);
+      window.sessionStorage.setItem(dailyFritzStorageKey, JSON.stringify(snapshot));
       dailyFritzStoragePendingRef.current = null;
       dailyFritzStorageTimerRef.current = null;
     }, 1000);
@@ -2503,7 +2496,6 @@ export default function BotMatchScreen({
         clearTimeout(dailyFritzStorageTimerRef.current);
         dailyFritzStorageTimerRef.current = null;
       }
-      flushPending();
     };
   }, [dailyFritzHandIndex, dailyFritzPackage?.attempt_id, dailyFritzStorageKey, isDailyFritzMode, match, moveLog, movesUsed]);
 
@@ -2515,10 +2507,9 @@ export default function BotMatchScreen({
       const pending = dailyFritzStoragePendingRef.current;
       if (!pending) return;
       try {
-        persistDailyFritzMatchSnapshot(window.localStorage, pending.key, pending.payload);
-        dailyFritzStoragePendingRef.current = null;
+        window.sessionStorage.setItem(pending.key, JSON.stringify(pending.payload));
       } catch {
-        // localStorage may be unavailable during unload — fail silently
+        // sessionStorage may be unavailable during unload — fail silently
       }
     };
     window.addEventListener('pagehide', flush);

--- a/client/src/bot/handLifecycle.behaviorTests.ts
+++ b/client/src/bot/handLifecycle.behaviorTests.ts
@@ -1,13 +1,18 @@
 import {
   canApplyNextHand,
+  DAILY_FRITZ_HAND_AUTO_ADVANCE_MS,
+  DAILY_FRITZ_HAND_REVEAL_DELAY_MS,
+  getDailyFritzWatchdogDelayMs,
   getHandLifecyclePhase,
   isDailyFritzAdvanceLocked,
   isDailyFritzSetTerminal,
   logHandLifecycle,
   resetHandLifecyclePhase,
   resolveDailyFritzNextHandCache,
+  resolveHandRevealScheduleMode,
   shouldAllowBotAction,
   shouldApplyBotActionResult,
+  shouldDailyFritzWatchdogAdvance,
   shouldShowHandRevealForHand,
 } from './handLifecycle.ts';
 
@@ -115,6 +120,57 @@ function testShouldShowHandRevealForHand(): void {
   assertEqual(shouldShowHandRevealForHand(3, 2), false, 'stale reveal timer');
 }
 
+function testHandRevealScheduleMode(): void {
+  assertEqual(resolveHandRevealScheduleMode(true), 'immediate', 'daily fritz immediate reveal');
+  assertEqual(resolveHandRevealScheduleMode(false), 'delayed', 'non-daily delayed reveal');
+}
+
+function testDailyFritzWatchdogGuards(): void {
+  assertEqual(
+    getDailyFritzWatchdogDelayMs(false),
+    DAILY_FRITZ_HAND_REVEAL_DELAY_MS + 3000,
+    'watchdog waits for reveal when hidden',
+  );
+  assertEqual(
+    getDailyFritzWatchdogDelayMs(true),
+    DAILY_FRITZ_HAND_AUTO_ADVANCE_MS + 4000,
+    'watchdog waits through countdown when visible',
+  );
+  assertEqual(
+    shouldDailyFritzWatchdogAdvance({
+      handOver: true,
+      gameOver: false,
+      handRevealVisible: false,
+      minAdvanceAt: null,
+      nowMs: 1000,
+    }),
+    false,
+    'watchdog cannot skip missing reveal',
+  );
+  assertEqual(
+    shouldDailyFritzWatchdogAdvance({
+      handOver: true,
+      gameOver: false,
+      handRevealVisible: true,
+      minAdvanceAt: 20_000,
+      nowMs: 10_000,
+    }),
+    false,
+    'watchdog respects min-advance gate',
+  );
+  assertEqual(
+    shouldDailyFritzWatchdogAdvance({
+      handOver: true,
+      gameOver: false,
+      handRevealVisible: true,
+      minAdvanceAt: 10_000,
+      nowMs: 10_000,
+    }),
+    true,
+    'watchdog may advance after reveal gate',
+  );
+}
+
 async function testResolveDailyFritzNextHandCache(): Promise<void> {
   let created = 0;
   const create = async () => {
@@ -185,6 +241,8 @@ async function run(): Promise<void> {
   testShouldApplyBotActionResult();
   testDailyFritzSetTerminal();
   testShouldShowHandRevealForHand();
+  testHandRevealScheduleMode();
+  testDailyFritzWatchdogGuards();
   testLifecyclePhaseAdvancesOnLog();
   testDailyFritzAdvanceLockWindow();
   await testResolveDailyFritzNextHandCache();

--- a/client/src/bot/handLifecycle.ts
+++ b/client/src/bot/handLifecycle.ts
@@ -88,6 +88,48 @@ export function shouldShowHandRevealForHand(
   return liveHandNumber === endedHandNumber;
 }
 
+export const DAILY_FRITZ_HAND_REVEAL_DELAY_MS = 1400;
+export const DAILY_FRITZ_HAND_AUTO_ADVANCE_MS = 5000;
+
+/** Daily Fritz shows hand result immediately; guided/bot modes keep a short delay. */
+export function resolveHandRevealScheduleMode(isDailyFritzMode: boolean): 'immediate' | 'delayed' {
+  return isDailyFritzMode ? 'immediate' : 'delayed';
+}
+
+export function getDailyFritzWatchdogDelayMs(handRevealVisible: boolean): number {
+  return handRevealVisible
+    ? DAILY_FRITZ_HAND_AUTO_ADVANCE_MS + 4000
+    : DAILY_FRITZ_HAND_REVEAL_DELAY_MS + 3000;
+}
+
+/** Watchdog may advance only after the hand-result modal has been shown and the countdown gate opens. */
+export function shouldDailyFritzWatchdogAdvance(input: {
+  handOver: boolean;
+  gameOver: boolean;
+  handRevealVisible: boolean;
+  minAdvanceAt: number | null;
+  nowMs: number;
+}): boolean {
+  if (!input.handOver || input.gameOver) return false;
+  if (!input.handRevealVisible) return false;
+  if (isDailyFritzAdvanceLocked(input.minAdvanceAt, input.nowMs)) return false;
+  return true;
+}
+
+export type DailyFritzHandBreadcrumbEvent =
+  | 'reveal-skipped'
+  | 'reveal-restored'
+  | 'draw-fallback'
+  | 'manual-advance-shown';
+
+/** Production-visible trust breadcrumbs for Daily Fritz hand lifecycle debugging. */
+export function logDailyFritzHandBreadcrumb(
+  event: DailyFritzHandBreadcrumbEvent,
+  detail: Record<string, unknown>,
+): void {
+  console.log(`[daily-flow] ${event}`, detail);
+}
+
 export function logHandLifecycle(payload: HandLifecycleLogPayload): void {
   const previousPhase = payload.previousPhase ?? lastPhase;
   lastPhase = payload.phase;

--- a/client/src/components/handOver/HandOverModal.tsx
+++ b/client/src/components/handOver/HandOverModal.tsx
@@ -157,6 +157,7 @@ export function HandOverModal({
   return (
     <div
       className="game-over-overlay hand-over-modal-overlay"
+      data-testid="hand-over-modal"
       role="dialog"
       aria-modal="true"
       aria-labelledby="hand-over-modal-title"
@@ -267,6 +268,7 @@ export function HandOverModal({
                     </div>
                     <div
                       className="hand-over-modal__progress-track"
+                      data-testid="hand-over-progress-track"
                       role="progressbar"
                       aria-valuemin={0}
                       aria-valuemax={100}

--- a/server/src/dailyPuzzleGeneration.test.ts
+++ b/server/src/dailyPuzzleGeneration.test.ts
@@ -97,7 +97,7 @@ describe('Daily Puzzle ladder generation budgets', () => {
     expect(result.topRejectionReasons.some((entry) => entry.reason === 'timeout')).toBe(true);
   });
 
-  it('classifies null branch tile errors as structural missing tile failures', async () => {
+  it('exhausts attempt budget on repeated missing tile builder failures instead of early abort', async () => {
     const result = await choosePuzzleForSlot('2026-05-17', tacticalProfile, {
       purpose: 'request',
       budget: {
@@ -110,15 +110,18 @@ describe('Daily Puzzle ladder generation budgets', () => {
         setupAndStrike: () => {
           throw new TypeError("Cannot read properties of null (reading 'tiles')");
         },
+        oneTurnHighScore: () => {
+          throw new TypeError("Cannot read properties of null (reading 'tiles')");
+        },
       },
       now: () => 1_000,
     });
 
     expect(result.ok).toBe(false);
     if (result.ok) return;
-    expect(result.reason).toBe('structural_failure');
-    expect(result.attemptsTried).toBe(4);
-    expect(result.topRejectionReasons).toContainEqual({ reason: 'missing_tiles', count: 4 });
+    expect(result.reason).toBe('attempt_limit');
+    expect(result.attemptsTried).toBe(20);
+    expect(result.topRejectionReasons).toContainEqual({ reason: 'missing_tiles', count: 20 });
   });
 
   it('uses a reported fallback tier when primary Tactical Setup fails but fallback type succeeds', async () => {
@@ -237,8 +240,9 @@ describe('Daily Puzzle ladder readiness and unavailable copy', () => {
     expect(getDailyPuzzleDisplayTitle(legacyFallbackSlot.slotIndex, legacyFallbackSlot.slotTitle)).toBe('Puzzle 2');
   });
 
-  it('keeps request-time generation behind an explicit env flag', () => {
+  it('keeps request-time generation opt-out via ENABLE_REQUEST_PUZZLE_GENERATION=false', () => {
     const source = readFileSync(resolve(__dirname, 'index.ts'), 'utf8');
+    expect(source).toContain('isRequestPuzzleGenerationEnabled');
     expect(source).toContain('ENABLE_REQUEST_PUZZLE_GENERATION');
     expect(source).toContain('request-time generation skipped');
   });

--- a/server/src/dailyPuzzleLadderPublish.ts
+++ b/server/src/dailyPuzzleLadderPublish.ts
@@ -1,0 +1,220 @@
+import {
+  isDailyPuzzleLadderReady,
+  normalizeDailyPuzzleSlot,
+  sortDailyPuzzleSlots,
+  type DailyPuzzleSlotRow,
+} from './dailyPuzzle';
+import {
+  assessDailyPuzzleLadderReadiness,
+  normalizePublishedSlotRows,
+} from './dailyPuzzleLadderReadiness';
+import type { LadderSlotGenerationProfile } from './seedDailyPuzzleLadder';
+
+const LADDER_SLOT_SELECT =
+  'id,puzzle_date,title,starting_board,starting_hand,max_moves,target_score,puzzle_type,deal_size,slot_index,slot_title,tier,slot_max_points,objective_type,objective_payload,set_version,published';
+
+type PostgrestResponseLike = {
+  ok: boolean;
+  status: number;
+  text(): Promise<string>;
+  json(): Promise<unknown>;
+};
+
+export type CuratedDailyPuzzlePayload = {
+  startingBoard: unknown;
+  startingHand: unknown[];
+  maxMoves: number;
+  targetScore: number;
+  puzzleType: string;
+  dealSize: number;
+};
+
+export type GeneratedLadderSlot = {
+  profile: LadderSlotGenerationProfile;
+  puzzle: CuratedDailyPuzzlePayload;
+  bestPossibleScore: number;
+};
+
+async function postgrestFetch(
+  path: string,
+  init?: RequestInit,
+  timeoutMs = 8_000,
+): Promise<PostgrestResponseLike> {
+  const supabaseUrl = process.env.SUPABASE_URL;
+  const serviceKey = process.env.SUPABASE_SERVICE_KEY;
+  if (!supabaseUrl) throw new Error('SUPABASE_URL is required.');
+  if (!serviceKey) throw new Error('SUPABASE_SERVICE_KEY is required.');
+  const url = new URL(path, supabaseUrl);
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(url, {
+      ...init,
+      headers: {
+        apikey: serviceKey,
+        Authorization: `Bearer ${serviceKey}`,
+        'Content-Type': 'application/json',
+        Prefer: 'resolution=merge-duplicates,return=representation',
+        ...(init?.headers ?? {}),
+      },
+      signal: init?.signal ?? controller.signal,
+    });
+  } catch (error) {
+    if (error instanceof Error && error.name === 'AbortError') {
+      throw new Error(`Supabase request timed out after ${timeoutMs}ms: ${path}`);
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export async function listPublishedLadderSlotRows(date: string): Promise<DailyPuzzleSlotRow[]> {
+  const response = await postgrestFetch(
+    `/rest/v1/daily_puzzles?select=${LADDER_SLOT_SELECT}&published=eq.true&puzzle_date=eq.${encodeURIComponent(date)}&order=set_version.asc,slot_index.asc,id.asc`,
+  );
+  if (!response.ok) return [];
+  const rows = (await response.json()) as DailyPuzzleSlotRow[];
+  return Array.isArray(rows) ? rows : [];
+}
+
+export async function isLadderReadyFromDatabase(date: string): Promise<boolean> {
+  try {
+    const rawRows = await listPublishedLadderSlotRows(date);
+    return isDailyPuzzleLadderReady(normalizePublishedSlotRows(rawRows));
+  } catch {
+    return false;
+  }
+}
+
+export async function unpublishLadderSlotsByIds(ids: string[]): Promise<number> {
+  const uniqueIds = [...new Set(ids.filter(Boolean))];
+  if (uniqueIds.length === 0) return 0;
+  const filter = uniqueIds.map((id) => encodeURIComponent(id)).join(',');
+  const response = await postgrestFetch(`/rest/v1/daily_puzzles?id=in.(${filter})`, {
+    method: 'PATCH',
+    headers: { Prefer: 'return=minimal' },
+    body: JSON.stringify({ published: false }),
+  });
+  if (!response.ok) {
+    throw new Error(`Failed to unpublish ladder slots: ${response.status} ${await response.text()}`);
+  }
+  return uniqueIds.length;
+}
+
+/**
+ * Unpublish published rows that do not form a complete ready ladder.
+ * Prevents players from seeing a broken 1–2 slot day.
+ */
+export async function scrubPartialPublishedLadderForDate(date: string): Promise<{
+  scrubbed: number;
+  ready: boolean;
+  readiness: ReturnType<typeof assessDailyPuzzleLadderReadiness>;
+}> {
+  const rawRows = await listPublishedLadderSlotRows(date);
+  const slots = normalizePublishedSlotRows(rawRows);
+  const readiness = assessDailyPuzzleLadderReadiness(date, slots);
+  if (readiness.ready) {
+    return { scrubbed: 0, ready: true, readiness };
+  }
+  if (slots.length === 0) {
+    return { scrubbed: 0, ready: false, readiness };
+  }
+  const scrubbed = await unpublishLadderSlotsByIds(slots.map((slot) => slot.id));
+  console.warn('[daily-puzzle-ladder] scrubbed-partial-publish', {
+    date,
+    scrubbed,
+    slotIndexes: slots.map((slot) => slot.slotIndex),
+    missingSlotIndexes: readiness.missingSlotIndexes,
+  });
+  return {
+    scrubbed,
+    ready: false,
+    readiness: assessDailyPuzzleLadderReadiness(date, []),
+  };
+}
+
+async function upsertPublishedSlot(
+  date: string,
+  config: {
+    slotIndex: number;
+    slotTitle: string;
+    tier: string;
+    slotMaxPoints: number;
+    puzzleType: string;
+  },
+  puzzle: CuratedDailyPuzzlePayload,
+  bestPossibleScore: number,
+): Promise<string[]> {
+  const response = await postgrestFetch('/rest/v1/daily_puzzles?on_conflict=puzzle_date,slot_index,set_version', {
+    method: 'POST',
+    body: JSON.stringify([
+      {
+        puzzle_date: date,
+        title: config.slotTitle,
+        starting_board: puzzle.startingBoard,
+        starting_hand: puzzle.startingHand,
+        max_moves: puzzle.maxMoves,
+        target_score: puzzle.targetScore,
+        puzzle_type: puzzle.puzzleType,
+        deal_size: puzzle.dealSize,
+        slot_index: config.slotIndex,
+        slot_title: config.slotTitle,
+        tier: config.tier,
+        slot_max_points: config.slotMaxPoints,
+        objective_type: puzzle.puzzleType,
+        objective_payload: {
+          best_possible_score: bestPossibleScore,
+        },
+        set_version: 1,
+        published: true,
+      },
+    ]),
+  });
+  if (!response.ok) {
+    throw new Error(`Failed to upsert slot ${config.slotIndex}: ${response.status} ${await response.text()}`);
+  }
+  const rows = (await response.json()) as Array<{ id?: string }> | null;
+  return Array.isArray(rows) ? rows.map((row) => row.id).filter((id): id is string => Boolean(id)) : [];
+}
+
+export async function publishGeneratedLadderSlots(
+  date: string,
+  generated: GeneratedLadderSlot[],
+): Promise<string[]> {
+  const publishedIds: string[] = [];
+  try {
+    for (const entry of generated) {
+      const ids = await upsertPublishedSlot(
+        date,
+        {
+          slotIndex: entry.profile.slotIndex,
+          slotTitle: entry.profile.slotTitle,
+          tier: entry.profile.tier,
+          slotMaxPoints: entry.profile.slotMaxPoints,
+          puzzleType: entry.puzzle.puzzleType,
+        },
+        entry.puzzle,
+        entry.bestPossibleScore,
+      );
+      publishedIds.push(...ids);
+    }
+    const rows = await listPublishedLadderSlotRows(date);
+    const slots = sortDailyPuzzleSlots(rows.map(normalizeDailyPuzzleSlot));
+    if (!isDailyPuzzleLadderReady(slots)) {
+      throw new Error('Ladder publish verification failed after upsert.');
+    }
+    return publishedIds;
+  } catch (error) {
+    if (publishedIds.length > 0) {
+      await unpublishLadderSlotsByIds(publishedIds).catch((rollbackError) => {
+        console.warn('[daily-puzzle-ladder] rollback-failed', {
+          date,
+          publishedIds,
+          error: rollbackError instanceof Error ? rollbackError.message : String(rollbackError),
+        });
+      });
+    }
+    throw error;
+  }
+}

--- a/server/src/dailyPuzzleLadderReadiness.test.ts
+++ b/server/src/dailyPuzzleLadderReadiness.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import {
+  assessDailyPuzzleLadderReadiness,
+  LADDER_READINESS_GRACE_MINUTES_PT,
+} from './dailyPuzzleLadderReadiness';
+import type { DailyPuzzleSlot } from './dailyPuzzle';
+
+function slot(overrides: Partial<DailyPuzzleSlot>): DailyPuzzleSlot {
+  return {
+    id: `slot-${overrides.slotIndex ?? 1}`,
+    puzzleDate: '2026-06-11',
+    slotIndex: 1,
+    slotTitle: 'Quick Line',
+    tier: 'quick_line',
+    puzzleType: 'one_turn_high_score',
+    maxMoves: 1,
+    targetScore: 999,
+    dealSize: 14,
+    slotMaxPoints: 150,
+    bestPossibleScore: 25,
+    startingBoard: { tiles: [] },
+    startingHand: [{ low: 1, high: 1 }],
+    objectiveType: 'one_turn_high_score',
+    objectivePayload: { best_possible_score: 25 },
+    setVersion: 1,
+    published: true,
+    ...overrides,
+  };
+}
+
+describe('dailyPuzzleLadderReadiness', () => {
+  it('marks a three-slot ladder ready', () => {
+    const readiness = assessDailyPuzzleLadderReadiness('2026-06-11', [
+      slot({ slotIndex: 1 }),
+      slot({ slotIndex: 2, slotTitle: 'Tactical Setup', tier: 'tactical_setup', slotMaxPoints: 250 }),
+      slot({ slotIndex: 3, slotTitle: 'Master Chain', tier: 'master_chain', slotMaxPoints: 400 }),
+    ]);
+    expect(readiness.ready).toBe(true);
+    expect(readiness.shouldAlert).toBe(false);
+    expect(readiness.missingSlotIndexes).toEqual([]);
+  });
+
+  it('flags partial publish as not ready and alerts after grace', () => {
+    const readiness = assessDailyPuzzleLadderReadiness(
+      '2026-06-11',
+      [slot({ slotIndex: 1 }), slot({ slotIndex: 3, slotTitle: 'Master Chain', tier: 'master_chain', slotMaxPoints: 400 })],
+      new Date('2026-06-11T08:30:00-07:00'),
+    );
+    expect(readiness.ready).toBe(false);
+    expect(readiness.publishedSlotCount).toBe(2);
+    expect(readiness.missingSlotIndexes).toEqual([2]);
+    expect(readiness.shouldAlert).toBe(true);
+    expect(readiness.alertReason).toContain('missing: 2');
+  });
+
+  it('does not alert before Pacific grace window ends', () => {
+    const readiness = assessDailyPuzzleLadderReadiness('2026-06-11', [], new Date('2026-06-11T00:05:00-07:00'));
+    expect(readiness.ready).toBe(false);
+    expect(readiness.shouldAlert).toBe(false);
+  });
+
+  it('exposes a 15-minute Pacific grace constant', () => {
+    expect(LADDER_READINESS_GRACE_MINUTES_PT).toBe(15);
+  });
+});

--- a/server/src/dailyPuzzleLadderReadiness.ts
+++ b/server/src/dailyPuzzleLadderReadiness.ts
@@ -1,0 +1,72 @@
+import { isDailyPuzzleLadderReady, normalizeDailyPuzzleSlot, sortDailyPuzzleSlots, type DailyPuzzleSlot } from './dailyPuzzle';
+
+const PACIFIC_TZ = 'America/Los_Angeles';
+
+export function getPacificDateKey(date: Date = new Date()): string {
+  return new Intl.DateTimeFormat('en-CA', {
+    timeZone: PACIFIC_TZ,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).format(date);
+}
+
+/** Minutes after Pacific midnight when today's ladder should be ready for players. */
+export const LADDER_READINESS_GRACE_MINUTES_PT = 15;
+
+export type DailyPuzzleLadderReadinessSnapshot = {
+  runDate: string;
+  ready: boolean;
+  publishedSlotCount: number;
+  missingSlotIndexes: number[];
+  legacySinglePuzzleDay: boolean;
+  shouldAlert: boolean;
+  alertReason: string | null;
+};
+
+export function assessDailyPuzzleLadderReadiness(
+  runDate: string,
+  publishedSlots: DailyPuzzleSlot[],
+  now: Date = new Date(),
+): DailyPuzzleLadderReadinessSnapshot {
+  const sorted = sortDailyPuzzleSlots(publishedSlots);
+  const ready = isDailyPuzzleLadderReady(sorted);
+  const present = new Set(sorted.map((slot) => slot.slotIndex));
+  const missingSlotIndexes = [1, 2, 3].filter((index) => !present.has(index as 1 | 2 | 3));
+  const shouldAlert = !ready && isPastLadderReadinessGracePt(runDate, now);
+  const alertReason = shouldAlert
+    ? `Daily Puzzle ladder for ${runDate} is not publish-ready (${sorted.length}/3 slots, missing: ${missingSlotIndexes.join(', ') || 'metadata'})`
+    : null;
+
+  return {
+    runDate,
+    ready,
+    publishedSlotCount: sorted.length,
+    missingSlotIndexes,
+    legacySinglePuzzleDay: !ready,
+    shouldAlert,
+    alertReason,
+  };
+}
+
+export function isPastLadderReadinessGracePt(runDate: string, now: Date = new Date()): boolean {
+  const todayPt = getPacificDateKey(now);
+  if (runDate !== todayPt) return false;
+
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone: PACIFIC_TZ,
+    hour: 'numeric',
+    minute: 'numeric',
+    hour12: false,
+  }).formatToParts(now);
+  const hour = Number(parts.find((part) => part.type === 'hour')?.value ?? '0');
+  const minute = Number(parts.find((part) => part.type === 'minute')?.value ?? '0');
+  const minutesSinceMidnight = hour * 60 + minute;
+  return minutesSinceMidnight >= LADDER_READINESS_GRACE_MINUTES_PT;
+}
+
+export function normalizePublishedSlotRows<T extends Parameters<typeof normalizeDailyPuzzleSlot>[0]>(
+  rows: T[],
+): DailyPuzzleSlot[] {
+  return sortDailyPuzzleSlots(rows.map((row) => normalizeDailyPuzzleSlot(row)));
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -61,6 +61,8 @@ import {
   getDailyFritzSkunkWinRank,
   normalizeDailyFritzSetSkunkFields,
 } from './dailyFritzSkunk';
+import { resetDailyFritzQaAttempt } from './dailyFritz/qaReset';
+import { restartDailyFritzUnsafeAttempt } from './dailyFritz/restartUnsafe';
 import {
   buildDailyPuzzleLeaderboard,
   calculateDailyPuzzleAwardedPoints,
@@ -83,6 +85,11 @@ import {
   type DailyPuzzleSlotRow,
 } from './dailyPuzzle';
 import { validateDailyPuzzleSubmission } from './dailyPuzzleSubmissionValidation';
+import {
+  assessDailyPuzzleLadderReadiness,
+  isPastLadderReadinessGracePt,
+} from './dailyPuzzleLadderReadiness';
+import { scrubPartialPublishedLadderForDate } from './dailyPuzzleLadderPublish';
 import { ensureDailyPuzzleLadderForDate } from './seedDailyPuzzleLadder';
 import {
   buildHomeDailySummary,
@@ -434,7 +441,38 @@ app.get('/ready', async (_req, res) => {
   const supabase = requiredEnvOk
     ? await getSupabaseReadiness()
     : { ok: false, latencyMs: 0, error: 'missing_required_env' };
-  const ok = requiredEnvOk && supabase.ok;
+
+  const todayPt = getPacificDateKey();
+  let dailyPuzzleLadder: ReturnType<typeof assessDailyPuzzleLadderReadiness> & { ok: boolean };
+  try {
+    const slots = requiredEnvOk ? await listDailyPuzzleSlotsForDate(todayPt) : [];
+    const readiness = assessDailyPuzzleLadderReadiness(todayPt, slots);
+    dailyPuzzleLadder = {
+      ...readiness,
+      ok: readiness.ready || !readiness.shouldAlert,
+    };
+    if (readiness.shouldAlert) {
+      console.error('[daily-puzzle-ladder] readiness-alert', {
+        runDate: todayPt,
+        publishedSlotCount: readiness.publishedSlotCount,
+        missingSlotIndexes: readiness.missingSlotIndexes,
+        alertReason: readiness.alertReason,
+      });
+    }
+  } catch (error) {
+    dailyPuzzleLadder = {
+      runDate: todayPt,
+      ready: false,
+      publishedSlotCount: 0,
+      missingSlotIndexes: [1, 2, 3],
+      legacySinglePuzzleDay: true,
+      shouldAlert: isPastLadderReadinessGracePt(todayPt),
+      alertReason: error instanceof Error ? error.message : String(error),
+      ok: false,
+    };
+  }
+
+  const ok = requiredEnvOk && supabase.ok && dailyPuzzleLadder.ok;
 
   res.status(ok ? 200 : 503).json({
     ...getRuntimeStatusPayload(),
@@ -443,6 +481,7 @@ app.get('/ready', async (_req, res) => {
       requiredEnv,
       recommendedEnv,
       supabase,
+      dailyPuzzleLadder,
     },
   });
 });
@@ -2270,6 +2309,13 @@ function isTruthyEnvFlag(value: string | undefined): boolean {
   return normalized === 'true' || normalized === '1' || normalized === 'yes';
 }
 
+/** Request-time ladder self-heal is on unless explicitly disabled. */
+function isRequestPuzzleGenerationEnabled(): boolean {
+  const raw = process.env.ENABLE_REQUEST_PUZZLE_GENERATION?.trim().toLowerCase();
+  if (raw === 'false' || raw === '0' || raw === 'no') return false;
+  return true;
+}
+
 /** Off by default in production; set ENABLE_STARTUP_FRITZ_WARMUP=true to run on boot. */
 function isStartupDailyFritzWarmupEnabled(): boolean {
   return isTruthyEnvFlag(process.env.ENABLE_STARTUP_FRITZ_WARMUP);
@@ -2528,7 +2574,20 @@ async function listDailyPuzzleSlotsForDateWithAutoSeed(runDate: string): Promise
   try {
     let slots = await listDailyPuzzleSlotsForDate(runDate);
     if (isDailyPuzzleLadderReady(slots)) return slots;
-    if (!isTruthyEnvFlag(process.env.ENABLE_REQUEST_PUZZLE_GENERATION)) {
+
+    if (!isDailyPuzzleLadderReady(slots) && slots.length > 0) {
+      const scrub = await scrubPartialPublishedLadderForDate(runDate);
+      if (scrub.scrubbed > 0) {
+        console.warn('[daily-puzzle-ladder] scrubbed-partial-on-read', {
+          runDate,
+          scrubbed: scrub.scrubbed,
+          missingSlotIndexes: scrub.readiness.missingSlotIndexes,
+        });
+        slots = [];
+      }
+    }
+
+    if (!isRequestPuzzleGenerationEnabled()) {
       console.warn('[daily-puzzle-ladder] request-time generation skipped', {
         runDate,
         reason: 'disabled',
@@ -4374,6 +4433,40 @@ app.post('/api/daily-fritz/abandon', async (req, res) => {
     res.status(500).json({
       error: error instanceof Error ? error.message : 'Failed to abandon Daily Fritz attempt.',
     });
+   }
+});
+
+app.post('/api/daily-fritz/restart', async (req, res) => {
+  const attemptId = typeof req.body?.attempt_id === 'string' ? req.body.attempt_id.trim() : '';
+  if (!attemptId) {
+    res.status(400).json({ error: 'attempt_id is required.' });
+    return;
+  }
+  try {
+    const authenticatedUserId = await getAuthenticatedUserId(req);
+    if (!authenticatedUserId) {
+      res.status(401).json({ error: 'Unauthorized' });
+      return;
+    }
+    const result = await restartDailyFritzUnsafeAttempt({
+      attemptId,
+      authenticatedUserId,
+    });
+    res.json(result);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (message === 'daily_fritz_restart_attempt_not_found') {
+      res.status(404).json({ error: 'Daily Fritz attempt not found.' });
+      return;
+    }
+    if (message.startsWith('daily_fritz_restart_attempt_locked:')) {
+      const status = message.split(':')[1] ?? 'locked';
+      res.status(409).json({ error: 'Daily Fritz attempt cannot be restarted.', status });
+      return;
+    }
+    res.status(500).json({
+      error: error instanceof Error ? error.message : 'Failed to restart Daily Fritz attempt.',
+    });
   }
 });
 
@@ -4503,6 +4596,41 @@ app.post('/api/daily-fritz/reset-attempt', async (req, res) => {
   } catch (error) {
     res.status(500).json({
       error: error instanceof Error ? error.message : 'Failed to reset Daily Fritz attempt.',
+    });
+  }
+});
+
+app.post('/api/daily-fritz/qa-reset', async (req, res) => {
+  try {
+    const authenticatedUserId = await getAuthenticatedUserId(req);
+    if (!authenticatedUserId) {
+      res.status(401).json({ error: 'Unauthorized' });
+      return;
+    }
+    const runDate = typeof req.body?.run_date === 'string' ? req.body.run_date.trim() : undefined;
+    const reason = typeof req.body?.reason === 'string' ? req.body.reason.trim() : 'qa_browser_reset';
+    const result = await resetDailyFritzQaAttempt({
+      runDate,
+      reason,
+      authenticatedUserId,
+    });
+    res.json({ ok: true, ...result });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (message.startsWith('qa_daily_fritz_reset_requires_') || message.startsWith('qa_daily_fritz_reset_blocked_')) {
+      res.status(403).json({ error: 'Daily Fritz QA reset is disabled.' });
+      return;
+    }
+    if (message === 'qa_daily_fritz_reset_forbidden_user') {
+      res.status(403).json({ error: 'Daily Fritz QA reset is limited to the configured QA account.' });
+      return;
+    }
+    if (message.startsWith('qa_daily_fritz_reset_refused_')) {
+      res.status(403).json({ error: 'Daily Fritz QA reset refused for this environment.' });
+      return;
+    }
+    res.status(500).json({
+      error: error instanceof Error ? error.message : 'Failed to reset Daily Fritz QA attempt.',
     });
   }
 });

--- a/server/src/seedDailyPuzzleLadder.ts
+++ b/server/src/seedDailyPuzzleLadder.ts
@@ -3,16 +3,19 @@ import {
   isDailyPuzzleLadderReady,
   normalizeDailyPuzzleSlot,
   sortDailyPuzzleSlots,
-  type DailyPuzzleSlotRow,
 } from './dailyPuzzle';
+import {
+  isLadderReadyFromDatabase,
+  listPublishedLadderSlotRows,
+  publishGeneratedLadderSlots,
+  scrubPartialPublishedLadderForDate,
+  type GeneratedLadderSlot,
+} from './dailyPuzzleLadderPublish';
 import {
   computeBestPossiblePuzzleScore,
   createHighScorePuzzle,
   generateSetupAndStrikePuzzle,
 } from './generatePuzzles';
-
-const LADDER_SLOT_SELECT =
-  'id,puzzle_date,title,starting_board,starting_hand,max_moves,target_score,puzzle_type,deal_size,slot_index,slot_title,tier,slot_max_points,objective_type,objective_payload,set_version,published';
 
 export type DailyPuzzleGenerationPurpose = 'request' | 'scheduled' | 'startup' | 'manual';
 
@@ -484,7 +487,7 @@ export async function choosePuzzleForSlot(
         const reason = classifyGenerationError(error);
         recordRejection(reason);
         if (
-          (reason === 'missing_tiles' || reason === 'validation_exception') &&
+          reason === 'validation_exception' &&
           (rejectionCounts.get(reason) ?? 0) >= budget.structuralFailureThreshold
         ) {
           if (planIndex < plans.length - 1) break;
@@ -502,67 +505,6 @@ export async function choosePuzzleForSlot(
     'attempt_limit',
     `Unable to generate ${profile.slotTitle} candidate after ${attemptsTried} attempts.`,
   );
-}
-
-type PostgrestResponseLike = {
-  ok: boolean;
-  status: number;
-  text(): Promise<string>;
-  json(): Promise<unknown>;
-};
-
-async function postgrestFetch(
-  path: string,
-  init?: RequestInit,
-  timeoutMs = 5_000,
-): Promise<PostgrestResponseLike> {
-  const supabaseUrl = process.env.SUPABASE_URL;
-  const serviceKey = process.env.SUPABASE_SERVICE_KEY;
-  if (!supabaseUrl) throw new Error('SUPABASE_URL is required.');
-  if (!serviceKey) throw new Error('SUPABASE_SERVICE_KEY is required.');
-  const url = new URL(path, supabaseUrl);
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), timeoutMs);
-  try {
-    return await fetch(url, {
-      ...init,
-      headers: {
-        apikey: serviceKey,
-        Authorization: `Bearer ${serviceKey}`,
-        'Content-Type': 'application/json',
-        Prefer: 'resolution=merge-duplicates,return=representation',
-        ...(init?.headers ?? {}),
-      },
-      signal: init?.signal ?? controller.signal,
-    });
-  } catch (error) {
-    if (error instanceof Error && error.name === 'AbortError') {
-      throw new Error(`Supabase request timed out after ${timeoutMs}ms: ${path}`);
-    }
-    throw error;
-  } finally {
-    clearTimeout(timeout);
-  }
-}
-
-async function listPublishedLadderSlotRows(date: string): Promise<DailyPuzzleSlotRow[]> {
-  const response = await postgrestFetch(
-    `/rest/v1/daily_puzzles?select=${LADDER_SLOT_SELECT}&published=eq.true&puzzle_date=eq.${encodeURIComponent(date)}&order=set_version.asc,slot_index.asc,id.asc`,
-  );
-  if (!response.ok) return [];
-  const rows = (await response.json()) as DailyPuzzleSlotRow[];
-  return Array.isArray(rows) ? rows : [];
-}
-
-/** Same readiness contract as `/api/daily-puzzle/today` (three published slots, scoring metadata). */
-async function isLadderReadyFromDatabase(date: string): Promise<boolean> {
-  try {
-    const rawRows = await listPublishedLadderSlotRows(date);
-    const slots = sortDailyPuzzleSlots(rawRows.map(normalizeDailyPuzzleSlot));
-    return isDailyPuzzleLadderReady(slots);
-  } catch {
-    return false;
-  }
 }
 
 export async function diagnoseDailyPuzzleLadderForDate(date: string): Promise<{
@@ -611,51 +553,6 @@ export async function diagnoseDailyPuzzleLadderForDate(date: string): Promise<{
   };
 }
 
-async function upsertSlot(
-  date: string,
-  config: {
-    slotIndex: number;
-    slotTitle: string;
-    tier: string;
-    slotMaxPoints: number;
-    puzzleType: string;
-  },
-  puzzle: CuratedDailyPuzzle,
-  bestPossibleScore: number,
-): Promise<string[]> {
-  const response = await postgrestFetch(
-    '/rest/v1/daily_puzzles?on_conflict=puzzle_date,slot_index,set_version',
-    {
-      method: 'POST',
-      body: JSON.stringify([{
-        puzzle_date: date,
-        title: config.slotTitle,
-        starting_board: puzzle.startingBoard,
-        starting_hand: puzzle.startingHand,
-        max_moves: puzzle.maxMoves,
-        target_score: puzzle.targetScore,
-        puzzle_type: puzzle.puzzleType,
-        deal_size: puzzle.dealSize,
-        slot_index: config.slotIndex,
-        slot_title: config.slotTitle,
-        tier: config.tier,
-        slot_max_points: config.slotMaxPoints,
-        objective_type: puzzle.puzzleType,
-        objective_payload: {
-          best_possible_score: bestPossibleScore,
-        },
-        set_version: 1,
-        published: true,
-      }]),
-    },
-  );
-  if (!response.ok) {
-    throw new Error(`Failed to upsert slot ${config.slotIndex}: ${response.status} ${await response.text()}`);
-  }
-  const rows = (await response.json()) as Array<{ id?: string }> | null;
-  return Array.isArray(rows) ? rows.map((row) => row.id).filter((id): id is string => Boolean(id)) : [];
-}
-
 /**
  * Idempotently writes three published `daily_puzzles` rows for the Pacific calendar date.
  * Used by CLI, server startup/schedule, and lazy `/api/daily-puzzle/today` when missing.
@@ -671,8 +568,20 @@ export async function ensureDailyPuzzleLadderForDate(
       console.warn('[daily-puzzle-ladder-seed] invalid date key', date);
       return 'failed';
     }
-    if (!options?.force && (await isLadderReadyFromDatabase(date))) {
+    const alreadyReady = await isLadderReadyFromDatabase(date);
+    if (!options?.force && alreadyReady) {
       return 'skipped';
+    }
+    if (!alreadyReady) {
+      const scrub = await scrubPartialPublishedLadderForDate(date);
+      if (scrub.scrubbed > 0) {
+        console.warn('[daily-puzzle-ladder] scrubbed-partial-before-generation', {
+          date,
+          purpose,
+          scrubbed: scrub.scrubbed,
+          missingSlotIndexes: scrub.readiness.missingSlotIndexes,
+        });
+      }
     }
 
     console.log('[daily-puzzle-ladder] generation-start', JSON.stringify({
@@ -681,15 +590,14 @@ export async function ensureDailyPuzzleLadderForDate(
       budget: GENERATION_BUDGETS[purpose],
     }));
 
-    const results: Array<{
-      profile: LadderSlotGenerationProfile;
-      puzzle: CuratedDailyPuzzle;
-      bestPossibleScore: number;
+    const generated: GeneratedLadderSlot[] = [];
+    const generationMeta: Array<{
+      slotIndex: number;
+      slotTitle: string;
       attemptsTried: number;
       elapsedMs: number;
       strategy: string;
       fallbackTier: GenerationPlan['fallbackTier'];
-      publishedRowIds: string[];
       topRejectionReasons: Array<{ reason: string; count: number }>;
     }> = [];
 
@@ -709,37 +617,34 @@ export async function ensureDailyPuzzleLadderForDate(
         }));
         return 'failed';
       }
-      const publishedRowIds = await upsertSlot(
-        date,
-        {
-          slotIndex: profile.slotIndex,
-          slotTitle: profile.slotTitle,
-          tier: profile.tier,
-          slotMaxPoints: profile.slotMaxPoints,
-          puzzleType: result.puzzle.puzzleType,
-        },
-        result.puzzle,
-        result.bestPossibleScore,
-      );
-      results.push({ ...result, publishedRowIds, profile });
+      generated.push({
+        profile,
+        puzzle: result.puzzle,
+        bestPossibleScore: result.bestPossibleScore,
+      });
+      generationMeta.push({
+        slotIndex: profile.slotIndex,
+        slotTitle: profile.slotTitle,
+        attemptsTried: result.attemptsTried,
+        elapsedMs: result.elapsedMs,
+        strategy: result.strategy,
+        fallbackTier: result.fallbackTier,
+        topRejectionReasons: result.topRejectionReasons,
+      });
     }
+
+    const publishedRowIds = await publishGeneratedLadderSlots(date, generated);
 
     console.log('[daily-puzzle-ladder] seeded', JSON.stringify({
       date,
       purpose,
       totalMs: Date.now() - startedAt,
-      slots: results.map((res) => ({
-        slotIndex: res.profile.slotIndex,
-        slotTitle: res.profile.slotTitle,
-        puzzleType: res.puzzle.puzzleType,
-        handSize: res.puzzle.startingHand.length,
-        bestPossibleScore: res.bestPossibleScore,
-        attempts: res.attemptsTried,
-        elapsedMs: res.elapsedMs,
-        strategy: res.strategy,
-        fallbackTier: res.fallbackTier,
-        publishedRowIds: res.publishedRowIds,
-        topRejectionReasons: res.topRejectionReasons,
+      publishedRowIds,
+      slots: generationMeta.map((meta, index) => ({
+        ...meta,
+        puzzleType: generated[index]?.puzzle.puzzleType,
+        handSize: generated[index]?.puzzle.startingHand.length,
+        bestPossibleScore: generated[index]?.bestPossibleScore,
       })),
     }, null, 2));
     return 'seeded';


### PR DESCRIPTION
## Summary

### Daily Puzzle — atomic publish / partial rollback

- **`dailyPuzzleLadderPublish.ts`** — new publish layer:
  - Generates all three slot payloads in memory first, then publishes in one pass via `publishGeneratedLadderSlots()`.
  - On any upsert/verification failure, **rolls back** any rows published in that attempt (`unpublishLadderSlotsByIds`).
  - **`scrubPartialPublishedLadderForDate()`** unpublishes 1–2 slot partial days so players never see a broken ladder (shows “being prepared” instead).
- **`seedDailyPuzzleLadder.ts`** — refactored to use atomic publish; scrubs partial rows before regeneration; no more sequential per-slot `published: true` upserts that could leave slot 2 missing.
- **`dailyPuzzleLadderReadiness.ts`** — Pacific readiness assessment with **15-minute post-midnight grace** before alerting.
- **`index.ts`**:
  - Scrub partial ladder on read path before returning slots.
  - Request-time self-heal **on by default** (`ENABLE_REQUEST_PUZZLE_GENERATION=false` to disable).
  - `/ready` includes `checks.dailyPuzzleLadder`; returns **503** when today’s ladder should alert.
- **`.github/workflows/gen-puzzles.yml`** — post-backfill `--diagnose` for today (Pacific) so CI fails if today isn’t publish-ready.
- **Generator** — stop early-aborting slot generation on repeated `missing_tiles` exceptions (was killing Tactical Setup after ~30 tries for some date seeds).

**Server log breadcrumbs (Daily Puzzle):**
- `[daily-puzzle-ladder] scrubbed-partial-publish` — partial day unpublished
- `[daily-puzzle-ladder] scrubbed-partial-on-read` — API read path scrub
- `[daily-puzzle-ladder] scrubbed-partial-before-generation` — pre-seed scrub
- `[daily-puzzle-ladder] rollback-failed` — publish rollback error (rare)
- `[daily-puzzle-ladder] readiness-alert` — `/ready` post-grace failure

### Today’s prod ladder — repair and verification

**Before (2026-06-11 Pacific):**
- `GET /api/daily-puzzle/today` → 2 published slots (1 + 3), `legacySinglePuzzleDay: true`
- `node server/dist/seedDailyPuzzleLadder.js --date 2026-06-11 --diagnose` → `publishable: false`, `slotCount: 2`

**Repair steps run (against prod Supabase via local `server/.env`):**
1. Scrub removed the broken 2-slot publish (`scrubbed: 2`, missing slot 2).
2. `--force` regen after generator fix produced all three slots atomically.

**After:**
```bash
node server/dist/seedDailyPuzzleLadder.js --date 2026-06-11 --diagnose
# publishable: true, slotCount: 3

curl -sS https://racehorse.onrender.com/api/daily-puzzle/today
# slots: 3, legacySinglePuzzleDay: false
```

> **Note:** DB repair is live now, but **Render/Vercel still need this deploy** for scrub-on-read, request-time self-heal, `/ready`, and client hand UX. Without server deploy, a future partial publish could still be served until the next successful seed.

### Daily Fritz — hand lifecycle hardening

**`handLifecycle.ts` + `BotMatchScreen.tsx`:**
- Daily Fritz hand-over modal shows **immediately** (no silent 1.4s delay skip).
- Yellow 5s countdown no longer resets when `handNumber` changes (removed from effect deps).
- **Watchdog** restores `pendingHandRevealRef` if reveal missing; **will not** `advanceHand` until modal visible and `dailyFritzMinAdvanceAtRef` gate opens.
- **Draw animation** falls back to `new-draw` pulse (player) or board toast (Fritz) when boneyard/hand refs are missing.

**Production console breadcrumbs (`[daily-flow]` via `logDailyFritzHandBreadcrumb`):**
| Event | When |
| --- | --- |
| `reveal-skipped` | Stale hand timer would have hidden the modal |
| `reveal-restored` | Watchdog re-shows pending hand result |
| `draw-fallback` | Flying-tile animation skipped; pulse/toast used |
| `manual-advance-shown` | Stall hint / fetch retry / setMatch-noop |

Existing logs retained: `[daily-flow] hand complete detected`, `reveal start`, `reveal countdown started`, `[hand-over] timer-start` / `timer-fired`, `watchdog skipped — reveal/countdown not finished`.

**`HandOverModal.tsx`** — `data-testid="hand-over-modal"` and `hand-over-progress-track` for Playwright.

**`dailyFritzHandLifecycleQa.mjs`** — browser QA for modal, countdown animation, clean advance, draw pulse smoke.

---

## Tests / builds run

| Command | Result |
| --- | --- |
| `npm run build --prefix server` | **Pass** |
| `npm run test --prefix server` | **Pass** (49 files, 388 tests) |
| `npm run build --prefix client` | **Pass** |
| `npm run test:hand-lifecycle --prefix client` | **Pass** |
| `node server/dist/seedDailyPuzzleLadder.js --date 2026-06-11 --diagnose` | **Pass** (3/3 publishable) |
| `curl https://racehorse.onrender.com/api/daily-puzzle/today` | **3 slots**, `legacySinglePuzzleDay: false` |
| `npm run qa:daily-fritz:hand-lifecycle --prefix client` | **Not run** — no `client/.auth/daily-fritz-qa.json` or QA creds in this environment; run post-deploy (see below) |

---

## Deployment checklist (required — local DB repair ≠ prod code)

### 1. Render (server) — **required**
Deploy this branch so production gets:
- [ ] Scrub-on-read for partial ladders
- [ ] Request-time self-heal (default on)
- [ ] `/ready` daily puzzle readiness check + alert logs
- [ ] Atomic publish / rollback on future seeds

**Env on Render:**
- [ ] `SUPABASE_URL` + `SUPABASE_SERVICE_KEY` set
- [ ] **`ENABLE_REQUEST_PUZZLE_GENERATION` must NOT be `false`** (unset or `true` = self-heal on)

### 2. Vercel (client) — **required**
Deploy so players get:
- [ ] Immediate hand-over modal (Daily Fritz)
- [ ] Stable 5s yellow countdown bar
- [ ] Watchdog that won’t skip past hand result
- [ ] Draw animation / fallback pulse
- [ ] `[daily-flow]` console breadcrumbs

### 3. GitHub Actions — **verify**
- [ ] `SUPABASE_SERVICE_KEY` repository secret is **current**
- [ ] `gen-puzzles.yml` runs every 6h; new diagnose step fails CI if today isn’t publish-ready after backfill

### 4. Post-deploy verification

**Daily Puzzle (prod API):**
```bash
curl -sS https://racehorse.onrender.com/api/daily-puzzle/today | jq '{slotCount: (.slots|length), legacy: .legacySinglePuzzleDay}'
curl -sS https://racehorse.onrender.com/ready | jq '.checks.dailyPuzzleLadder'
```
- [ ] `slotCount: 3`, `legacy: false`
- [ ] `/ready` → `checks.dailyPuzzleLadder.ok: true` (after 00:15 Pacific grace on a broken day)

**Daily Fritz (manual + browser console):**
- [ ] Start Daily Fritz, complete a hand → hand-over modal appears **every time**
- [ ] Yellow countdown bar visible and animates 5s
- [ ] Next hand deals **only after** modal/countdown (not watchdog-skipped)
- [ ] On draw: flying tile **or** `new-draw` pulse / toast; console may show `[daily-flow] draw-fallback`
- [ ] Console shows `[daily-flow] reveal start` immediately on hand end (not delayed skip)

### 5. Playwright hand-lifecycle QA (post-deploy + auth)

**Auth setup** (one of):
- `client/.auth/daily-fritz-qa.json` from a signed-in session, or
- `QA_DAILY_FRITZ_EMAIL` + `QA_DAILY_FRITZ_PASSWORD`, or
- `QA_DAILY_FRITZ_USER_ID` + `SUPABASE_SERVICE_KEY` for magic-link bootstrap

**Run against deployed app:**
```bash
DAILY_FRITZ_QA_APP_URL=https://racehorsedoms.vercel.app \
  npm run qa:daily-fritz:hand-lifecycle --prefix client
```
Report: `docs/daily-fritz-hand-lifecycle-qa-report.md`  
Artifacts: `docs/qa-artifacts/daily-fritz-hand-lifecycle/`

Scenarios: DF-HAND-01 (modal), DF-HAND-02/03 (countdown), DF-HAND-04/06 (clean advance), DF-HAND-05 (draw pulse smoke).

---

## Test plan

- [ ] Merge + deploy Render + Vercel
- [ ] Confirm Render env (`ENABLE_REQUEST_PUZZLE_GENERATION` not false)
- [ ] Confirm GitHub `SUPABASE_SERVICE_KEY`
- [ ] Run post-deploy curl checks above
- [ ] Play one Daily Fritz hand on prod; watch `[daily-flow]` console
- [ ] Run Playwright hand-lifecycle QA with auth against prod URL

Made with [Cursor](https://cursor.com)