### PR TITLE
fix(ci): server OOM + multiplayer reconnect E2E

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,9 @@ jobs:
       - name: Server tests
         env:
           TZ: America/Los_Angeles
-        run: npm run test --prefix server
+          # Vitest workers on Node 24 routinely OOM the default ~2GB heap on ubuntu-latest.
+          NODE_OPTIONS: --max-old-space-size=4096
+        run: npm run test --prefix server -- --maxWorkers=2
 
       - name: Server build
         run: npm run build --prefix server

--- a/client/e2e/helpers/multiplayerMatch.ts
+++ b/client/e2e/helpers/multiplayerMatch.ts
@@ -4,6 +4,7 @@ const TRANSPORT_LOSS_DETECT_MS = 70_000;
 
 const LAST_ROOM_STORAGE_KEY = 'racehorse_last_room_code';
 const GUEST_ID_STORAGE_KEY = 'racehorse_guest_identity_v1';
+const GUEST_NAME_STORAGE_KEY = 'racehorse_guest_display_name_v1';
 
 export const MULTIPLAYER_SHELL_LOCATOR =
   '.mm-page.multiplayer-hub, .mm-page.mm-mp-bridge, .pml-root.pml-mp-bridge';
@@ -30,23 +31,33 @@ export const E2E_PLAYER_B: E2EPlayerIdentity = {
 export function makeRunIdentity(role: 'a' | 'b', runId: string): E2EPlayerIdentity {
   const suffix = runId.replace(/[^a-zA-Z0-9_-]/g, '_').slice(0, 48);
   // Must use guest_ prefix — getOrCreateGuestIdentityId() only preserves existing guest_* ids on reload.
+  // Display name must match getOrCreateGuestDisplayName()'s `Guest NNNN` contract, otherwise the
+  // client regenerates the label mid-match (e.g. after a room sync) and HUD assertions flake.
+  let hash = 0;
+  const guestId = `guest_e2e_mp_${role}_${suffix}`;
+  for (let index = 0; index < guestId.length; index += 1) {
+    hash = (hash * 31 + guestId.charCodeAt(index)) >>> 0;
+  }
   return {
-    guestId: `guest_e2e_mp_${role}_${suffix}`,
-    username: role === 'a' ? 'E2E_PlayerA' : 'E2E_PlayerB',
+    guestId,
+    username: `Guest ${String(hash % 10000).padStart(4, '0')}`,
   };
 }
 
 export async function seedPlayerIdentity(context: BrowserContext, identity: E2EPlayerIdentity) {
-  // Only seed guest id — do NOT clear last room code here; addInitScript runs on every
+  // Seed guest id + display name. Do NOT clear last room code here; addInitScript runs on every
   // navigation including mid-test reload, and refresh-recovery depends on persistence.
   // Cross-test isolation uses unique guest ids via makeRunIdentity + fresh contexts.
   await context.addInitScript(
-    ({ guestId, guestKey }) => {
+    ({ guestId, username, guestKey, nameKey }) => {
       window.localStorage.setItem(guestKey, guestId);
+      window.localStorage.setItem(nameKey, username);
     },
     {
       guestId: identity.guestId,
+      username: identity.username,
       guestKey: GUEST_ID_STORAGE_KEY,
+      nameKey: GUEST_NAME_STORAGE_KEY,
     },
   );
 }
@@ -227,16 +238,33 @@ export async function readLastRoomCode(page: Page): Promise<string> {
   }, LAST_ROOM_STORAGE_KEY);
 }
 
+/**
+ * Read numeric scores from the live HUD pills.
+ * Prefer `.wl-player-score` over full pill text — display names can resolve/change
+ * after reconnect without any score mutation (e.g. `@GUEST` → `@GUEST 4909`).
+ */
 export async function readHudScorePair(page: Page): Promise<{ you: string; opponent: string }> {
   const pills = page.locator('.wl-player-pill, .rh-player-pill');
   await expect(pills.first()).toBeVisible({ timeout: 10_000 });
   const count = await pills.count();
+
+  const readScore = async (pillIndex: number): Promise<string> => {
+    const score = pills.nth(pillIndex).locator('.wl-player-score, .rh-player-score');
+    if ((await score.count()) > 0) {
+      return ((await score.first().innerText()) ?? '').trim();
+    }
+    // Fallback: last whitespace-separated token from the pill (score sits under the label).
+    const raw = ((await pills.nth(pillIndex).innerText()) ?? '').trim();
+    const parts = raw.split(/\s+/);
+    return parts[parts.length - 1] ?? raw;
+  };
+
   if (count < 2) {
-    return { you: await pills.nth(0).innerText(), opponent: '' };
+    return { you: await readScore(0), opponent: '' };
   }
   return {
-    you: (await pills.nth(0).innerText()).trim(),
-    opponent: (await pills.nth(1).innerText()).trim(),
+    you: await readScore(0),
+    opponent: await readScore(1),
   };
 }
 

--- a/server/vitest.config.ts
+++ b/server/vitest.config.ts
@@ -4,5 +4,7 @@ export default defineConfig({
   test: {
     exclude: ['**/node_modules/**', '**/dist/**'],
     include: ['src/**/*.test.ts'],
+    // Cap parallelism in CI to keep Node heap under ubuntu-latest limits.
+    ...(process.env.CI ? { maxWorkers: 2 } : {}),
   },
 });


### PR DESCRIPTION
## Summary
- Raise Node heap and cap Vitest workers for Server Validation so the suite no longer OOMs on ubuntu-latest.
- Stabilize multiplayer reconnect E2E: seed `Guest NNNN` display names (matching client identity contract) and assert numeric HUD scores instead of brittle full-pill label text.

## Test plan
- [x] `CI=true NODE_OPTIONS=--max-old-space-size=4096 npm run test --prefix server -- --maxWorkers=2` (529/529 after game-core build)
- [ ] GitHub Actions Server Validation green
- [ ] GitHub Actions Client Validation green (especially `multiplayer-in-match-reconnect.spec.ts`)


Made with [Cursor](https://cursor.com)