### PR TITLE
fix(daily-fritz): commit Fritz evidence before cancellable presentation

### DIFF
--- a/client/e2e/daily-fritz-verifier-race.spec.ts
+++ b/client/e2e/daily-fritz-verifier-race.spec.ts
@@ -1,0 +1,136 @@
+/**
+ * Browser regression: Daily Fritz hand submission must not surface verifier
+ * divergence errors after the finalize-before-present fix.
+ *
+ * Requires QA auth at client/.auth/daily-fritz-qa.json and live API.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { expect, test, type Page, type Response } from '@playwright/test';
+
+const authState = path.resolve(process.cwd(), '.auth/daily-fritz-qa.json');
+
+function hasValidAuthState(filePath: string): boolean {
+  if (!fs.existsSync(filePath)) return false;
+  try {
+    const state = JSON.parse(fs.readFileSync(filePath, 'utf8')) as {
+      origins?: Array<{ localStorage?: Array<{ name?: string; value?: string }> }>;
+    };
+    return state.origins?.some((origin) => origin.localStorage?.some((entry) => {
+      if (!entry.name?.startsWith('sb-') || !entry.name.endsWith('-auth-token') || !entry.value) {
+        return false;
+      }
+      const session = JSON.parse(entry.value) as { expires_at?: unknown };
+      return typeof session.expires_at === 'number' && session.expires_at > Date.now() / 1000 + 60;
+    })) ?? false;
+  } catch {
+    return false;
+  }
+}
+
+function isDailyFritzEvidenceRoute(url: string): boolean {
+  return url.includes('/api/daily-fritz/next-hand')
+    || url.includes('/api/daily-fritz/record-game');
+}
+
+async function openDailyFritzMatch(page: Page): Promise<void> {
+  await page.goto('/#/daily-fritz');
+  await expect(page.getByRole('heading', { name: 'Daily Fritz' })).toBeVisible({ timeout: 20_000 });
+  const start = page.locator('.df-pvf-start-btn');
+  await expect(start).toBeEnabled({ timeout: 20_000 });
+  await start.click();
+  await expect(page.locator('.bot-match-screen.bot-match-mode-daily-fritz')).toBeVisible({
+    timeout: 30_000,
+  });
+}
+
+test.describe('Daily Fritz verifier-race browser journey', () => {
+  test.skip(!hasValidAuthState(authState), 'A current authenticated Daily Fritz QA fixture is required');
+
+  test('survives remount pressure and submits without verifier divergence', async ({ browser }) => {
+    test.setTimeout(180_000);
+    const context = await browser.newContext({
+      storageState: authState,
+      viewport: { width: 1440, height: 900 },
+    });
+    const page = await context.newPage();
+    const pageErrors: string[] = [];
+    const verificationBodies: Array<{ status: number; body: string }> = [];
+
+    page.on('pageerror', (error) => pageErrors.push(error.message));
+    page.on('console', (message) => {
+      if (message.type() === 'error') pageErrors.push(message.text());
+    });
+    page.on('response', async (response: Response) => {
+      if (!isDailyFritzEvidenceRoute(response.url())) return;
+      try {
+        verificationBodies.push({
+          status: response.status(),
+          body: await response.text(),
+        });
+      } catch {
+        verificationBodies.push({ status: response.status(), body: '' });
+      }
+    });
+
+    try {
+      await openDailyFritzMatch(page);
+
+      // Remount / Strict Mode pressure while Fritz may be presenting.
+      for (let index = 0; index < 4; index += 1) {
+        await page.evaluate(() => {
+          window.dispatchEvent(new Event('resize'));
+          document.body.setAttribute('data-df-remount-pressure', String(Date.now()));
+        });
+        await page.waitForTimeout(250);
+      }
+
+      // Play legal tiles when available to advance toward hand completion.
+      for (let turn = 0; turn < 40; turn += 1) {
+        const handOver = page.locator('.hand-over-modal, [data-testid="hand-over-modal"], .bot-hand-over');
+        if (await handOver.first().isVisible().catch(() => false)) break;
+
+        const modalError = page.getByText(/Fritz action does not match the official policy|Transcript actor does not own the turn/i);
+        expect(await modalError.count()).toBe(0);
+
+        const playable = page.locator('.hand-container button.domino-tile:not(.unplayable):not(.disabled)').first();
+        if (await playable.isVisible().catch(() => false)) {
+          await playable.click();
+          const end = page.locator('.placement-zone.active, .end-target.active').first();
+          if (await end.isVisible().catch(() => false)) {
+            await end.click();
+          }
+        }
+        await page.waitForTimeout(400);
+      }
+
+      // Force another remount burst near end-of-hand / submission window.
+      for (let index = 0; index < 3; index += 1) {
+        await page.evaluate(() => window.dispatchEvent(new Event('resize')));
+        await page.waitForTimeout(200);
+      }
+
+      await page.waitForTimeout(2_000);
+
+      const divergence = page.getByText(/Fritz action does not match the official policy|Transcript actor does not own the turn/i);
+      expect(await divergence.count()).toBe(0);
+
+      for (const entry of verificationBodies) {
+        expect(entry.body).not.toMatch(/fritz_action_mismatch|wrong_actor/i);
+        expect(entry.body).not.toMatch(/Fritz action does not match the official policy/i);
+        expect(entry.body).not.toMatch(/Transcript actor does not own the turn/i);
+        if (entry.status >= 400) {
+          // Soft-fail only when the body clearly indicates verifier divergence.
+          expect(entry.status).not.toBe(409);
+        }
+      }
+
+      const cleanErrors = pageErrors.filter((message) =>
+        !/ResizeObserver|favicon|net::ERR/i.test(message)
+      );
+      expect(cleanErrors, cleanErrors.join('\n')).toEqual([]);
+    } finally {
+      await context.close();
+    }
+  });
+});

--- a/client/src/modules/bot-turn/botTurnPresentBeforeFinalizeRace.test.ts
+++ b/client/src/modules/bot-turn/botTurnPresentBeforeFinalizeRace.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Daily Fritz end-of-hand verifier races — present-before-finalize (fixed).
+ *
+ * Invariant: Fritz presentation never mutates authoritative match; finalize
+ * (evidence + apply) must precede any cancellable presentation await.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createBotMatch, type BotMatchState } from '../match/runtime/botEngine.ts';
+import {
+  listEmbeddedForcedDrawTiles,
+  presentEmbeddedForcedDraws,
+} from './embeddedForcedDrawPresentation.ts';
+import { buildBotTurnScheduleKey } from './useBotTurnEffect.ts';
+
+function scoringRecoveryFixture(): {
+  beforePlay: BotMatchState;
+  afterPlay: BotMatchState;
+  drawnTiles: ReturnType<typeof listEmbeddedForcedDrawTiles>;
+} {
+  const beforePlay = createBotMatch(60, 7);
+  beforePlay.currentPlayer = 'bot';
+  beforePlay.handOpen = true;
+  beforePlay.board = {
+    mainLine: [{ tile: { low: 1, high: 4 }, orientation: 'horizontal-normal' }],
+    leftEnd: 1,
+    rightEnd: 4,
+    leftEndIsDouble: false,
+    rightEndIsDouble: false,
+    hubDoubles: [],
+  };
+  beforePlay.players.bot.hand = [{ low: 1, high: 6 }];
+  beforePlay.boneyard = [
+    { low: 2, high: 3 },
+    { low: 3, high: 5 },
+    { low: 4, high: 4 },
+  ];
+
+  const drawnTiles = [
+    { low: 2, high: 3 },
+    { low: 3, high: 5 },
+  ];
+  const afterPlay: BotMatchState = {
+    ...beforePlay,
+    board: {
+      mainLine: [
+        { tile: { low: 1, high: 6 }, orientation: 'horizontal-normal' },
+        { tile: { low: 1, high: 4 }, orientation: 'horizontal-normal' },
+      ],
+      leftEnd: 6,
+      rightEnd: 4,
+      leftEndIsDouble: false,
+      rightEndIsDouble: false,
+      hubDoubles: [],
+    },
+    boneyard: [{ low: 4, high: 4 }],
+    players: {
+      ...beforePlay.players,
+      bot: {
+        ...beforePlay.players.bot,
+        hand: [...drawnTiles],
+        score: 5,
+      },
+    },
+    currentPlayer: 'bot',
+  };
+
+  expect(listEmbeddedForcedDrawTiles(beforePlay, afterPlay)).toEqual(drawnTiles);
+  return { beforePlay, afterPlay, drawnTiles };
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('present-before-finalize bot-turn race (Daily Fritz)', () => {
+  it('must not mutate Fritz match fields that remount the bot-turn schedule key', async () => {
+    const { beforePlay, afterPlay, drawnTiles } = scoringRecoveryFixture();
+    let live: BotMatchState = structuredClone(beforePlay);
+    const tenureKey = () => buildBotTurnScheduleKey({
+      currentPlayer: live.currentPlayer,
+      handNumber: live.handNumber,
+      handOver: live.handOver,
+      gameOver: live.gameOver,
+      retryNonce: 0,
+    });
+    const keys: string[] = [tenureKey()];
+
+    await presentEmbeddedForcedDraws({
+      player: 'bot',
+      beforePlay,
+      afterPlay,
+      drawnTiles,
+      setMatch: (next) => {
+        live = typeof next === 'function' ? next(live) : next;
+        keys.push(tenureKey());
+      },
+      onDrawVisualStep: vi.fn(),
+      triggerDrawStepAnimation: vi.fn(),
+      setDrawSequenceActiveBoth: vi.fn(),
+      drawStepMs: 0,
+      isMuted: true,
+    });
+
+    expect(new Set(keys).size).toBe(1);
+    expect(live.board?.mainLine).toEqual(beforePlay.board?.mainLine);
+    expect(live.boneyard).toEqual(beforePlay.boneyard);
+    expect(live.players.bot.hand).toEqual(beforePlay.players.bot.hand);
+  });
+
+  it('must not call setMatch for Fritz embedded recovery draws', async () => {
+    const { beforePlay, afterPlay, drawnTiles } = scoringRecoveryFixture();
+    const setMatch = vi.fn();
+
+    await presentEmbeddedForcedDraws({
+      player: 'bot',
+      beforePlay,
+      afterPlay,
+      drawnTiles,
+      setMatch,
+      onDrawVisualStep: vi.fn(),
+      triggerDrawStepAnimation: vi.fn(),
+      setDrawSequenceActiveBoth: vi.fn(),
+      drawStepMs: 0,
+      isMuted: true,
+    });
+
+    expect(setMatch).not.toHaveBeenCalled();
+  });
+
+  it('presentation cancel cannot leave live board ahead of empty move log', async () => {
+    const { beforePlay, afterPlay, drawnTiles } = scoringRecoveryFixture();
+    let live: BotMatchState = structuredClone(beforePlay);
+    const moveLog: Array<{ action: string }> = [];
+
+    // Correct order: finalize evidence first, then present (cancellable).
+    moveLog.push({ action: 'place' });
+    live = structuredClone(afterPlay);
+
+    await presentEmbeddedForcedDraws({
+      player: 'bot',
+      beforePlay,
+      afterPlay,
+      drawnTiles,
+      setMatch: (next) => {
+        live = typeof next === 'function' ? next(live) : next;
+      },
+      onDrawVisualStep: vi.fn(),
+      triggerDrawStepAnimation: vi.fn(),
+      setDrawSequenceActiveBoth: vi.fn(),
+      drawStepMs: 0,
+      isMuted: true,
+    });
+
+    // Simulate cleanup cancel after finalize — presentation must not rewind or
+    // strip evidence; live stays at authoritative afterPlay.
+    expect(moveLog).toHaveLength(1);
+    expect(live.board?.mainLine).toEqual(afterPlay.board?.mainLine);
+    expect(live.players.bot.hand).toEqual(afterPlay.players.bot.hand);
+  });
+
+  it('finalize-before-present ordering: evidence commits before cancellable await', async () => {
+    const events: string[] = [];
+    const { beforePlay, afterPlay, drawnTiles } = scoringRecoveryFixture();
+
+    const finalize = () => {
+      events.push('finalize');
+    };
+    const present = async () => {
+      events.push('present-start');
+      await presentEmbeddedForcedDraws({
+        player: 'bot',
+        beforePlay,
+        afterPlay,
+        drawnTiles,
+        setMatch: () => {
+          events.push('setMatch');
+        },
+        onDrawVisualStep: vi.fn(),
+        triggerDrawStepAnimation: vi.fn(),
+        setDrawSequenceActiveBoth: vi.fn(),
+        drawStepMs: 0,
+        isMuted: true,
+      });
+      events.push('present-end');
+    };
+
+    finalize();
+    await present();
+
+    expect(events).toEqual(['finalize', 'present-start', 'present-end']);
+  });
+});

--- a/client/src/modules/bot-turn/botTurnScheduleKey.test.ts
+++ b/client/src/modules/bot-turn/botTurnScheduleKey.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from 'vitest';
+import { buildBotTurnScheduleKey } from './useBotTurnEffect.ts';
+import { shouldScheduleBotTurn, shouldContinueBotTurnAtTimer } from './botTurnGuards.ts';
+import { createBotMatch } from '../match/runtime/botEngine.ts';
+
+describe('buildBotTurnScheduleKey', () => {
+  it('ignores hand, boneyard, and board length churn during the same tenure', () => {
+    const base = {
+      currentPlayer: 'bot',
+      handNumber: 1,
+      handOver: false,
+      gameOver: false,
+      retryNonce: 0,
+    };
+    const before = buildBotTurnScheduleKey(base);
+    // Presentation / apply churn must not remount the active tenure.
+    expect(buildBotTurnScheduleKey(base)).toBe(before);
+    expect(before).toBe('bot:1:false:false:0');
+  });
+
+  it('changes when currentPlayer hands off', () => {
+    expect(buildBotTurnScheduleKey({
+      currentPlayer: 'bot',
+      handNumber: 1,
+      handOver: false,
+      gameOver: false,
+      retryNonce: 0,
+    })).not.toBe(buildBotTurnScheduleKey({
+      currentPlayer: 'you',
+      handNumber: 1,
+      handOver: false,
+      gameOver: false,
+      retryNonce: 0,
+    }));
+  });
+
+  it('changes when handNumber advances (new hand / game progression)', () => {
+    expect(buildBotTurnScheduleKey({
+      currentPlayer: 'bot',
+      handNumber: 1,
+      handOver: false,
+      gameOver: false,
+      retryNonce: 0,
+    })).not.toBe(buildBotTurnScheduleKey({
+      currentPlayer: 'bot',
+      handNumber: 2,
+      handOver: false,
+      gameOver: false,
+      retryNonce: 0,
+    }));
+  });
+
+  it('changes when retryNonce bumps (intentional reschedule)', () => {
+    expect(buildBotTurnScheduleKey({
+      currentPlayer: 'bot',
+      handNumber: 1,
+      handOver: false,
+      gameOver: false,
+      retryNonce: 0,
+    })).not.toBe(buildBotTurnScheduleKey({
+      currentPlayer: 'bot',
+      handNumber: 1,
+      handOver: false,
+      gameOver: false,
+      retryNonce: 1,
+    }));
+  });
+
+  it('changes when handOver or gameOver flips', () => {
+    const active = buildBotTurnScheduleKey({
+      currentPlayer: 'bot',
+      handNumber: 1,
+      handOver: false,
+      gameOver: false,
+      retryNonce: 0,
+    });
+    expect(buildBotTurnScheduleKey({
+      currentPlayer: 'bot',
+      handNumber: 1,
+      handOver: true,
+      gameOver: false,
+      retryNonce: 0,
+    })).not.toBe(active);
+    expect(buildBotTurnScheduleKey({
+      currentPlayer: 'bot',
+      handNumber: 1,
+      handOver: false,
+      gameOver: true,
+      retryNonce: 0,
+    })).not.toBe(active);
+  });
+});
+
+describe('bot tenure scheduling vs terminal state', () => {
+  it('does not schedule an additional bot action after handOver', () => {
+    const match = createBotMatch(60, 7);
+    match.currentPlayer = 'bot';
+    match.handOver = true;
+    expect(shouldScheduleBotTurn({
+      match,
+      drawSequenceActive: false,
+      botTurnInFlight: false,
+      preGameDrawActive: false,
+      isDailyFritzMode: true,
+      dailyFritzSetResult: null,
+      isGuidedTranscriptMode: false,
+      isGuidedV2Mode: false,
+      isGuidedV2OffLine: false,
+    })).toBe(false);
+  });
+
+  it('does not continue the bot chain after handOver', () => {
+    const match = createBotMatch(60, 7);
+    match.currentPlayer = 'bot';
+    match.handOver = true;
+    expect(shouldContinueBotTurnAtTimer({
+      match,
+      isDailyFritzMode: true,
+      dailyFritzSetResult: null,
+    })).toBe(false);
+  });
+
+  it('schedules a genuine new bot tenure when it is Fritz to move', () => {
+    const match = createBotMatch(60, 7);
+    match.currentPlayer = 'bot';
+    match.handOver = false;
+    match.gameOver = false;
+    expect(shouldScheduleBotTurn({
+      match,
+      drawSequenceActive: false,
+      botTurnInFlight: false,
+      preGameDrawActive: false,
+      isDailyFritzMode: true,
+      dailyFritzSetResult: null,
+      isGuidedTranscriptMode: false,
+      isGuidedV2Mode: false,
+      isGuidedV2OffLine: false,
+    })).toBe(true);
+  });
+});
+
+describe('Strict Mode schedule-key stability', () => {
+  it('double invoke with the same tenure key does not invent a second identity', () => {
+    const keyA = buildBotTurnScheduleKey({
+      currentPlayer: 'bot',
+      handNumber: 1,
+      handOver: false,
+      gameOver: false,
+      retryNonce: 0,
+    });
+    const keyB = buildBotTurnScheduleKey({
+      currentPlayer: 'bot',
+      handNumber: 1,
+      handOver: false,
+      gameOver: false,
+      retryNonce: 0,
+    });
+    // React Strict Mode remounts the effect with the same key; identity must match
+    // so the second mount replaces the cancelled first run instead of dual tenures.
+    expect(keyA).toBe(keyB);
+  });
+});

--- a/client/src/modules/bot-turn/embeddedForcedDrawPresentation.test.ts
+++ b/client/src/modules/bot-turn/embeddedForcedDrawPresentation.test.ts
@@ -145,8 +145,7 @@ describe('presentEmbeddedForcedDraws', () => {
     expect(setDrawSequenceActiveBoth).toHaveBeenCalledWith(false);
     expect(onDrawVisualStep).toHaveBeenCalled();
     expect(triggerDrawStepAnimation).toHaveBeenCalledTimes(2);
-    // Post-play board commit + one commit per draw step.
-    expect(setMatch).toHaveBeenCalled();
-    expect(setMatch.mock.calls.length).toBeGreaterThanOrEqual(3);
+    // Fritz recovery draws are overlay-only — never mutate authoritative match.
+    expect(setMatch).not.toHaveBeenCalled();
   });
 });

--- a/client/src/modules/bot-turn/embeddedForcedDrawPresentation.ts
+++ b/client/src/modules/bot-turn/embeddedForcedDrawPresentation.ts
@@ -54,8 +54,12 @@ export type PresentEmbeddedForcedDrawsDeps = {
 };
 
 /**
- * Animate embedded forced draws after a scoring/double play, then leave the caller
- * to commit the authoritative afterPlay state.
+ * Animate embedded forced draws after a scoring/double play.
+ *
+ * Fritz (`bot`) is overlay-only: never mutate authoritative match. The caller must
+ * finalizeBotTurnExecution (move log + applyAndNotify) before awaiting this, so
+ * cancellation during animation cannot leave the board ahead of transcript evidence.
+ * Player tray still commits mid-animation so face-up tiles appear one-by-one.
  */
 export async function presentEmbeddedForcedDraws(
   deps: PresentEmbeddedForcedDrawsDeps,
@@ -91,8 +95,11 @@ export async function presentEmbeddedForcedDraws(
 
   setDrawSequenceActiveBoth(true);
   try {
-    // Land the scored/double play on the board first, then animate recovery draws.
-    setMatch(postPlayState);
+    // Player tray: land the scored/double play, then animate recovery draws.
+    // Fritz: overlay-only (authoritative match must already be committed by caller).
+    if (player === 'you') {
+      setMatch(postPlayState);
+    }
     onDrawVisualStep?.(player, postPlayState);
 
     for (let index = 0; index < drawnTiles.length; index += 1) {
@@ -112,19 +119,6 @@ export async function presentEmbeddedForcedDraws(
       onDrawVisualStep?.(player, stepState);
       if (player === 'you') {
         setMatch(stepState);
-      } else {
-        // Fritz rack is face-down; keep board committed and tick overlay counts.
-        setMatch({
-          ...stepState,
-          players: {
-            ...stepState.players,
-            bot: {
-              ...stepState.players.bot,
-              // Keep authoritative hand length in sync for HUD fallbacks.
-              hand: stepHand,
-            },
-          },
-        });
       }
       queueSound(() => playDrawSound(isMuted), 0);
       triggerDrawStepAnimation(player, stepState);

--- a/client/src/modules/bot-turn/useBotTurnEffect.ts
+++ b/client/src/modules/bot-turn/useBotTurnEffect.ts
@@ -30,6 +30,26 @@ import {
 } from './fritzPresentation.ts';
 import type { BotTurnPorts } from './types.ts';
 
+/**
+ * Tenure identity only — never include hand/board/boneyard sizes (mid-turn churn
+ * remounts the effect, cancels before finalize, and desyncs Daily Fritz transcripts).
+ */
+export function buildBotTurnScheduleKey(input: {
+  currentPlayer: string;
+  handNumber: number;
+  handOver: boolean;
+  gameOver: boolean;
+  retryNonce: number;
+}): string {
+  return [
+    input.currentPlayer,
+    input.handNumber,
+    input.handOver,
+    input.gameOver,
+    input.retryNonce,
+  ].join(':');
+}
+
 export type UseBotTurnEffectArgs = {
   match: BotMatchState;
   matchRef: React.MutableRefObject<BotMatchState>;
@@ -63,36 +83,20 @@ export type UseBotTurnEffectArgs = {
 
 /**
  * Owns Fritz's tenure: claim in-flight immediately, then wait/think/act inside that
- * lock so effect remounts cannot clearTimeout the think delay down to milliseconds.
- * Cadence theater: variable beats, honest phase strip, place/score settles, handoff.
+ * lock. The effect only re-runs when the turn schedule key changes — unstable ports /
+ * presentation callbacks must not abort mid-think.
+ *
+ * Invariant: finalizeBotTurnExecution (move-log evidence + applyAndNotify) runs
+ * synchronously after a successful executeBotTurn result and BEFORE any cancellable
+ * presentation / settle await. Cancel after that boundary may skip theater only.
  */
 export function useBotTurnEffect(args: UseBotTurnEffectArgs): void {
   const {
     match,
     matchRef,
-    ports,
-    localRun,
-    runDrawSequence,
-    fritzDifficulty,
-    isDailyFritzMode,
-    dailyFritzPackage,
-    isGuidedTranscriptMode,
-    isGuidedV2Mode,
-    isGuidedV2OffLine,
-    preGameDrawActiveRef,
-    drawSequenceActiveRef,
-    isGhostMode,
-    ghostProfile,
-    isMuted,
-    moveCounterRef,
     botChainPauseRef,
     botTurnInFlightRef,
-    setMatch,
-    onDrawVisualStep,
-    triggerDrawStepAnimation,
-    drawStepMs,
-    opponentLabel,
-    setFritzPresentation,
+    localRun,
   } = args;
 
   const {
@@ -104,39 +108,38 @@ export function useBotTurnEffect(args: UseBotTurnEffectArgs): void {
   const botActionRetryRef = useRef({ key: '', attempts: 0 });
   const botActionRetryTimerRef = useRef<ReturnType<typeof window.setTimeout> | null>(null);
 
-  // Schedule from turn identity, not every match field churn.
-  const botScheduleKey = [
-    match.currentPlayer,
-    match.handNumber,
-    match.turnIndex ?? 0,
-    match.handOver,
-    match.gameOver,
-    match.players.bot.hand.length,
-    match.players.you.hand.length,
-    match.boneyard.length,
-    match.board?.mainLine.length ?? 0,
-    botTurnRetryNonce,
-  ].join(':');
+  // Keep latest args without putting them in the effect dep list (remount cancel race).
+  const liveRef = useRef(args);
+  liveRef.current = args;
+
+  const botScheduleKey = buildBotTurnScheduleKey({
+    currentPlayer: match.currentPlayer,
+    handNumber: match.handNumber,
+    handOver: match.handOver,
+    gameOver: match.gameOver,
+    retryNonce: botTurnRetryNonce,
+  });
 
   useEffect(() => {
+    const live = () => liveRef.current;
     botMatchDebugLog('[BOT-EFFECT] fired', {
       botScheduleKey,
       currentPlayer: matchRef.current.currentPlayer,
-      drawSequenceActive: drawSequenceActiveRef.current,
+      drawSequenceActive: live().drawSequenceActiveRef.current,
       botTurnInFlight: botTurnInFlightRef.current,
     });
 
     if (
       !shouldScheduleBotTurn({
         match: matchRef.current,
-        drawSequenceActive: drawSequenceActiveRef.current,
+        drawSequenceActive: live().drawSequenceActiveRef.current,
         botTurnInFlight: botTurnInFlightRef.current,
-        preGameDrawActive: preGameDrawActiveRef.current,
-        isDailyFritzMode,
-        dailyFritzSetResult: dailyFritzPackage?.set_result,
-        isGuidedTranscriptMode,
-        isGuidedV2Mode,
-        isGuidedV2OffLine,
+        preGameDrawActive: live().preGameDrawActiveRef.current,
+        isDailyFritzMode: live().isDailyFritzMode,
+        dailyFritzSetResult: live().dailyFritzPackage?.set_result,
+        isGuidedTranscriptMode: live().isGuidedTranscriptMode,
+        isGuidedV2Mode: live().isGuidedV2Mode,
+        isGuidedV2OffLine: live().isGuidedV2OffLine,
       })
     ) {
       return;
@@ -155,7 +158,7 @@ export function useBotTurnEffect(args: UseBotTurnEffectArgs): void {
     let turnScoreTotal = 0;
 
     const setPhase = (patch: Partial<FritzPresentationState> & { phase: FritzPresentationState['phase'] }) => {
-      setFritzPresentation({
+      live().setFritzPresentation({
         phase: patch.phase,
         drawCount: patch.drawCount ?? 0,
         turnScoreTotal: patch.turnScoreTotal ?? turnScoreTotal,
@@ -190,8 +193,8 @@ export function useBotTurnEffect(args: UseBotTurnEffectArgs): void {
           if (
             !shouldContinueBotTurnAtTimer({
               match: matchRef.current,
-              isDailyFritzMode,
-              dailyFritzSetResult: dailyFritzPackage?.set_result,
+              isDailyFritzMode: live().isDailyFritzMode,
+              dailyFritzSetResult: live().dailyFritzPackage?.set_result,
             })
           ) {
             break;
@@ -211,8 +214,8 @@ export function useBotTurnEffect(args: UseBotTurnEffectArgs): void {
             if (
               !shouldContinueBotTurnAtTimer({
                 match: matchRef.current,
-                isDailyFritzMode,
-                dailyFritzSetResult: dailyFritzPackage?.set_result,
+                isDailyFritzMode: live().isDailyFritzMode,
+                dailyFritzSetResult: live().dailyFritzPackage?.set_result,
               })
             ) {
               break;
@@ -228,7 +231,8 @@ export function useBotTurnEffect(args: UseBotTurnEffectArgs): void {
           isFirstAction = false;
 
           let drawCountSeen = 0;
-          const theaterRunDrawSequence: typeof runDrawSequence = async (
+          const step = live();
+          const theaterRunDrawSequence: typeof step.runDrawSequence = async (
             initialState,
             player,
             token,
@@ -243,12 +247,12 @@ export function useBotTurnEffect(args: UseBotTurnEffectArgs): void {
                 lastScorePoints: 0,
               });
             }
-            return runDrawSequence(
+            return live().runDrawSequence(
               initialState,
               player,
               token,
-              (step) => {
-                if (player === 'bot' && step.actionKind === 'draw') {
+              (drawStep) => {
+                if (player === 'bot' && drawStep.actionKind === 'draw') {
                   drawCountSeen += 1;
                   setPhase({
                     phase: 'drawing',
@@ -257,7 +261,7 @@ export function useBotTurnEffect(args: UseBotTurnEffectArgs): void {
                     lastScorePoints: 0,
                   });
                 }
-                onStep?.(step);
+                onStep?.(drawStep);
               },
               drawStepMsOverride,
             );
@@ -276,24 +280,24 @@ export function useBotTurnEffect(args: UseBotTurnEffectArgs): void {
                 lastScorePoints: 0,
               });
             }
-            onDrawVisualStep?.(player, state);
+            live().onDrawVisualStep?.(player, state);
           };
 
           const execution = await executeBotTurn({
             liveAtTurn: matchRef.current,
             matchSnapshotSource: matchRef.current,
-            ports,
+            ports: step.ports,
             matchRef,
             runDrawSequence: theaterRunDrawSequence,
             runToken,
             isLocalRunCurrent,
             cancelled: () => cancelled,
-            isGhostMode,
-            ghostProfile,
-            fritzDifficulty,
-            isDailyFritzMode,
-            isMuted,
-            moveCounter: moveCounterRef.current,
+            isGhostMode: step.isGhostMode,
+            ghostProfile: step.ghostProfile,
+            fritzDifficulty: step.fritzDifficulty,
+            isDailyFritzMode: step.isDailyFritzMode,
+            isMuted: step.isMuted,
+            moveCounter: step.moveCounterRef.current,
             setBotChainPaused: (paused) => {
               botChainPauseRef.current = paused;
             },
@@ -302,33 +306,15 @@ export function useBotTurnEffect(args: UseBotTurnEffectArgs): void {
           if (cancelled || !isLocalRunCurrent(runToken)) break;
           if (!execution.result) break;
 
-          if (execution.playBeforeState) {
-            const drawnTiles = listEmbeddedForcedDrawTiles(
+          // Commit move-log + authoritative match BEFORE any presentation await.
+          // Presenting first used to setMatch mid-animation; effect cleanup could
+          // abort before finalize and leave live state ahead of the transcript.
+          const drawnTiles = execution.playBeforeState
+            ? listEmbeddedForcedDrawTiles(
               execution.playBeforeState,
               execution.result.state,
-            );
-            if (drawnTiles.length > 0) {
-              setPhase({
-                phase: 'drawing',
-                drawCount: drawnTiles.length,
-                turnScoreTotal,
-                lastScorePoints: 0,
-              });
-              await presentEmbeddedForcedDraws({
-                player: 'bot',
-                beforePlay: execution.playBeforeState,
-                afterPlay: execution.result.state,
-                drawnTiles,
-                setMatch,
-                onDrawVisualStep: wrappedOnDrawVisualStep,
-                triggerDrawStepAnimation,
-                setDrawSequenceActiveBoth: ports.setDrawSequenceActiveBoth,
-                drawStepMs,
-                isMuted,
-              });
-              if (cancelled || !isLocalRunCurrent(runToken)) break;
-            }
-          }
+            )
+            : [];
 
           const scoredPoints = execution.result.scored?.points ?? 0;
           if (scoredPoints > 0) {
@@ -343,14 +329,17 @@ export function useBotTurnEffect(args: UseBotTurnEffectArgs): void {
             drawCount: 0,
           });
 
+          const finalizeLive = live();
           const finalized = finalizeBotTurnExecution({
             execution,
-            ports,
+            ports: finalizeLive.ports,
             matchRef,
-            matchSnapshotSource: matchRef.current,
-            isGhostMode,
-            isDailyFritzMode,
-            moveCounter: moveCounterRef.current,
+            // Prefer pre-play state (after any pre-play draws) so place evidence
+            // is not keyed off a stale matchRef that never received mid-draw setMatch.
+            matchSnapshotSource: execution.playBeforeState ?? matchRef.current,
+            isGhostMode: finalizeLive.isGhostMode,
+            isDailyFritzMode: finalizeLive.isDailyFritzMode,
+            moveCounter: finalizeLive.moveCounterRef.current,
             setBotChainPaused: (paused) => {
               botChainPauseRef.current = paused;
             },
@@ -367,21 +356,49 @@ export function useBotTurnEffect(args: UseBotTurnEffectArgs): void {
             break;
           }
 
+          if (drawnTiles.length > 0 && execution.playBeforeState) {
+            setPhase({
+              phase: 'drawing',
+              drawCount: drawnTiles.length,
+              turnScoreTotal,
+              lastScorePoints: scoredPoints,
+            });
+            const drawLive = live();
+            await presentEmbeddedForcedDraws({
+              player: 'bot',
+              beforePlay: execution.playBeforeState,
+              afterPlay: execution.result.state,
+              drawnTiles,
+              setMatch: drawLive.setMatch,
+              onDrawVisualStep: wrappedOnDrawVisualStep,
+              triggerDrawStepAnimation: drawLive.triggerDrawStepAnimation,
+              setDrawSequenceActiveBoth: drawLive.ports.setDrawSequenceActiveBoth,
+              drawStepMs: drawLive.drawStepMs,
+              isMuted: drawLive.isMuted,
+            });
+            // Evidence already committed — cancel only skips settle/chain wait.
+            if (cancelled || !isLocalRunCurrent(runToken)) break;
+          }
+
           // One score surface: sticky running total while Fritz still holds the turn.
-          if (scoredPoints > 0 && !isDailyFritzMode) {
-            ports.showBoardToast(
-              buildFritzScoreCeremonyMessage(opponentLabel, scoredPoints, turnScoreTotal),
+          if (scoredPoints > 0 && !finalizeLive.isDailyFritzMode) {
+            finalizeLive.ports.showBoardToast(
+              buildFritzScoreCeremonyMessage(
+                finalizeLive.opponentLabel,
+                scoredPoints,
+                turnScoreTotal,
+              ),
               'bot',
               {
                 sticky: true,
                 points: scoredPoints,
                 turnTotal: turnScoreTotal,
-                actorLabel: opponentLabel.toUpperCase().slice(0, 10),
+                actorLabel: finalizeLive.opponentLabel.toUpperCase().slice(0, 10),
               },
             );
-          } else if (scoredPoints === 0 && isDailyFritzMode) {
+          } else if (scoredPoints === 0 && finalizeLive.isDailyFritzMode) {
             // A non-scoring chain step must not leave the prior +N on screen.
-            ports.clearBoardToast();
+            finalizeLive.ports.clearBoardToast();
           }
 
           const settleMs = willPlace || scoredPoints > 0
@@ -393,59 +410,36 @@ export function useBotTurnEffect(args: UseBotTurnEffectArgs): void {
           }
 
           if (!computeBotChainPaused(execution.result)) {
-            if (!isDailyFritzMode) {
-              ports.clearBoardToast();
+            if (!live().isDailyFritzMode) {
+              live().ports.clearBoardToast();
             }
             break;
           }
         }
       } finally {
         botTurnInFlightRef.current = false;
-        setFritzPresentation(IDLE_FRITZ_PRESENTATION);
+        live().setFritzPresentation(IDLE_FRITZ_PRESENTATION);
         if (isLocalRunCurrent(runToken)) {
           finishLocalRun(runToken);
         }
-        ports.setDrawSequenceActiveBoth(false);
+        live().ports.setDrawSequenceActiveBoth(false);
       }
     })();
 
     return () => {
+      // Schedule-key changed (or unmount): abort this tenure so the next key can claim.
       cancelled = true;
-      botMatchDebugLog('[BOT-EFFECT] cleanup', { cancelled });
+      botMatchDebugLog('[BOT-EFFECT] cleanup', { cancelled: true, botScheduleKey });
       if (botActionRetryTimerRef.current) {
         clearTimeout(botActionRetryTimerRef.current);
         botActionRetryTimerRef.current = null;
       }
       botTurnInFlightRef.current = false;
       finishLocalRun(runToken);
+      // Don't leave draw lock stuck — that blocks the next schedule forever.
+      live().ports.setDrawSequenceActiveBoth(false);
     };
-  }, [
-    botScheduleKey,
-    matchRef,
-    ports,
-    ghostProfile,
-    isGhostMode,
-    isGuidedTranscriptMode,
-    runDrawSequence,
-    beginLocalRun,
-    isLocalRunCurrent,
-    finishLocalRun,
-    isMuted,
-    isDailyFritzMode,
-    dailyFritzPackage?.set_result,
-    isGuidedV2Mode,
-    isGuidedV2OffLine,
-    preGameDrawActiveRef,
-    drawSequenceActiveRef,
-    botTurnInFlightRef,
-    fritzDifficulty,
-    moveCounterRef,
-    botChainPauseRef,
-    setMatch,
-    onDrawVisualStep,
-    triggerDrawStepAnimation,
-    drawStepMs,
-    opponentLabel,
-    setFritzPresentation,
-  ]);
+  // Intentionally schedule-key only — liveRef carries ports/callbacks without aborting tenure.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [botScheduleKey]);
 }

--- a/packages/game-core/src/dailyFritzDivergenceTrace.ts
+++ b/packages/game-core/src/dailyFritzDivergenceTrace.ts
@@ -1,0 +1,90 @@
+/**
+ * Canonical Daily Fritz divergence digests (shared client/server replay traces).
+ * Test/debug only — not wired into production request paths.
+ * Pure JS so the same digest works in Node and the browser bundle.
+ */
+import type { GameState, Tile } from './types.ts';
+
+function stableTile(tile: Tile): string {
+  return `${tile.low}|${tile.high}`;
+}
+
+function stableTiles(tiles: readonly Tile[]): string {
+  return tiles.map(stableTile).join(',');
+}
+
+/** FNV-1a 32-bit hex — stable across Node/browser for equality traces. */
+export function digestCanonicalString(value: string): string {
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return (hash >>> 0).toString(16).padStart(8, '0');
+}
+
+/** Canonical pre/post action state digest for client↔server divergence traces. */
+export function digestDailyFritzGameState(state: GameState): string {
+  const payload = {
+    handNumber: state.handNumber,
+    sequence: state.sequence,
+    currentPlayer: state.playerIds[state.currentPlayerIndex],
+    handOpen: state.handOpen,
+    handOver: state.handOver,
+    gameOver: state.gameOver,
+    consecutivePasses: state.consecutivePasses,
+    scores: Object.fromEntries(
+      state.playerIds.map((id) => [id, state.players[id]?.score ?? 0]),
+    ),
+    hands: Object.fromEntries(
+      state.playerIds.map((id) => [id, stableTiles(state.players[id]?.hand ?? [])]),
+    ),
+    boneyard: stableTiles(state.boneyard),
+    deadTiles: stableTiles(state.deadTiles),
+    board: state.board
+      ? {
+          leftEnd: state.board.leftEnd,
+          rightEnd: state.board.rightEnd,
+          mainLine: state.board.mainLine.map((placement) => ({
+            tile: stableTile(placement.tile),
+            orientation: placement.orientation,
+          })),
+          hubDoubles: state.board.hubDoubles,
+        }
+      : null,
+  };
+  return digestCanonicalString(JSON.stringify(payload));
+}
+
+export type DailyFritzDivergenceActionTrace = {
+  challengeId: string;
+  attemptId: string;
+  gameNumber: 1 | 2 | 3;
+  handIndex: number;
+  actionIndex: number;
+  stateSeqBefore: string;
+  stateSeqAfter: string;
+  expectedActor: string;
+  submittedActor: string;
+  commandType: string;
+  tile: string | null;
+  position: string | null;
+  preDigest: string;
+  postDigest: string;
+  tier: string;
+  rulesVersion: number;
+  protocolVersion: number;
+  fritzPolicyVersion: number;
+  handOver: boolean;
+  selectedFritzMove: string | null;
+  candidateFritzMoves: string[];
+};
+
+export function formatFritzMoveCandidate(input: {
+  tile: Tile;
+  position: string;
+  score?: number;
+}): string {
+  const score = typeof input.score === 'number' ? `@${input.score}` : '';
+  return `${input.tile.low}|${input.tile.high}@${input.position}${score}`;
+}

--- a/server/src/dailyFritzHonestPathStress.test.ts
+++ b/server/src/dailyFritzHonestPathStress.test.ts
@@ -1,0 +1,230 @@
+/**
+ * Deterministic Daily Fritz honest-path stress harness.
+ *
+ * Generates complete hands with the official policy on both seats (player plays
+ * like Fritz for determinism), verifies every hand with verifyDailyFritzHand.
+ *
+ * Usage (from server/):
+ *   npx vitest run src/dailyFritzHonestPathStress.test.ts
+ *   DF_STRESS_HANDS=10000 npx vitest run src/dailyFritzHonestPathStress.test.ts
+ *   DF_STRESS_SETS=1000 npx vitest run src/dailyFritzHonestPathStress.test.ts
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  applyGameCommand,
+  chooseOfficialFritzDecision,
+  DAILY_FRITZ_TRANSCRIPT_PROTOCOL_VERSION,
+  FRITZ_POLICY_VERSION,
+  GAME_RULES_VERSION,
+  listOptimalOfficialFritzPlays,
+  type DailyFritzTranscriptAction,
+  type FritzDecision,
+  type GameState,
+} from '@racehorse/game-core';
+import { generateSingleDailyFritzGameHand } from './dailyFritz';
+import {
+  createOfficialDailyFritzHandState,
+  verifyDailyFritzHand,
+} from './dailyFritzVerifier';
+// Import from this worktree's source — root node_modules may point at the
+// primary checkout's built package during sibling-worktree investigation.
+import {
+  digestDailyFritzGameState,
+} from '../../packages/game-core/src/dailyFritzDivergenceTrace.ts';
+
+const HAND_BUDGET = Number(process.env.DF_STRESS_HANDS ?? '200');
+const SET_BUDGET = Number(process.env.DF_STRESS_SETS ?? '50');
+const TIERS = ['standard', 'elite'] as const;
+
+function decisionToAction(
+  sequence: number,
+  actor: 'player' | 'fritz',
+  decision: FritzDecision,
+): DailyFritzTranscriptAction {
+  if (decision.kind === 'play') {
+    return {
+      sequence,
+      actor,
+      kind: 'play',
+      tile: decision.tile,
+      position: decision.position,
+    };
+  }
+  return { sequence, actor, kind: decision.kind };
+}
+
+function playHonestHand(input: {
+  challengeId: string;
+  attemptId: string;
+  gameNumber: 1 | 2 | 3;
+  handIndex: number;
+  tier: (typeof TIERS)[number];
+  runDate: string;
+  playerScore: number;
+  fritzScore: number;
+}): { transcriptActions: DailyFritzTranscriptAction[]; terminal: GameState; digests: string[] } {
+  const deal = generateSingleDailyFritzGameHand(
+    input.runDate,
+    input.gameNumber,
+    input.handIndex,
+    7,
+  );
+  let state = createOfficialDailyFritzHandState({
+    deal,
+    handIndex: input.handIndex,
+    drawWinner: 'you',
+    winningScore: 60,
+    dealSize: 7,
+    playerScore: input.playerScore,
+    fritzScore: input.fritzScore,
+  });
+
+  const actions: DailyFritzTranscriptAction[] = [];
+  const digests = [digestDailyFritzGameState(state)];
+
+  for (let guard = 0; guard < 512 && !state.handOver; guard += 1) {
+    const actorId = state.playerIds[state.currentPlayerIndex];
+    const actor = actorId === 'player' ? 'player' as const : 'fritz' as const;
+    const decision = chooseOfficialFritzDecision({
+      state,
+      participantId: actorId,
+      tier: input.tier,
+    });
+    if (actor === 'fritz' && decision.kind === 'play') {
+      const optimal = listOptimalOfficialFritzPlays({
+        state,
+        participantId: 'fritz',
+        tier: input.tier,
+      });
+      expect(optimal.some((move) =>
+        move.tile.low === decision.tile.low
+        && move.tile.high === decision.tile.high
+        && move.position === decision.position
+      )).toBe(true);
+    }
+    const action = decisionToAction(actions.length, actor, decision);
+    actions.push(action);
+    state = applyGameCommand(state, {
+      version: 1,
+      commandId: `stress:${actions.length}`,
+      sequence: state.sequence,
+      actorId,
+      kind: decision.kind,
+      ...(decision.kind === 'play'
+        ? { tile: decision.tile, position: decision.position }
+        : {}),
+    } as Parameters<typeof applyGameCommand>[1]).state;
+    digests.push(digestDailyFritzGameState(state));
+  }
+
+  expect(state.handOver).toBe(true);
+  return { transcriptActions: actions, terminal: state, digests };
+}
+
+describe('Daily Fritz honest-path stress', () => {
+  it(`verifies ${HAND_BUDGET} deterministic hands across tiers`, () => {
+    for (let index = 0; index < HAND_BUDGET; index += 1) {
+      const tier = TIERS[index % TIERS.length];
+      const gameNumber = ((index % 3) + 1) as 1 | 2 | 3;
+      const handIndex = index % 8;
+      const runDate = `2026-07-${String((index % 28) + 1).padStart(2, '0')}`;
+      const challengeId = `daily-fritz:${runDate}:r2:s1`;
+      const played = playHonestHand({
+        challengeId,
+        attemptId: `attempt-${index}`,
+        gameNumber,
+        handIndex,
+        tier,
+        runDate,
+        playerScore: 0,
+        fritzScore: 0,
+      });
+
+      expect(() => verifyDailyFritzHand({
+        transcript: {
+          protocolVersion: DAILY_FRITZ_TRANSCRIPT_PROTOCOL_VERSION,
+          rulesVersion: GAME_RULES_VERSION,
+          fritzPolicyVersion: FRITZ_POLICY_VERSION,
+          challengeId,
+          attemptId: `attempt-${index}`,
+          gameNumber,
+          handIndex,
+          actions: played.transcriptActions,
+        },
+        initialState: createOfficialDailyFritzHandState({
+          deal: generateSingleDailyFritzGameHand(runDate, gameNumber, handIndex, 7),
+          handIndex,
+          drawWinner: 'you',
+          winningScore: 60,
+          dealSize: 7,
+          playerScore: 0,
+          fritzScore: 0,
+        }),
+        expectedChallengeId: challengeId,
+        expectedAttemptId: `attempt-${index}`,
+        expectedGameNumber: gameNumber,
+        expectedHandIndex: handIndex,
+        userId: 'stress-user',
+        fritzTier: tier,
+      })).not.toThrow();
+    }
+  }, 120_000);
+
+  it(`verifies ${SET_BUDGET} best-of-three score progressions (game1→2→3 hand0)`, () => {
+    for (let setIndex = 0; setIndex < SET_BUDGET; setIndex += 1) {
+      const tier = TIERS[setIndex % TIERS.length];
+      const runDate = `2026-08-${String((setIndex % 28) + 1).padStart(2, '0')}`;
+      const challengeId = `daily-fritz:${runDate}:r2:s1`;
+      let playerScore = 0;
+      let fritzScore = 0;
+
+      for (const gameNumber of [1, 2, 3] as const) {
+        const handIndex = 0;
+        const attemptId = `set-${setIndex}-g${gameNumber}`;
+        const played = playHonestHand({
+          challengeId,
+          attemptId,
+          gameNumber,
+          handIndex,
+          tier,
+          runDate,
+          playerScore,
+          fritzScore,
+        });
+
+        const initialState = createOfficialDailyFritzHandState({
+          deal: generateSingleDailyFritzGameHand(runDate, gameNumber, handIndex, 7),
+          handIndex,
+          drawWinner: 'you',
+          winningScore: 60,
+          dealSize: 7,
+          playerScore,
+          fritzScore,
+        });
+
+        const verified = verifyDailyFritzHand({
+          transcript: {
+            protocolVersion: DAILY_FRITZ_TRANSCRIPT_PROTOCOL_VERSION,
+            rulesVersion: GAME_RULES_VERSION,
+            fritzPolicyVersion: FRITZ_POLICY_VERSION,
+            challengeId,
+            attemptId,
+            gameNumber,
+            handIndex,
+            actions: played.transcriptActions,
+          },
+          initialState,
+          expectedChallengeId: challengeId,
+          expectedAttemptId: attemptId,
+          expectedGameNumber: gameNumber,
+          expectedHandIndex: handIndex,
+          userId: 'stress-user',
+          fritzTier: tier,
+        });
+
+        playerScore = verified.result.playerScoreAfter;
+        fritzScore = verified.result.fritzScoreAfter;
+      }
+    }
+  }, 180_000);
+});

--- a/server/src/dailyFritzLifecycleJourney.test.ts
+++ b/server/src/dailyFritzLifecycleJourney.test.ts
@@ -1,0 +1,236 @@
+/**
+ * Lifecycle journey: Fritz scoring play → recovery draws → remount/cancel during
+ * presentation window → evidence already finalized → hand completes → verify →
+ * game 2 fresh transcript/actor/sequence.
+ *
+ * Models the fixed client ordering (finalize then present) under cleanup pressure.
+ * Uses the real verifier; does not weaken acceptance rules.
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  applyGameCommand,
+  chooseOfficialFritzDecision,
+  DAILY_FRITZ_TRANSCRIPT_PROTOCOL_VERSION,
+  FRITZ_POLICY_VERSION,
+  GAME_RULES_VERSION,
+  type DailyFritzTranscriptAction,
+  type GameState,
+} from '@racehorse/game-core';
+import {
+  createOfficialDailyFritzHandState,
+  verifyDailyFritzHand,
+} from './dailyFritzVerifier';
+
+function envelope(
+  actions: DailyFritzTranscriptAction[],
+  gameNumber: 1 | 2 | 3,
+  handIndex: number,
+) {
+  return {
+    protocolVersion: DAILY_FRITZ_TRANSCRIPT_PROTOCOL_VERSION,
+    rulesVersion: GAME_RULES_VERSION,
+    fritzPolicyVersion: FRITZ_POLICY_VERSION,
+    challengeId: 'lifecycle-challenge',
+    attemptId: 'lifecycle-attempt',
+    gameNumber,
+    handIndex,
+    actions,
+  };
+}
+
+function playToTerminal(
+  initial: GameState,
+  seedActions: DailyFritzTranscriptAction[] = [],
+): { actions: DailyFritzTranscriptAction[]; terminal: GameState } {
+  let state = initial;
+  const actions: DailyFritzTranscriptAction[] = [];
+  for (const action of seedActions) {
+    actions.push({ ...action, sequence: actions.length });
+    state = applyGameCommand(state, {
+      version: 1,
+      commandId: `seed-${action.sequence}`,
+      sequence: state.sequence,
+      actorId: action.actor,
+      kind: action.kind,
+      ...(action.kind === 'play'
+        ? { tile: action.tile, position: action.position }
+        : {}),
+    } as Parameters<typeof applyGameCommand>[1]).state;
+  }
+  while (!state.handOver && actions.length < 128) {
+    const actorId = state.playerIds[state.currentPlayerIndex];
+    const actor = actorId === 'player' ? 'player' as const : 'fritz' as const;
+    const decision = chooseOfficialFritzDecision({
+      state,
+      participantId: actorId,
+      tier: 'elite',
+    });
+    if (decision.kind === 'play') {
+      actions.push({
+        sequence: actions.length,
+        actor,
+        kind: 'play',
+        tile: decision.tile,
+        position: decision.position,
+      });
+      state = applyGameCommand(state, {
+        version: 1,
+        commandId: `a${actions.length}`,
+        sequence: state.sequence,
+        actorId,
+        kind: 'play',
+        tile: decision.tile,
+        position: decision.position,
+      }).state;
+    } else {
+      actions.push({ sequence: actions.length, actor, kind: decision.kind });
+      state = applyGameCommand(state, {
+        version: 1,
+        commandId: `a${actions.length}`,
+        sequence: state.sequence,
+        actorId,
+        kind: decision.kind,
+      }).state;
+    }
+  }
+  expect(state.handOver).toBe(true);
+  return { actions, terminal: state };
+}
+
+describe('Daily Fritz lifecycle journey (finalize-before-present + remount pressure)', () => {
+  it('finalizes scoring evidence once, survives presentation cancel, verifies, and starts game 2 clean', async () => {
+    const start = createOfficialDailyFritzHandState({
+      deal: {
+        player_tiles: [{ low: 0, high: 0 }],
+        fritz_tiles: [{ low: 1, high: 6 }],
+        boneyard: [
+          { low: 2, high: 3 },
+          { low: 3, high: 5 },
+          { low: 4, high: 4 },
+          { low: 0, high: 2 },
+          { low: 0, high: 5 },
+        ],
+        locked: [{ low: 0, high: 2 }, { low: 0, high: 5 }],
+      },
+      handIndex: 0,
+      drawWinner: 'bot',
+      winningScore: 60,
+      dealSize: 7,
+      playerScore: 0,
+      fritzScore: 0,
+    });
+
+    const open = {
+      ...start,
+      board: {
+        mainLine: [{ tile: { low: 1, high: 4 }, orientation: 'horizontal-normal' as const }],
+        leftEnd: 1,
+        rightEnd: 4,
+        leftEndIsDouble: false,
+        rightEndIsDouble: false,
+        hubDoubles: [],
+      },
+      handOpen: true,
+      sequence: 0,
+      currentPlayerIndex: 1,
+    };
+
+    const scorePlay = chooseOfficialFritzDecision({
+      state: open,
+      participantId: 'fritz',
+      tier: 'elite',
+    });
+    expect(scorePlay).toEqual({
+      kind: 'play',
+      tile: { low: 1, high: 6 },
+      position: 'left',
+    });
+    if (scorePlay.kind !== 'play') throw new Error('expected score play');
+
+    const afterScore = applyGameCommand(open, {
+      version: 1,
+      commandId: 'score',
+      sequence: open.sequence,
+      actorId: 'fritz',
+      kind: 'play',
+      tile: scorePlay.tile,
+      position: scorePlay.position,
+    }).state;
+
+    // Fixed client ordering: append evidence before any cancellable presentation await.
+    const moveLog: DailyFritzTranscriptAction[] = [{
+      sequence: 0,
+      actor: 'fritz',
+      kind: 'play',
+      tile: scorePlay.tile,
+      position: scorePlay.position,
+    }];
+
+    // Simulate presentation delay + Strict Mode / remount cancel after finalize.
+    await new Promise((resolve) => setTimeout(resolve, 8));
+    // Cancel must not strip or duplicate evidence.
+    expect(moveLog).toHaveLength(1);
+
+    // Evidence already committed for the scoring play; continue from afterScore.
+    const rest = playToTerminal(afterScore);
+    const completedActions: DailyFritzTranscriptAction[] = [
+      ...moveLog,
+      ...rest.actions.map((action, index) => ({
+        ...action,
+        sequence: moveLog.length + index,
+      })),
+    ];
+    expect(completedActions.filter((action) =>
+      action.kind === 'play'
+      && action.actor === 'fritz'
+      && action.tile.low === scorePlay.tile.low
+      && action.tile.high === scorePlay.tile.high
+      && action.position === scorePlay.position
+    )).toHaveLength(1);
+
+    const verified = verifyDailyFritzHand({
+      transcript: envelope(completedActions, 1, 0),
+      initialState: open,
+      expectedChallengeId: 'lifecycle-challenge',
+      expectedAttemptId: 'lifecycle-attempt',
+      expectedGameNumber: 1,
+      expectedHandIndex: 0,
+      userId: 'lifecycle-user',
+      fritzTier: 'elite',
+    });
+    expect(verified.result.actionCount).toBe(completedActions.length);
+    expect(verified.result.gameNumber).toBe(1);
+    expect(verified.result.handIndex).toBe(0);
+
+    // Game 2: fresh transcript index/actor/sequence; prior hand actions must not leak.
+    const game2Start = createOfficialDailyFritzHandState({
+      deal: {
+        player_tiles: [{ low: 6, high: 6 }],
+        fritz_tiles: [{ low: 0, high: 5 }],
+        boneyard: [],
+        locked: [],
+      },
+      handIndex: 0,
+      drawWinner: 'you',
+      winningScore: 60,
+      dealSize: 7,
+      playerScore: verified.result.playerScoreAfter,
+      fritzScore: verified.result.fritzScoreAfter,
+    });
+    const game2 = playToTerminal(game2Start);
+    expect(game2.actions[0]?.sequence).toBe(0);
+    expect(game2.actions.every((action, index) => action.sequence === index)).toBe(true);
+    expect(game2.actions).not.toEqual(completedActions);
+
+    expect(() => verifyDailyFritzHand({
+      transcript: envelope(game2.actions, 2, 0),
+      initialState: game2Start,
+      expectedChallengeId: 'lifecycle-challenge',
+      expectedAttemptId: 'lifecycle-attempt',
+      expectedGameNumber: 2,
+      expectedHandIndex: 0,
+      userId: 'lifecycle-user',
+      fritzTier: 'elite',
+    })).not.toThrow();
+  });
+});

--- a/server/src/dailyFritzPresentBeforeFinalizeRace.test.ts
+++ b/server/src/dailyFritzPresentBeforeFinalizeRace.test.ts
@@ -1,0 +1,337 @@
+/**
+ * Reconstructs the transcript shape produced when Fritz's scoring play is applied
+ * in live UI (presentEmbeddedForcedDraws) but never appended to the move log
+ * (finalize cancelled by bot-turn remount), then a later tenure logs the
+ * post-recovery follow-up from the advanced live state.
+ *
+ * Verifier correctly rejects — class A (different input state / incomplete evidence).
+ * Production surfaces this at the end-of-hand modal as fritz_action_mismatch with
+ * different tiles at the same seat (got X expected Y @ branch-0-1).
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  applyGameCommand,
+  chooseOfficialFritzDecision,
+  DAILY_FRITZ_TRANSCRIPT_PROTOCOL_VERSION,
+  FRITZ_POLICY_VERSION,
+  GAME_RULES_VERSION,
+  type DailyFritzTranscriptAction,
+} from '@racehorse/game-core';
+import {
+  createOfficialDailyFritzHandState,
+  DailyFritzVerificationError,
+  verifyDailyFritzHand,
+} from './dailyFritzVerifier';
+
+describe('Daily Fritz present-before-finalize transcript race', () => {
+  it('rejects a follow-up Fritz play whose prior scoring play was never logged', () => {
+    const start = createOfficialDailyFritzHandState({
+      deal: {
+        player_tiles: [{ low: 0, high: 0 }],
+        fritz_tiles: [{ low: 1, high: 6 }],
+        boneyard: [
+          { low: 2, high: 3 },
+          { low: 3, high: 5 },
+          { low: 4, high: 4 },
+          { low: 0, high: 2 },
+          { low: 0, high: 5 },
+        ],
+        locked: [{ low: 0, high: 2 }, { low: 0, high: 5 }],
+      },
+      handIndex: 0,
+      drawWinner: 'bot',
+      winningScore: 60,
+      dealSize: 7,
+      playerScore: 0,
+      fritzScore: 0,
+    });
+
+    const open = {
+      ...start,
+      board: {
+        mainLine: [{ tile: { low: 1, high: 4 }, orientation: 'horizontal-normal' as const }],
+        leftEnd: 1,
+        rightEnd: 4,
+        leftEndIsDouble: false,
+        rightEndIsDouble: false,
+        hubDoubles: [],
+      },
+      handOpen: true,
+      sequence: 0,
+      currentPlayerIndex: 1,
+    };
+
+    const scorePlay = chooseOfficialFritzDecision({
+      state: open,
+      participantId: 'fritz',
+      tier: 'elite',
+    });
+    expect(scorePlay).toEqual({
+      kind: 'play',
+      tile: { low: 1, high: 6 },
+      position: 'left',
+    });
+
+    const afterScore = applyGameCommand(open, {
+      version: 1,
+      commandId: 'score',
+      sequence: open.sequence,
+      actorId: 'fritz',
+      kind: 'play',
+      tile: { low: 1, high: 6 },
+      position: 'left',
+    }).state;
+
+    const followUp = chooseOfficialFritzDecision({
+      state: afterScore,
+      participantId: 'fritz',
+      tier: 'elite',
+    });
+    expect(followUp.kind).toBe('play');
+    if (followUp.kind !== 'play') throw new Error('expected follow-up play');
+
+    // Race transcript: scoring play never logged; follow-up chosen from advanced live state.
+    const raceActions: DailyFritzTranscriptAction[] = [
+      {
+        sequence: 0,
+        actor: 'fritz',
+        kind: 'play',
+        tile: followUp.tile,
+        position: followUp.position,
+      },
+    ];
+
+    let caught: DailyFritzVerificationError | null = null;
+    try {
+      verifyDailyFritzHand({
+        transcript: {
+          protocolVersion: DAILY_FRITZ_TRANSCRIPT_PROTOCOL_VERSION,
+          rulesVersion: GAME_RULES_VERSION,
+          fritzPolicyVersion: FRITZ_POLICY_VERSION,
+          challengeId: 'c',
+          attemptId: 'a',
+          gameNumber: 1,
+          handIndex: 0,
+          actions: raceActions,
+        },
+        initialState: open,
+        expectedChallengeId: 'c',
+        expectedAttemptId: 'a',
+        expectedGameNumber: 1,
+        expectedHandIndex: 0,
+        userId: 'u',
+        fritzTier: 'elite',
+      });
+    } catch (error) {
+      caught = error as DailyFritzVerificationError;
+    }
+
+    expect(caught).toBeInstanceOf(DailyFritzVerificationError);
+    expect(caught?.code).toBe('fritz_action_mismatch');
+    expect(caught?.message).toMatch(/Fritz action does not match the official policy/);
+    // Same seat class as production screenshot: different tiles, not empty-arm siblings.
+    expect(caught?.message).toMatch(/got play /);
+    expect(caught?.message).toMatch(/expected play /);
+    const gotTile = followUp.tile;
+    const expectedTile = scorePlay.kind === 'play' ? scorePlay.tile : null;
+    expect(expectedTile).not.toBeNull();
+    expect(`${gotTile.low}|${gotTile.high}`).not.toBe(`${expectedTile!.low}|${expectedTile!.high}`);
+  });
+
+  it('rejects a Fritz action logged after an absorbed auto-pass when the scoring play was omitted', () => {
+    const start = createOfficialDailyFritzHandState({
+      deal: {
+        player_tiles: [{ low: 0, high: 0 }],
+        fritz_tiles: [{ low: 1, high: 6 }],
+        boneyard: [
+          { low: 2, high: 3 },
+          { low: 0, high: 2 },
+          { low: 0, high: 5 },
+        ],
+        locked: [{ low: 0, high: 2 }, { low: 0, high: 5 }],
+      },
+      handIndex: 0,
+      drawWinner: 'bot',
+      winningScore: 60,
+      dealSize: 7,
+      playerScore: 0,
+      fritzScore: 0,
+    });
+
+    const open = {
+      ...start,
+      board: {
+        mainLine: [{ tile: { low: 1, high: 4 }, orientation: 'horizontal-normal' as const }],
+        leftEnd: 1,
+        rightEnd: 4,
+        leftEndIsDouble: false,
+        rightEndIsDouble: false,
+        hubDoubles: [],
+      },
+      handOpen: true,
+      sequence: 0,
+      currentPlayerIndex: 1,
+    };
+
+    const afterScore = applyGameCommand(open, {
+      version: 1,
+      commandId: 'score',
+      sequence: open.sequence,
+      actorId: 'fritz',
+      kind: 'play',
+      tile: { low: 1, high: 6 },
+      position: 'left',
+    }).state;
+    expect(afterScore.playerIds[afterScore.currentPlayerIndex]).toBe('player');
+
+    // Presentation forces currentPlayer back to bot while animating; a stale tenure
+    // can then append a Fritz action though authoritative turn is already player's.
+    let caught: DailyFritzVerificationError | null = null;
+    try {
+      verifyDailyFritzHand({
+        transcript: {
+          protocolVersion: DAILY_FRITZ_TRANSCRIPT_PROTOCOL_VERSION,
+          rulesVersion: GAME_RULES_VERSION,
+          fritzPolicyVersion: FRITZ_POLICY_VERSION,
+          challengeId: 'c',
+          attemptId: 'a',
+          gameNumber: 1,
+          handIndex: 0,
+          actions: [
+            { sequence: 0, actor: 'fritz', kind: 'play', tile: { low: 1, high: 6 }, position: 'left' },
+            { sequence: 1, actor: 'fritz', kind: 'pass' },
+          ],
+        },
+        initialState: open,
+        expectedChallengeId: 'c',
+        expectedAttemptId: 'a',
+        expectedGameNumber: 1,
+        expectedHandIndex: 0,
+        userId: 'u',
+        fritzTier: 'elite',
+      });
+    } catch (error) {
+      caught = error as DailyFritzVerificationError;
+    }
+
+    expect(caught).toBeInstanceOf(DailyFritzVerificationError);
+    expect(caught?.code).toBe('wrong_actor');
+    expect(caught?.message).toMatch(/Transcript actor does not own the turn/);
+  });
+
+  it('accepts an honest scoring play with absorbed recovery draws and follow-up', () => {
+    const start = createOfficialDailyFritzHandState({
+      deal: {
+        player_tiles: [{ low: 0, high: 0 }],
+        fritz_tiles: [{ low: 1, high: 6 }],
+        boneyard: [
+          { low: 2, high: 3 },
+          { low: 3, high: 5 },
+          { low: 4, high: 4 },
+          { low: 0, high: 2 },
+          { low: 0, high: 5 },
+        ],
+        locked: [{ low: 0, high: 2 }, { low: 0, high: 5 }],
+      },
+      handIndex: 0,
+      drawWinner: 'bot',
+      winningScore: 60,
+      dealSize: 7,
+      playerScore: 0,
+      fritzScore: 0,
+    });
+
+    const open = {
+      ...start,
+      board: {
+        mainLine: [{ tile: { low: 1, high: 4 }, orientation: 'horizontal-normal' as const }],
+        leftEnd: 1,
+        rightEnd: 4,
+        leftEndIsDouble: false,
+        rightEndIsDouble: false,
+        hubDoubles: [],
+      },
+      handOpen: true,
+      sequence: 0,
+      currentPlayerIndex: 1,
+    };
+
+    let state = open;
+    const actions: DailyFritzTranscriptAction[] = [];
+    // Lifecycle: finalize evidence for scoring play (presentation may then remount).
+    actions.push({
+      sequence: 0,
+      actor: 'fritz',
+      kind: 'play',
+      tile: { low: 1, high: 6 },
+      position: 'left',
+    });
+    state = applyGameCommand(state, {
+      version: 1,
+      commandId: 'score',
+      sequence: state.sequence,
+      actorId: 'fritz',
+      kind: 'play',
+      tile: { low: 1, high: 6 },
+      position: 'left',
+    }).state;
+
+    while (!state.handOver && actions.length < 64) {
+      const actorId = state.playerIds[state.currentPlayerIndex];
+      const actor = actorId === 'player' ? 'player' as const : 'fritz' as const;
+      const decision = chooseOfficialFritzDecision({
+        state,
+        participantId: actorId,
+        tier: 'elite',
+      });
+      if (decision.kind === 'play') {
+        actions.push({
+          sequence: actions.length,
+          actor,
+          kind: 'play',
+          tile: decision.tile,
+          position: decision.position,
+        });
+        state = applyGameCommand(state, {
+          version: 1,
+          commandId: `a${actions.length}`,
+          sequence: state.sequence,
+          actorId,
+          kind: 'play',
+          tile: decision.tile,
+          position: decision.position,
+        }).state;
+      } else {
+        actions.push({ sequence: actions.length, actor, kind: decision.kind });
+        state = applyGameCommand(state, {
+          version: 1,
+          commandId: `a${actions.length}`,
+          sequence: state.sequence,
+          actorId,
+          kind: decision.kind,
+        }).state;
+      }
+    }
+
+    expect(state.handOver).toBe(true);
+    expect(() => verifyDailyFritzHand({
+      transcript: {
+        protocolVersion: DAILY_FRITZ_TRANSCRIPT_PROTOCOL_VERSION,
+        rulesVersion: GAME_RULES_VERSION,
+        fritzPolicyVersion: FRITZ_POLICY_VERSION,
+        challengeId: 'c',
+        attemptId: 'a',
+        gameNumber: 1,
+        handIndex: 0,
+        actions,
+      },
+      initialState: open,
+      expectedChallengeId: 'c',
+      expectedAttemptId: 'a',
+      expectedGameNumber: 1,
+      expectedHandIndex: 0,
+      userId: 'u',
+      fritzTier: 'elite',
+    })).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- Prevent Daily Fritz end-of-hand verifier rejects (`fritz_action_mismatch` / `wrong_actor`) by making Fritz recovery-draw presentation overlay-only, finalizing move-log evidence before any cancellable presentation await, and narrowing `botScheduleKey` to tenure identity so remounts cannot skip finalize.
- Adds deterministic race, schedule-key, lifecycle-journey, honest-path stress, and Playwright verifier-race coverage. Strict server verification and official Fritz policy are unchanged.

## Test plan
- [x] Client race / presentation / schedule-key unit tests
- [x] Server verifier + multi-draw + present-before-finalize race tests
- [x] Lifecycle journey (finalize → present cancel pressure → verify → game 2)
- [x] `DF_STRESS_HANDS=10000 DF_STRESS_SETS=1000` honest-path stress (0 mismatches)
- [ ] Refresh QA auth and run `client/e2e/daily-fritz-verifier-race.spec.ts` against patched client+server (merge gate)
- [x] Client + game-core builds
- [ ] Server `tsc` still blocked by pre-existing `ignoreDeprecations` (out of scope)


Made with [Cursor](https://cursor.com)