### PR TITLE
Harden Daily Fritz transactional authority

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,9 @@ jobs:
           TZ: America/Los_Angeles
         run: npm run test --prefix server
 
+      - name: Typecheck Daily Fritz authority soak harness
+        run: npm run typecheck:scripts --prefix server
+
       - name: Server build
         run: npm run build --prefix server
 

--- a/.github/workflows/daily-fritz-authority-soak.yml
+++ b/.github/workflows/daily-fritz-authority-soak.yml
@@ -1,0 +1,62 @@
+name: Daily Fritz Authority Soak
+
+on:
+  workflow_dispatch:
+    inputs:
+      base_url:
+        description: Deployed server origin to exercise
+        required: true
+        default: https://racehorse.onrender.com
+        type: string
+      users:
+        description: Number of ephemeral authenticated players
+        required: true
+        default: '5'
+        type: string
+      concurrency:
+        description: Concurrent player wave size
+        required: true
+        default: '2'
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: daily-fritz-authority-soak
+  cancel-in-progress: false
+
+jobs:
+  authority-soak:
+    name: Game 1 authority and recovery soak
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    environment: production-soak
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build shared game core
+        run: npm run build -w @racehorse/game-core
+
+      - name: Typecheck authority harness
+        run: npm run typecheck:scripts --prefix server
+
+      - name: Run authority soak
+        env:
+          DAILY_FRITZ_SOAK_BASE_URL: ${{ inputs.base_url }}
+          DAILY_FRITZ_SOAK_USERS: ${{ inputs.users }}
+          DAILY_FRITZ_SOAK_CONCURRENCY: ${{ inputs.concurrency }}
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+          VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY }}
+        run: npm run soak:daily-fritz-authority --prefix server

--- a/client/src/dailyFritz/api.ts
+++ b/client/src/dailyFritz/api.ts
@@ -4,9 +4,6 @@ import type { FritzTier } from '../bot/fritzConfig';
 import type { Tile } from '../types.ts';
 import { normalizePreGameDrawTile } from '../match/preGameDraw/preGameDrawLogic.ts';
 
-const DAILY_FRITZ_CLIENT_DEBUG_LOGS =
-  import.meta.env.DEV === true || import.meta.env.VITE_DEBUG_DAILY_FRITZ === 'true';
-
 export const DAILY_FRITZ_REQUEST_ID_HEADER = 'x-racehorse-request-id';
 
 export function createDailyFritzRequestId(): string {
@@ -24,14 +21,13 @@ export const DAILY_FRITZ_NEXT_HAND_TIMEOUT_MS = 10_000;
 
 export const DAILY_FRITZ_TODAY_CACHE_PREFIX = 'racehorse:daily-fritz:today:';
 
-function dfClientDebug(...args: unknown[]): void {
-  if (DAILY_FRITZ_CLIENT_DEBUG_LOGS) console.log(...args);
+function dfClientDebug(..._args: unknown[]): void {
+  void _args;
 }
 
-function dfInitLog(event: string, payload?: Record<string, unknown>): void {
-  if (DAILY_FRITZ_CLIENT_DEBUG_LOGS) {
-    console.log(`[daily-fritz:init] ${event}`, payload ?? {});
-  }
+function dfInitLog(_event: string, _payload?: Record<string, unknown>): void {
+  void _event;
+  void _payload;
 }
 
 function isDailyFritzInitPath(path: string): boolean {
@@ -216,6 +212,8 @@ const DAILY_FRITZ_RECOVERABLE_AUTHORITY_CODES = new Set([
   'fritz_policy_version_mismatch',
   'fritz_policy_contract_mismatch',
   'missing_fritz_state_digest',
+  'stale_revision',
+  'command_slot_conflict',
 ]);
 
 export function isRecoverableDailyFritzAuthorityCode(code: string | null | undefined): boolean {
@@ -319,6 +317,7 @@ export interface DailyFritzTodayResponse {
   deal_size: BotDealSize;
   winning_score: number;
   attempt_status: 'none' | 'started' | 'completed' | 'abandoned';
+  authority_revision?: number | null;
   current_game_number: DailyFritzSetGameNumber | null;
   needs_completion?: boolean;
   streak: number;
@@ -341,6 +340,7 @@ export interface DailyFritzStartResponse {
   ok: true;
   attempt_id: string;
   verified_match_id: string;
+  authority_revision?: number;
   run_date: string;
   challenge_id?: string;
   rules_version?: number;
@@ -379,6 +379,7 @@ export interface DailyFritzNextHandResponse {
   current_game_number?: DailyFritzSetGameNumber | null;
   set_result?: DailyFritzSetResult | null;
   current_hand_index: number;
+  authority_revision?: number;
   current_game_scores: { you: number; fritz: number };
   hand: BotHandDeal;
   draw_winner: DailyFritzDrawWinner;
@@ -391,6 +392,7 @@ export interface DailyFritzNextHandResponse {
 export interface DailyFritzCompleteResponse {
   ok: true;
   replayed?: boolean;
+  authority_revision?: number;
   rank: number | null;
   leaderboard_preview: DailyFritzLeaderboardRow[];
 }
@@ -398,6 +400,7 @@ export interface DailyFritzCompleteResponse {
 export interface DailyFritzRecordGameResponse {
   ok: true;
   replayed?: boolean;
+  authority_revision?: number;
   set_result: DailyFritzSetResult;
   next_game_number: DailyFritzSetGameNumber | null;
 }
@@ -458,13 +461,6 @@ export async function startDailyFritz(options?: {
     timeoutMs: options?.timeoutMs,
   });
   const normalized = normalizeDailyFritzStartDrawFields(response);
-  console.log('[df-scripted-draw] start response', {
-    drawWinner: normalized.draw_winner ?? null,
-    rawDrawPlayerTile: response.draw_player_tile ?? null,
-    rawDrawFritzTile: response.draw_fritz_tile ?? null,
-    normalizedDrawPlayerTile: normalized.draw_player_tile ?? null,
-    normalizedDrawFritzTile: normalized.draw_fritz_tile ?? null,
-  });
   return normalized;
 }
 
@@ -762,4 +758,46 @@ export async function recordDailyFritzGame(input: {
 
 export async function abandonDailyFritz(attemptId: string): Promise<void> {
   throwApiResult(await timedApiPost<{ ok: true }>('/api/daily-fritz/abandon', { attempt_id: attemptId }));
+}
+
+export type DailyFritzClientTelemetryEvent =
+  | 'mode_impression'
+  | 'start_requested'
+  | 'first_move'
+  | 'recovery_started'
+  | 'recovery_succeeded'
+  | 'recovery_failed'
+  | 'review_opened'
+  | 'leaderboard_opened'
+  | 'share_requested'
+  | 'share_completed';
+
+/** Analytics is intentionally best-effort and can never block gameplay authority. */
+export async function recordDailyFritzTelemetry(input: {
+  eventId: string;
+  eventType: DailyFritzClientTelemetryEvent;
+  attemptId?: string | null;
+  runDate?: string | null;
+  challengeId?: string | null;
+  sessionId?: string | null;
+  durationMs?: number | null;
+  failureCode?: string | null;
+  payload?: Record<string, unknown>;
+}): Promise<void> {
+  try {
+    await timedApiPost<{ ok: true }>('/api/daily-fritz/telemetry', {
+      event_id: input.eventId,
+      event_type: input.eventType,
+      attempt_id: input.attemptId ?? null,
+      run_date: input.runDate ?? null,
+      challenge_id: input.challengeId ?? null,
+      session_id: input.sessionId ?? null,
+      duration_ms: input.durationMs ?? null,
+      failure_code: input.failureCode ?? null,
+      client_release: import.meta.env.VITE_APP_VERSION ?? 'unknown',
+      payload: input.payload ?? {},
+    });
+  } catch {
+    // Telemetry never changes the official run or surfaces an error to players.
+  }
 }

--- a/client/src/dailyFritz/dailyFritzScreenHelpers.ts
+++ b/client/src/dailyFritz/dailyFritzScreenHelpers.ts
@@ -12,13 +12,9 @@ const DAILY_FRITZ_SET_VERSION = 2;
 
 export const DAILY_FRITZ_INIT_SLOW_MS = 10_000;
 
-const DAILY_FRITZ_INIT_DEBUG =
-  import.meta.env.DEV === true || import.meta.env.VITE_DEBUG_DAILY_FRITZ === 'true';
-
-export function dfInitLog(event: string, payload?: Record<string, unknown>): void {
-  if (DAILY_FRITZ_INIT_DEBUG) {
-    console.log(`[daily-fritz:init] ${event}`, payload ?? {});
-  }
+export function dfInitLog(_event: string, _payload?: Record<string, unknown>): void {
+  void _event;
+  void _payload;
 }
 
 export function readTodayCache(cacheKey: string | null): DailyFritzTodayResponse | null {

--- a/client/src/dailyFritz/telemetry.test.ts
+++ b/client/src/dailyFritz/telemetry.test.ts
@@ -1,0 +1,22 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { dailyFritzTelemetryEventId, getDailyFritzTelemetrySession } from './telemetry';
+
+describe('Daily Fritz client telemetry identity', () => {
+  afterEach(() => window.sessionStorage.clear());
+
+  it('keeps one session identity per daily challenge within a browser tab', () => {
+    const first = getDailyFritzTelemetrySession('2026-08-01');
+    const repeated = getDailyFritzTelemetrySession('2026-08-01');
+    const nextDay = getDailyFritzTelemetrySession('2026-08-02');
+
+    expect(first).toBe(repeated);
+    expect(nextDay).not.toBe(first);
+  });
+
+  it('creates stable bounded event identities for exactly-once client events', () => {
+    expect(dailyFritzTelemetryEventId('attempt-1', 'first_move'))
+      .toBe('attempt-1:first_move:once');
+    expect(dailyFritzTelemetryEventId('x'.repeat(200), 'recovery_succeeded', 'resume-1'))
+      .toHaveLength(160);
+  });
+});

--- a/client/src/dailyFritz/telemetry.ts
+++ b/client/src/dailyFritz/telemetry.ts
@@ -1,0 +1,30 @@
+const SESSION_PREFIX = 'racehorse:daily-fritz:telemetry-session:';
+
+function randomId(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+}
+
+export function getDailyFritzTelemetrySession(runDate: string): string {
+  const key = `${SESSION_PREFIX}${runDate}`;
+  if (typeof window === 'undefined') return `server-${randomId()}`;
+  try {
+    const existing = window.sessionStorage.getItem(key);
+    if (existing) return existing;
+    const created = randomId();
+    window.sessionStorage.setItem(key, created);
+    return created;
+  } catch {
+    return randomId();
+  }
+}
+
+export function dailyFritzTelemetryEventId(
+  scope: string,
+  eventType: string,
+  suffix = 'once',
+): string {
+  return `${scope}:${eventType}:${suffix}`.slice(0, 160);
+}

--- a/client/src/dailyFritz/useDailyFritzInit.ts
+++ b/client/src/dailyFritz/useDailyFritzInit.ts
@@ -5,6 +5,7 @@ import {
   DAILY_FRITZ_INIT_TIMEOUT_MS,
   DAILY_FRITZ_TODAY_CACHE_PREFIX,
   getTodayDailyFritz,
+  recordDailyFritzTelemetry,
   type DailyFritzTodayResponse,
 } from './api';
 import {
@@ -14,6 +15,7 @@ import {
   readTodayCache,
   shouldClearStaleClientState,
 } from './dailyFritzScreenHelpers';
+import { dailyFritzTelemetryEventId, getDailyFritzTelemetrySession } from './telemetry';
 import type { DailyFritzInitPhase } from './dailyFritzScreenTypes';
 
 export type UseDailyFritzInitParams = {
@@ -153,6 +155,15 @@ export function useDailyFritzInit({ userId }: UseDailyFritzInitParams): UseDaily
         setToday(response);
         persistTodayCache(response);
         setInitPhase('ready');
+        const sessionId = getDailyFritzTelemetrySession(response.run_date);
+        void recordDailyFritzTelemetry({
+          eventId: dailyFritzTelemetryEventId(sessionId, 'mode_impression'),
+          eventType: 'mode_impression',
+          runDate: response.run_date,
+          challengeId: response.challenge_id ?? null,
+          sessionId,
+          payload: { attemptStatus: response.attempt_status },
+        });
         dfInitLog('state', { phase: 'ready' });
       } catch {
         if (initRequestIdRef.current !== requestId) return;

--- a/client/src/dailyFritz/useDailyFritzRunController.ts
+++ b/client/src/dailyFritz/useDailyFritzRunController.ts
@@ -5,6 +5,7 @@ import {
   DAILY_FRITZ_INIT_TIMEOUT_MS,
   DailyFritzAuthorityRecoveryError,
   recordDailyFritzGame,
+  recordDailyFritzTelemetry,
   startDailyFritz,
   type DailyFritzSetGameNumber,
   type DailyFritzSetGameResult,
@@ -28,6 +29,7 @@ import type {
 import { buildDailyFritzTranscript } from './dailyFritzTranscript';
 import { createDailyFritzChallengeIdentity } from './dailyFritzChallengeIdentity';
 import type { MoveEntry } from '../game/moveLogger';
+import { dailyFritzTelemetryEventId, getDailyFritzTelemetrySession } from './telemetry';
 import {
   buildDailyFritzStorageKey,
   discardDailyFritzSnapshot,
@@ -248,6 +250,16 @@ export function useDailyFritzRunController({
     setStartActionPending(true);
     setHubError(null);
     setSetOverlay(null);
+    if (today?.run_date) {
+      const sessionId = getDailyFritzTelemetrySession(today.run_date);
+      void recordDailyFritzTelemetry({
+        eventId: dailyFritzTelemetryEventId(sessionId, 'start_requested'),
+        eventType: 'start_requested',
+        runDate: today.run_date,
+        challengeId: today.challenge_id ?? null,
+        sessionId,
+      });
+    }
     try {
       const started = await startDailyFritz({ timeoutMs: DAILY_FRITZ_INIT_TIMEOUT_MS });
       await handleStartResponse(started, normalizeSetResult(today?.set_result ?? today?.result));
@@ -268,6 +280,17 @@ export function useDailyFritzRunController({
       setOverlay != null && 'setResult' in setOverlay
         ? setOverlay.setResult
         : normalizeSetResult(today?.set_result ?? today?.result);
+    if (today?.run_date) {
+      const sessionId = getDailyFritzTelemetrySession(today.run_date);
+      void recordDailyFritzTelemetry({
+        eventId: dailyFritzTelemetryEventId(sessionId, 'start_requested', 'resume'),
+        eventType: 'start_requested',
+        runDate: today.run_date,
+        challengeId: today.challenge_id ?? null,
+        sessionId,
+        payload: { resume: true },
+      });
+    }
     try {
       const started = await startDailyFritz({ timeoutMs: DAILY_FRITZ_INIT_TIMEOUT_MS });
       setSetOverlay(null);
@@ -379,13 +402,42 @@ export function useDailyFritzRunController({
       }
     } catch (err) {
       if (err instanceof DailyFritzAuthorityRecoveryError) {
+        const sessionId = getDailyFritzTelemetrySession(run.run_date);
+        const recoveryScope = `${run.attempt_id}:${gameNumber}:${game.currentHandIndex}`;
+        void recordDailyFritzTelemetry({
+          eventId: dailyFritzTelemetryEventId(recoveryScope, 'recovery_started'),
+          eventType: 'recovery_started',
+          attemptId: run.attempt_id,
+          runDate: run.run_date,
+          challengeId: run.challenge_id ?? null,
+          sessionId,
+          failureCode: err.verifierCode,
+        });
         discardDailyFritzSnapshot(buildDailyFritzStorageKey(run.attempt_id, gameNumber));
         setSetOverlay(null);
         closeEmbeddedRun();
         setHubError('Daily Fritz restored the last verified hand. Your verified progress is safe.');
         try {
           await loadToday();
-        } catch {
+          void recordDailyFritzTelemetry({
+            eventId: dailyFritzTelemetryEventId(recoveryScope, 'recovery_succeeded'),
+            eventType: 'recovery_succeeded',
+            attemptId: run.attempt_id,
+            runDate: run.run_date,
+            challengeId: run.challenge_id ?? null,
+            sessionId,
+            failureCode: err.verifierCode,
+          });
+        } catch (recoveryError) {
+          void recordDailyFritzTelemetry({
+            eventId: dailyFritzTelemetryEventId(recoveryScope, 'recovery_failed'),
+            eventType: 'recovery_failed',
+            attemptId: run.attempt_id,
+            runDate: run.run_date,
+            challengeId: run.challenge_id ?? null,
+            sessionId,
+            failureCode: recoveryError instanceof Error ? recoveryError.name : 'reload_failed',
+          });
           // The hub keeps the recovery message and its normal retry affordance.
         }
         return;

--- a/client/src/modules/bot-turn/fritzPresentation.ts
+++ b/client/src/modules/bot-turn/fritzPresentation.ts
@@ -3,7 +3,7 @@
  * Shared by Daily Fritz and Play vs Fritz (same bot-turn spine).
  *
  * HUD pill stays calm (thinking / drawing / your move).
- * Score toast owns the ceremony (sticky running total during chains).
+ * Score toast owns the ceremony (timed +N; never sticky forever).
  */
 
 export type FritzPresentationPhase =

--- a/client/src/modules/bot-turn/types.ts
+++ b/client/src/modules/bot-turn/types.ts
@@ -58,7 +58,7 @@ export type BotTurnPorts = {
       actorLabel?: string;
     },
   ) => void;
-  /** Clears a sticky score toast when Fritz's turn ends. */
+  /** Clears a score toast when Fritz's turn ends or a non-scoring step follows. */
   clearBoardToast: () => void;
   onAuthoringFritzActionCaptured?: (capture: AuthoringFritzActionCapture) => void;
   onAuthoringV2FritzEvent?: (capture: AuthoringV2FritzEventCapture) => void;

--- a/client/src/modules/bot-turn/useBotTurnEffect.ts
+++ b/client/src/modules/bot-turn/useBotTurnEffect.ts
@@ -18,6 +18,7 @@ import {
   BOT_PLAYER_HANDOFF_DELAY_MS,
   resolveBotChainContinueDelayMs,
   resolveBotOpeningDelayMs,
+  BOT_SCORE_HOLD_MS,
   resolveBotPostActionSettleMs,
   shouldContinueBotTurnAtTimer,
   shouldScheduleBotTurn,
@@ -380,7 +381,8 @@ export function useBotTurnEffect(args: UseBotTurnEffectArgs): void {
             if (cancelled || !isLocalRunCurrent(runToken)) break;
           }
 
-          // One score surface: sticky running total while Fritz still holds the turn.
+          // Score toast is always timed. Clear immediately on non-scoring steps so a
+          // prior +N cannot linger into the next Fritz tile / your-move handoff.
           if (scoredPoints > 0 && !finalizeLive.isDailyFritzMode) {
             finalizeLive.ports.showBoardToast(
               buildFritzScoreCeremonyMessage(
@@ -390,14 +392,13 @@ export function useBotTurnEffect(args: UseBotTurnEffectArgs): void {
               ),
               'bot',
               {
-                sticky: true,
+                holdMs: BOT_SCORE_HOLD_MS,
                 points: scoredPoints,
                 turnTotal: turnScoreTotal,
                 actorLabel: finalizeLive.opponentLabel.toUpperCase().slice(0, 10),
               },
             );
-          } else if (scoredPoints === 0 && finalizeLive.isDailyFritzMode) {
-            // A non-scoring chain step must not leave the prior +N on screen.
+          } else if (scoredPoints === 0) {
             finalizeLive.ports.clearBoardToast();
           }
 
@@ -410,15 +411,15 @@ export function useBotTurnEffect(args: UseBotTurnEffectArgs): void {
           }
 
           if (!computeBotChainPaused(execution.result)) {
-            if (!live().isDailyFritzMode) {
-              live().ports.clearBoardToast();
-            }
+            live().ports.clearBoardToast();
             break;
           }
         }
       } finally {
         botTurnInFlightRef.current = false;
         live().setFritzPresentation(IDLE_FRITZ_PRESENTATION);
+        // Tenure end / cancel must not leave a score toast on your-move.
+        live().ports.clearBoardToast();
         if (isLocalRunCurrent(runToken)) {
           finishLocalRun(runToken);
         }

--- a/client/src/modules/daily/useDailyFritzSessionPersistence.ts
+++ b/client/src/modules/daily/useDailyFritzSessionPersistence.ts
@@ -11,6 +11,8 @@ import {
 } from './dailyFritzSessionStorage.ts';
 import { buildDailyFritzTranscript } from '../../dailyFritz/dailyFritzTranscript.ts';
 import { getFritzPolicyContract, isSupportedFritzPolicyVersion } from '@racehorse/game-core';
+import { recordDailyFritzTelemetry } from '../../dailyFritz/api.ts';
+import { dailyFritzTelemetryEventId, getDailyFritzTelemetrySession } from '../../dailyFritz/telemetry.ts';
 
 type UseDailyFritzSessionPersistenceArgs = {
   enabled: boolean;
@@ -55,6 +57,25 @@ export function useDailyFritzSessionPersistence({
   const storagePendingRef = useRef<{ key: string; payload: object } | null>(null);
   const startedAtRef = useRef(initialStartedAt ?? new Date().toISOString());
   const revisionRef = useRef(initialRevision);
+  const firstMoveReportedRef = useRef(false);
+
+  useEffect(() => {
+    if (!enabled || !attemptId || !runDate || firstMoveReportedRef.current) return;
+    const firstPlayerMove = moveLog.find((entry) => entry.player === 'you');
+    if (!firstPlayerMove) return;
+    firstMoveReportedRef.current = true;
+    const sessionId = getDailyFritzTelemetrySession(runDate);
+    void recordDailyFritzTelemetry({
+      eventId: dailyFritzTelemetryEventId(attemptId, 'first_move'),
+      eventType: 'first_move',
+      attemptId,
+      runDate,
+      challengeId: createDailyFritzChallengeIdentity(runDate).challengeId,
+      sessionId,
+      durationMs: Math.max(0, Date.now() - new Date(startedAtRef.current).getTime()),
+      payload: { gameNumber, handIndex: dailyFritzHandIndex },
+    });
+  }, [attemptId, dailyFritzHandIndex, enabled, gameNumber, moveLog, runDate]);
 
   useEffect(() => {
     if (!enabled || !storageKey || !attemptId || !runDate || !runFingerprint || typeof window === 'undefined') return;

--- a/client/src/modules/match/hooks/useMatchPresentation.ts
+++ b/client/src/modules/match/hooks/useMatchPresentation.ts
@@ -150,19 +150,16 @@ export function useMatchPresentation({
       turnTotal: options?.turnTotal,
     });
 
-    // Sticky toasts stay until the next ceremony update (chain continuity).
-    if (options?.sticky) {
-      scoreToastHideTimerRef.current = null;
-      scoreToastClearTimerRef.current = null;
-      return;
-    }
-
-    const holdMs = options?.holdMs ?? BOT_SCORE_TOAST_HIDE_MS;
+    // Always time-dismiss. "Sticky" only lengthens the hold for chain ceremony —
+    // never leave a toast without an expiry (bot-tenure cancel can skip clearBoardToast).
+    const holdMs = options?.sticky
+      ? (options?.holdMs ?? Math.max(BOT_SCORE_HOLD_MS * 2, 2100))
+      : (options?.holdMs ?? BOT_SCORE_TOAST_HIDE_MS);
     const clearMs = Math.max(holdMs + 300, BOT_SCORE_TOAST_CLEAR_MS);
-    scoreToastHideTimerRef.current = setTimeout(() => {
+    scoreToastHideTimerRef.current = window.setTimeout(() => {
       setScoreToast((prev) => hideScoreToastEvent(prev, eventId));
     }, holdMs);
-    scoreToastClearTimerRef.current = setTimeout(() => {
+    scoreToastClearTimerRef.current = window.setTimeout(() => {
       setScoreToast((prev) => clearScoreToastEvent(prev, eventId));
     }, clearMs);
   }, [scoreToastHideTimerRef, scoreToastClearTimerRef]);

--- a/server/.env.example
+++ b/server/.env.example
@@ -4,3 +4,5 @@ ENABLE_QA_TOURNAMENT_SEED=0
 QA_TOURNAMENT_USER_ID=
 QA_ALLOW_NONLOCAL_STAGING=0
 SENTRY_DSN=your_sentry_dsn
+# Enable only after all four 2026-08-01 Daily Fritz migrations are applied.
+DAILY_FRITZ_TRANSACTIONAL_COMMANDS=false

--- a/server/package.json
+++ b/server/package.json
@@ -10,6 +10,8 @@
     "build": "tsc -p tsconfig.json",
     "start": "node dist/index.js",
     "test": "vitest run",
+    "soak:daily-fritz-authority": "tsx scripts/dailyFritzAuthoritySoak.ts",
+    "typecheck:scripts": "tsc -p tsconfig.scripts.json",
     "check:daily-ladder": "node dist/checkDailyPuzzleLadder.js",
     "seed:daily-ladder": "node dist/seedDailyPuzzleLadder.js",
     "gen:puzzles": "bash ../scripts/gen-puzzles.sh",

--- a/server/scripts/dailyFritzAuthoritySoak.ts
+++ b/server/scripts/dailyFritzAuthoritySoak.ts
@@ -1,0 +1,329 @@
+import { randomUUID } from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import '../src/loadEnv';
+import {
+  DAILY_FRITZ_AUTHORITY_STATE_DIGEST_VERSION,
+  DAILY_FRITZ_TRANSCRIPT_PROTOCOL_VERSION,
+  FRITZ_POLICY_VERSION,
+  GAME_RULES_VERSION,
+  getFritzPolicyContract,
+  type DailyFritzTranscript,
+} from '@racehorse/game-core';
+import type { DailyFritzDrawWinner, DailyFritzHandDeal, DailyFritzTier } from '../src/dailyFritz';
+import { buildHonestDailyFritzHandTranscript } from '../src/testing/dailyFritzTranscriptDriver';
+
+function applyEnvFile(filePath: string): void {
+  if (!fs.existsSync(filePath)) return;
+  for (const line of fs.readFileSync(filePath, 'utf8').split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const separator = trimmed.indexOf('=');
+    if (separator <= 0) continue;
+    const key = trimmed.slice(0, separator).trim();
+    if (!key || process.env[key] != null) continue;
+    let value = trimmed.slice(separator + 1).trim();
+    if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+      value = value.slice(1, -1);
+    }
+    process.env[key] = value;
+  }
+}
+
+applyEnvFile(path.resolve(process.cwd(), '../client/.env'));
+
+type Json = Record<string, unknown>;
+type StartPackage = Json & {
+  attempt_id: string;
+  verified_match_id: string;
+  run_date: string;
+  challenge_id: string;
+  authority_revision: number;
+  current_hand_index: number;
+  current_game_number: 1 | 2 | 3;
+  current_game_scores: { you: number; fritz: number };
+  fritz_tier: DailyFritzTier;
+  fritz_policy_version: 1 | 2;
+  deal_size: 7 | 14;
+  winning_score: number;
+  first_hand: DailyFritzHandDeal;
+  draw_winner: DailyFritzDrawWinner;
+};
+type HandPackage = Json & {
+  current_hand_index: number;
+  authority_revision: number;
+  current_game_scores: { you: number; fritz: number };
+  hand: DailyFritzHandDeal;
+  replayed?: boolean;
+};
+
+const baseUrl = (process.env.DAILY_FRITZ_SOAK_BASE_URL ?? 'http://127.0.0.1:3001').replace(/\/$/, '');
+const supabaseUrl = required('SUPABASE_URL').replace(/\/$/, '');
+const serviceKey = required('SUPABASE_SERVICE_KEY');
+const anonKey = required('VITE_SUPABASE_ANON_KEY');
+const users = positiveInt(process.env.DAILY_FRITZ_SOAK_USERS, 1);
+const concurrency = positiveInt(process.env.DAILY_FRITZ_SOAK_CONCURRENCY, 1);
+const timeoutMs = positiveInt(process.env.DAILY_FRITZ_SOAK_TIMEOUT_MS, 20_000);
+
+function required(name: string): string {
+  const value = process.env[name]?.trim();
+  if (!value) throw new Error(`${name} is required.`);
+  return value;
+}
+
+function positiveInt(value: string | undefined, fallback: number): number {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+async function fetchJson<T>(url: string, init: RequestInit, expected = [200]): Promise<T> {
+  const response = await fetch(url, { ...init, signal: AbortSignal.timeout(timeoutMs) });
+  const body = await response.json().catch(() => ({})) as Json;
+  if (!expected.includes(response.status)) {
+    throw new Error(`${init.method ?? 'GET'} ${url} returned ${response.status}: ${JSON.stringify(body)}`);
+  }
+  return body as T;
+}
+
+async function createUser(): Promise<{ id: string; accessToken: string }> {
+  const id = randomUUID();
+  const email = `df-soak-${id}@racehorse-test.invalid`;
+  const password = `Df-${randomUUID()}-Aa9!`;
+  const created = await fetchJson<Json>(`${supabaseUrl}/auth/v1/admin/users`, {
+    method: 'POST',
+    headers: { apikey: serviceKey, authorization: `Bearer ${serviceKey}`, 'content-type': 'application/json' },
+    body: JSON.stringify({ email, password, email_confirm: true }),
+  });
+  const userId = String(created.id ?? '');
+  if (!userId) throw new Error('Supabase did not return an ephemeral user ID.');
+  const signedIn = await fetchJson<Json>(`${supabaseUrl}/auth/v1/token?grant_type=password`, {
+    method: 'POST',
+    headers: { apikey: anonKey, 'content-type': 'application/json' },
+    body: JSON.stringify({ email, password }),
+  });
+  const accessToken = String(signedIn.access_token ?? '');
+  if (!accessToken) throw new Error('Supabase did not return an ephemeral access token.');
+  return { id: userId, accessToken };
+}
+
+async function deleteUser(id: string): Promise<void> {
+  const response = await fetch(`${supabaseUrl}/auth/v1/admin/users/${encodeURIComponent(id)}`, {
+    method: 'DELETE',
+    headers: { apikey: serviceKey, authorization: `Bearer ${serviceKey}` },
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+  if (!response.ok && response.status !== 404) {
+    throw new Error(`Failed to remove ephemeral soak user ${id}: ${response.status}`);
+  }
+}
+
+function api(token: string, pathName: string, body?: Json): Promise<Json> {
+  return fetchJson<Json>(`${baseUrl}${pathName}`, {
+    method: body ? 'POST' : 'GET',
+    headers: {
+      authorization: `Bearer ${token}`,
+      ...(body ? { 'content-type': 'application/json' } : {}),
+    },
+    ...(body ? { body: JSON.stringify(body) } : {}),
+  });
+}
+
+function apiExpect(token: string, pathName: string, body: Json, expected: number[]): Promise<Json> {
+  return fetchJson<Json>(`${baseUrl}${pathName}`, {
+    method: 'POST',
+    headers: { authorization: `Bearer ${token}`, 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  }, expected);
+}
+
+const startBody = {
+  verification_protocol_version: DAILY_FRITZ_TRANSCRIPT_PROTOCOL_VERSION,
+  game_rules_version: GAME_RULES_VERSION,
+  fritz_policy_version: FRITZ_POLICY_VERSION,
+  fritz_policy_contract: getFritzPolicyContract(FRITZ_POLICY_VERSION),
+  state_digest_version: DAILY_FRITZ_AUTHORITY_STATE_DIGEST_VERSION,
+  supported_transcript_protocol_versions: [DAILY_FRITZ_TRANSCRIPT_PROTOCOL_VERSION],
+  supported_fritz_policies: [{
+    version: FRITZ_POLICY_VERSION,
+    contract: getFritzPolicyContract(FRITZ_POLICY_VERSION),
+  }],
+  supported_state_digest_versions: [DAILY_FRITZ_AUTHORITY_STATE_DIGEST_VERSION],
+  client_release: 'daily-fritz-authority-soak',
+};
+
+function handCommand(pkg: StartPackage, handIndex: number, transcript: DailyFritzTranscript): Json {
+  return {
+    attempt_id: pkg.attempt_id,
+    verified_match_id: pkg.verified_match_id,
+    run_date: pkg.run_date,
+    game_number: 1,
+    completed_hand_index: handIndex,
+    transcript,
+  };
+}
+
+async function assertAuthorityRows(attemptId: string, expectedHands: number): Promise<void> {
+  const headers = { apikey: serviceKey, authorization: `Bearer ${serviceKey}` };
+  const [hands, games, operations, outbox, events] = await Promise.all([
+    fetchJson<Json[]>(`${supabaseUrl}/rest/v1/daily_fritz_verified_hands?select=hand_index&attempt_id=eq.${attemptId}`, { headers }),
+    fetchJson<Json[]>(`${supabaseUrl}/rest/v1/daily_fritz_verified_games?select=game_number&attempt_id=eq.${attemptId}`, { headers }),
+    fetchJson<Json[]>(`${supabaseUrl}/rest/v1/daily_fritz_attempt_operations?select=operation_id,status&attempt_id=eq.${attemptId}`, { headers }),
+    fetchJson<Json[]>(`${supabaseUrl}/rest/v1/daily_fritz_outbox?select=event_type,analytics_projected_at&attempt_id=eq.${attemptId}`, { headers }),
+    fetchJson<Json[]>(`${supabaseUrl}/rest/v1/daily_fritz_events?select=event_type,source,idempotency_key&attempt_id=eq.${attemptId}&source=eq.outbox`, { headers }),
+  ]);
+  if (hands.length !== expectedHands) throw new Error(`Expected ${expectedHands} verified hands, found ${hands.length}.`);
+  if (games.length !== 1) throw new Error(`Expected one verified game, found ${games.length}.`);
+  if (new Set(operations.map((row) => row.operation_id)).size !== operations.length) {
+    throw new Error('Duplicate durable operation receipts detected.');
+  }
+  if (!outbox.some((row) => row.event_type === 'game_recorded')) {
+    throw new Error('Game authority committed without its transactional outbox event.');
+  }
+  if (outbox.some((row) => !row.analytics_projected_at)) {
+    throw new Error('Committed authority outbox event was not projected into canonical analytics.');
+  }
+  const gameEvents = events.filter((row) => row.event_type === 'game_recorded');
+  if (gameEvents.length !== 1 || gameEvents[0]?.source !== 'outbox') {
+    throw new Error(`Expected exactly one canonical outbox game event, found ${gameEvents.length}.`);
+  }
+  if (new Set(events.map((row) => row.idempotency_key)).size !== events.length) {
+    throw new Error('Duplicate canonical analytics identities detected.');
+  }
+}
+
+async function runOne(index: number): Promise<Json> {
+  const startedAt = Date.now();
+  const user = await createUser();
+  try {
+    const starts = await Promise.all([
+      api(user.accessToken, '/api/daily-fritz/start', startBody),
+      api(user.accessToken, '/api/daily-fritz/start', startBody),
+    ]) as StartPackage[];
+    const pkg = starts[0];
+    if (starts.some((value) => value.attempt_id !== pkg.attempt_id || value.challenge_id !== pkg.challenge_id)) {
+      throw new Error('Concurrent starts did not resolve to one attempt and challenge.');
+    }
+
+    let handIndex = pkg.current_hand_index;
+    let hand = pkg.first_hand;
+    let scores = pkg.current_game_scores;
+    let handCount = 0;
+    let lastTranscript: DailyFritzTranscript | null = null;
+
+    while (handCount < 64) {
+      const driven = buildHonestDailyFritzHandTranscript({
+        challengeId: pkg.challenge_id,
+        attemptId: pkg.attempt_id,
+        gameNumber: 1,
+        handIndex,
+        deal: hand,
+        drawWinner: pkg.draw_winner,
+        winningScore: pkg.winning_score,
+        dealSize: pkg.deal_size,
+        playerScore: scores.you,
+        fritzScore: scores.fritz,
+        fritzTier: pkg.fritz_tier,
+        fritzPolicyVersion: pkg.fritz_policy_version,
+      });
+      lastTranscript = driven.transcript;
+      handCount += 1;
+      if (driven.terminalState.gameOver) break;
+
+      const command = handCommand(pkg, handIndex, driven.transcript);
+      let next: HandPackage;
+      if (handCount === 1) {
+        const duplicates = await Promise.all([
+          api(user.accessToken, '/api/daily-fritz/next-hand', command),
+          api(user.accessToken, '/api/daily-fritz/next-hand', command),
+        ]) as HandPackage[];
+        if (!duplicates.some((value) => value.replayed === true)) {
+          throw new Error('Concurrent duplicate hand command did not replay the durable result.');
+        }
+        next = duplicates[0].current_hand_index >= duplicates[1].current_hand_index
+          ? duplicates[0] : duplicates[1];
+        const alternate = buildHonestDailyFritzHandTranscript({
+          challengeId: pkg.challenge_id,
+          attemptId: pkg.attempt_id,
+          gameNumber: 1,
+          handIndex,
+          deal: hand,
+          drawWinner: pkg.draw_winner,
+          winningScore: pkg.winning_score,
+          dealSize: pkg.deal_size,
+          playerScore: scores.you,
+          fritzScore: scores.fritz,
+          fritzTier: pkg.fritz_tier,
+          fritzPolicyVersion: pkg.fritz_policy_version,
+          playerPolicy: 'last_legal',
+        });
+        if (JSON.stringify(alternate.transcript.actions) !== JSON.stringify(driven.transcript.actions)) {
+          const conflict = await apiExpect(
+            user.accessToken,
+            '/api/daily-fritz/next-hand',
+            handCommand(pkg, handIndex, alternate.transcript),
+            [409],
+          );
+          if (conflict.code !== 'verified_hand_conflict'
+            || conflict.recoverable !== true
+            || conflict.recovery_action !== 'reload_official_hand') {
+            throw new Error(`Cross-device conflict was not recoverable: ${JSON.stringify(conflict)}`);
+          }
+        }
+      } else if (handCount === 2) {
+        await api(user.accessToken, '/api/daily-fritz/next-hand', command); // Simulated lost response.
+        next = await api(user.accessToken, '/api/daily-fritz/next-hand', command) as HandPackage;
+        if (next.replayed !== true) throw new Error('Lost-response retry was not replayed idempotently.');
+      } else {
+        next = await api(user.accessToken, '/api/daily-fritz/next-hand', command) as HandPackage;
+      }
+      handIndex = next.current_hand_index;
+      hand = next.hand;
+      scores = next.current_game_scores;
+
+      if (handCount === 2) {
+        const today = await api(user.accessToken, '/api/daily-fritz/today');
+        const resumed = await api(user.accessToken, '/api/daily-fritz/start', startBody) as StartPackage;
+        if (today.attempt_status !== 'started' || resumed.current_hand_index !== handIndex) {
+          throw new Error('Refresh/reconnect did not return the authoritative hand index.');
+        }
+        hand = resumed.first_hand;
+        scores = resumed.current_game_scores;
+      }
+    }
+    if (!lastTranscript) throw new Error('Game one produced no terminal transcript.');
+
+    const recordBody = {
+      attempt_id: pkg.attempt_id,
+      verified_match_id: pkg.verified_match_id,
+      run_date: pkg.run_date,
+      game_number: 1,
+      transcript: lastTranscript,
+    };
+    const gameResults = await Promise.all([
+      api(user.accessToken, '/api/daily-fritz/record-game', recordBody),
+      api(user.accessToken, '/api/daily-fritz/record-game', recordBody),
+    ]);
+    if (gameResults.some((value) => !value.set_result)) {
+      throw new Error('Game-one verification did not return a set result.');
+    }
+    await assertAuthorityRows(pkg.attempt_id, handCount);
+    return { index, attemptId: pkg.attempt_id, handCount, elapsedMs: Date.now() - startedAt };
+  } finally {
+    await deleteUser(user.id);
+  }
+}
+
+async function main(): Promise<void> {
+  const results: Json[] = [];
+  for (let offset = 0; offset < users; offset += concurrency) {
+    const wave = Array.from({ length: Math.min(concurrency, users - offset) }, (_, waveIndex) =>
+      runOne(offset + waveIndex));
+    results.push(...await Promise.all(wave));
+  }
+  process.stdout.write(`${JSON.stringify({ ok: true, users, concurrency, baseUrl, results }, null, 2)}\n`);
+}
+
+void main().catch((error) => {
+  process.stderr.write(`${error instanceof Error ? error.stack : String(error)}\n`);
+  process.exitCode = 1;
+});

--- a/server/src/dailyFritzAuthorityFeature.test.ts
+++ b/server/src/dailyFritzAuthorityFeature.test.ts
@@ -1,0 +1,19 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { isDailyFritzTransactionalAuthorityEnabled } from './dailyFritzAuthorityFeature';
+
+describe('Daily Fritz transactional authority rollout gate', () => {
+  const original = process.env.DAILY_FRITZ_TRANSACTIONAL_COMMANDS;
+  afterEach(() => {
+    if (original === undefined) delete process.env.DAILY_FRITZ_TRANSACTIONAL_COMMANDS;
+    else process.env.DAILY_FRITZ_TRANSACTIONAL_COMMANDS = original;
+  });
+
+  it('fails safe until explicitly enabled', () => {
+    delete process.env.DAILY_FRITZ_TRANSACTIONAL_COMMANDS;
+    expect(isDailyFritzTransactionalAuthorityEnabled()).toBe(false);
+    process.env.DAILY_FRITZ_TRANSACTIONAL_COMMANDS = 'true';
+    expect(isDailyFritzTransactionalAuthorityEnabled()).toBe(true);
+    process.env.DAILY_FRITZ_TRANSACTIONAL_COMMANDS = '1';
+    expect(isDailyFritzTransactionalAuthorityEnabled()).toBe(false);
+  });
+});

--- a/server/src/dailyFritzAuthorityFeature.ts
+++ b/server/src/dailyFritzAuthorityFeature.ts
@@ -1,0 +1,7 @@
+/**
+ * Expand-first rollout gate. Keep false until all 2026-08-01 Daily Fritz
+ * migrations are applied; then enable on every server instance together.
+ */
+export function isDailyFritzTransactionalAuthorityEnabled(): boolean {
+  return process.env.DAILY_FRITZ_TRANSACTIONAL_COMMANDS === 'true';
+}

--- a/server/src/dailyFritzPublishedChallenge.test.ts
+++ b/server/src/dailyFritzPublishedChallenge.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import {
+  assertValidDailyFritzPublishedChallenge,
+  buildDailyFritzPublishedChallenge,
+  canonicalizeDailyFritzChallenge,
+} from './dailyFritzPublishedChallenge';
+
+describe('immutable Daily Fritz challenge contract', () => {
+  it('publishes byte-stable authority for all three games', () => {
+    const first = buildDailyFritzPublishedChallenge({
+      runDate: '2026-08-01',
+      publishedAt: '2026-08-01T07:00:00.000Z',
+    });
+    const second = buildDailyFritzPublishedChallenge({
+      runDate: '2026-08-01',
+      publishedAt: '2026-08-01T08:00:00.000Z',
+    });
+
+    expect(first.contentDigest).toBe(second.contentDigest);
+    expect(first.games.map((game) => game.contentDigest))
+      .toEqual(second.games.map((game) => game.contentDigest));
+    expect(first.games.map((game) => game.hands.length)).toEqual([12, 12, 12]);
+    expect(first.games.map((game) => game.gameNumber)).toEqual([1, 2, 3]);
+    expect(() => assertValidDailyFritzPublishedChallenge(first)).not.toThrow();
+  });
+
+  it('changes the package digest for a different calendar day', () => {
+    const first = buildDailyFritzPublishedChallenge({ runDate: '2026-08-01' });
+    const second = buildDailyFritzPublishedChallenge({ runDate: '2026-08-02' });
+    expect(first.contentDigest).not.toBe(second.contentDigest);
+  });
+
+  it('canonicalizes object keys before hashing or persistence comparison', () => {
+    expect(canonicalizeDailyFritzChallenge({ z: 1, nested: { b: 2, a: 1 } }))
+      .toBe(canonicalizeDailyFritzChallenge({ nested: { a: 1, b: 2 }, z: 1 }));
+  });
+
+  it('rejects altered hand authority even when the outer digest is unchanged', () => {
+    const challenge = buildDailyFritzPublishedChallenge({ runDate: '2026-08-01' });
+    const corrupted = structuredClone(challenge);
+    corrupted.games[1].hands[0].player_tiles[0] = { low: 6, high: 6 };
+    expect(() => assertValidDailyFritzPublishedChallenge(corrupted))
+      .toThrow(/duplicate tiles|digest is invalid/);
+  });
+
+  it('rejects inconsistent draw authority', () => {
+    const challenge = buildDailyFritzPublishedChallenge({ runDate: '2026-08-01' });
+    const corrupted = structuredClone(challenge);
+    corrupted.games[0].drawWinner = corrupted.games[0].drawWinner === 'you' ? 'bot' : 'you';
+    expect(() => assertValidDailyFritzPublishedChallenge(corrupted))
+      .toThrow('Daily Fritz game 1 draw package is inconsistent.');
+  });
+});

--- a/server/src/dailyFritzPublishedChallenge.ts
+++ b/server/src/dailyFritzPublishedChallenge.ts
@@ -1,0 +1,277 @@
+import { createHash } from 'crypto';
+import {
+  DAILY_FRITZ_TRANSCRIPT_PROTOCOL_VERSION,
+  DAILY_FRITZ_VERIFIER_VERSION,
+  FRITZ_POLICY_VERSION,
+  GAME_RULES_VERSION,
+  getFritzPolicyContract,
+} from '@racehorse/game-core';
+import {
+  dailyFritzDrawTilesMatchWinner,
+  generateSingleDailyFritzGameHand,
+  getDailyFritzDrawTiles,
+  getDailyFritzDrawWinner,
+  getDailyFritzGameSeed,
+  getDailyFritzSeed,
+  type DailyFritzDrawTiles,
+  type DailyFritzDrawWinner,
+  type DailyFritzHandDeal,
+  type DailyFritzRunStatus,
+  type DailyFritzSetGameNumber,
+  type DailyFritzTier,
+} from './dailyFritz';
+import {
+  buildDailyFritzChallengeId,
+  DAILY_FRITZ_RULES_VERSION,
+  DAILY_FRITZ_SEED_VERSION,
+  DAILY_FRITZ_TIME_ZONE,
+} from './dailyFritzIdentity';
+
+export const DAILY_FRITZ_CHALLENGE_CONTRACT_VERSION = 1 as const;
+export const DAILY_FRITZ_GENERATION_VERSION = 1 as const;
+export const DAILY_FRITZ_RANKING_VERSION = 1 as const;
+export const DAILY_FRITZ_PUBLISHED_HAND_SLOTS = 12 as const;
+export const DAILY_FRITZ_HAND_GENERATION_CONTRACT =
+  'double-six-v1:{gameSeed}:hand:{handIndex}' as const;
+
+export type DailyFritzPublishedGame = {
+  gameNumber: DailyFritzSetGameNumber;
+  seed: string;
+  drawWinner: DailyFritzDrawWinner;
+  drawTiles: DailyFritzDrawTiles;
+  handGenerationContract: typeof DAILY_FRITZ_HAND_GENERATION_CONTRACT;
+  hands: DailyFritzHandDeal[];
+  contentDigest: string;
+};
+
+export type DailyFritzPublishedChallengeContent = {
+  contractVersion: typeof DAILY_FRITZ_CHALLENGE_CONTRACT_VERSION;
+  challengeId: string;
+  runDate: string;
+  timeZone: typeof DAILY_FRITZ_TIME_ZONE;
+  generationVersion: typeof DAILY_FRITZ_GENERATION_VERSION;
+  seedVersion: typeof DAILY_FRITZ_SEED_VERSION;
+  productRulesVersion: typeof DAILY_FRITZ_RULES_VERSION;
+  gameRulesVersion: typeof GAME_RULES_VERSION;
+  transcriptProtocolVersion: typeof DAILY_FRITZ_TRANSCRIPT_PROTOCOL_VERSION;
+  verifierVersion: typeof DAILY_FRITZ_VERIFIER_VERSION;
+  fritzPolicyVersion: typeof FRITZ_POLICY_VERSION;
+  fritzPolicyContract: string;
+  rankingVersion: typeof DAILY_FRITZ_RANKING_VERSION;
+  seed: string;
+  fritzTier: DailyFritzTier;
+  dealSize: 7 | 14;
+  winningScore: number;
+  games: [DailyFritzPublishedGame, DailyFritzPublishedGame, DailyFritzPublishedGame];
+};
+
+export type DailyFritzPublishedChallenge = DailyFritzPublishedChallengeContent & {
+  status: DailyFritzRunStatus;
+  contentDigest: string;
+  publishedAt: string;
+  invalidatedAt: string | null;
+  invalidationReason: string | null;
+};
+
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalize);
+  if (!value || typeof value !== 'object') return value;
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, nested]) => [key, canonicalize(nested)]),
+  );
+}
+
+export function canonicalizeDailyFritzChallenge(value: unknown): string {
+  return JSON.stringify(canonicalize(value));
+}
+
+export function digestDailyFritzChallengeContent(value: unknown): string {
+  return createHash('sha256')
+    .update(canonicalizeDailyFritzChallenge(value))
+    .digest('hex');
+}
+
+function tileKey(value: { low: number; high: number }): string {
+  return `${Math.min(value.low, value.high)}|${Math.max(value.low, value.high)}`;
+}
+
+function assertValidTile(value: unknown, path: string): asserts value is { low: number; high: number } {
+  if (!value || typeof value !== 'object') throw new Error(`${path} is not a tile.`);
+  const tile = value as Record<string, unknown>;
+  if (
+    !Number.isInteger(tile.low)
+    || !Number.isInteger(tile.high)
+    || Number(tile.low) < 0
+    || Number(tile.high) < 0
+    || Number(tile.low) > 6
+    || Number(tile.high) > 6
+    || Number(tile.low) > Number(tile.high)
+  ) {
+    throw new Error(`${path} is not a canonical double-six tile.`);
+  }
+}
+
+function assertValidHand(deal: DailyFritzHandDeal, dealSize: 7 | 14, path: string): void {
+  if (deal.player_tiles.length !== dealSize || deal.fritz_tiles.length !== dealSize) {
+    throw new Error(`${path} has the wrong deal size.`);
+  }
+  const deckTiles = [
+    ...deal.player_tiles,
+    ...deal.fritz_tiles,
+    ...deal.boneyard,
+  ];
+  if (deckTiles.length !== 28) throw new Error(`${path} does not conserve the double-six deck.`);
+  deckTiles.forEach((tile, index) => assertValidTile(tile, `${path}.tiles[${index}]`));
+  const keys = deckTiles.map(tileKey);
+  if (new Set(keys).size !== 28) throw new Error(`${path} contains duplicate tiles.`);
+  deal.locked.forEach((tile, index) => {
+    assertValidTile(tile, `${path}.locked[${index}]`);
+    if (!deal.boneyard.some((candidate) => tileKey(candidate) === tileKey(tile))) {
+      throw new Error(`${path} has a locked tile outside the boneyard.`);
+    }
+  });
+}
+
+export function getDailyFritzPublishedChallengeContent(
+  challenge: DailyFritzPublishedChallenge,
+): DailyFritzPublishedChallengeContent {
+  const {
+    status: _status,
+    contentDigest: _contentDigest,
+    publishedAt: _publishedAt,
+    invalidatedAt: _invalidatedAt,
+    invalidationReason: _invalidationReason,
+    ...content
+  } = challenge;
+  return content;
+}
+
+export function assertValidDailyFritzPublishedChallenge(
+  challenge: DailyFritzPublishedChallenge,
+): void {
+  if (challenge.contractVersion !== DAILY_FRITZ_CHALLENGE_CONTRACT_VERSION) {
+    throw new Error('Unsupported Daily Fritz challenge contract version.');
+  }
+  if (challenge.challengeId !== buildDailyFritzChallengeId(challenge.runDate)) {
+    throw new Error('Daily Fritz challenge identity does not match its date and versions.');
+  }
+  if (challenge.seed !== getDailyFritzSeed(challenge.runDate)) {
+    throw new Error('Daily Fritz challenge seed does not match its date.');
+  }
+  if (
+    challenge.timeZone !== DAILY_FRITZ_TIME_ZONE
+    || challenge.generationVersion !== DAILY_FRITZ_GENERATION_VERSION
+    || challenge.seedVersion !== DAILY_FRITZ_SEED_VERSION
+    || challenge.productRulesVersion !== DAILY_FRITZ_RULES_VERSION
+    || challenge.gameRulesVersion !== GAME_RULES_VERSION
+    || challenge.transcriptProtocolVersion !== DAILY_FRITZ_TRANSCRIPT_PROTOCOL_VERSION
+    || challenge.verifierVersion !== DAILY_FRITZ_VERIFIER_VERSION
+    || challenge.fritzPolicyVersion !== FRITZ_POLICY_VERSION
+    || challenge.fritzPolicyContract !== getFritzPolicyContract(FRITZ_POLICY_VERSION)
+    || challenge.rankingVersion !== DAILY_FRITZ_RANKING_VERSION
+  ) {
+    throw new Error('Daily Fritz challenge versions are incompatible with this publisher.');
+  }
+  if (challenge.games.length !== 3) throw new Error('Daily Fritz requires exactly three games.');
+  for (const [index, game] of challenge.games.entries()) {
+    const gameNumber = (index + 1) as DailyFritzSetGameNumber;
+    if (game.gameNumber !== gameNumber || game.seed !== getDailyFritzGameSeed(challenge.runDate, gameNumber)) {
+      throw new Error(`Daily Fritz game ${gameNumber} identity is invalid.`);
+    }
+    if (game.handGenerationContract !== DAILY_FRITZ_HAND_GENERATION_CONTRACT) {
+      throw new Error(`Daily Fritz game ${gameNumber} generation contract is invalid.`);
+    }
+    if (!dailyFritzDrawTilesMatchWinner(game.drawTiles, game.drawWinner)) {
+      throw new Error(`Daily Fritz game ${gameNumber} draw package is inconsistent.`);
+    }
+    if (game.hands.length !== DAILY_FRITZ_PUBLISHED_HAND_SLOTS) {
+      throw new Error(`Daily Fritz game ${gameNumber} is missing published hand slots.`);
+    }
+    game.hands.forEach((hand, handIndex) => {
+      assertValidHand(hand, challenge.dealSize, `games[${index}].hands[${handIndex}]`);
+    });
+    const { contentDigest, ...gameContent } = game;
+    if (digestDailyFritzChallengeContent(gameContent) !== contentDigest) {
+      throw new Error(`Daily Fritz game ${gameNumber} digest is invalid.`);
+    }
+  }
+  if (digestDailyFritzChallengeContent(getDailyFritzPublishedChallengeContent(challenge)) !== challenge.contentDigest) {
+    throw new Error('Daily Fritz challenge digest is invalid.');
+  }
+  if (challenge.status === 'invalidated' && !challenge.invalidatedAt) {
+    throw new Error('Invalidated Daily Fritz challenge is missing invalidation metadata.');
+  }
+}
+
+function buildPublishedGame(input: {
+  runDate: string;
+  gameNumber: DailyFritzSetGameNumber;
+  dealSize: 7 | 14;
+}): DailyFritzPublishedGame {
+  const gameContent = {
+    gameNumber: input.gameNumber,
+    seed: getDailyFritzGameSeed(input.runDate, input.gameNumber),
+    drawWinner: getDailyFritzDrawWinner(input.runDate, input.gameNumber),
+    drawTiles: getDailyFritzDrawTiles(input.runDate, input.gameNumber),
+    handGenerationContract: DAILY_FRITZ_HAND_GENERATION_CONTRACT,
+    hands: Array.from({ length: DAILY_FRITZ_PUBLISHED_HAND_SLOTS }, (_, handIndex) =>
+      generateSingleDailyFritzGameHand(
+        input.runDate,
+        input.gameNumber,
+        handIndex,
+        input.dealSize,
+      )),
+  };
+  return {
+    ...gameContent,
+    contentDigest: digestDailyFritzChallengeContent(gameContent),
+  };
+}
+
+export function buildDailyFritzPublishedChallenge(input: {
+  runDate: string;
+  fritzTier?: DailyFritzTier;
+  dealSize?: 7 | 14;
+  winningScore?: number;
+  publishedAt?: string;
+}): DailyFritzPublishedChallenge {
+  const dealSize = input.dealSize ?? 7;
+  const games = ([1, 2, 3] as const).map((gameNumber) =>
+    buildPublishedGame({ runDate: input.runDate, gameNumber, dealSize })) as [
+      DailyFritzPublishedGame,
+      DailyFritzPublishedGame,
+      DailyFritzPublishedGame,
+    ];
+  const content: DailyFritzPublishedChallengeContent = {
+    contractVersion: DAILY_FRITZ_CHALLENGE_CONTRACT_VERSION,
+    challengeId: buildDailyFritzChallengeId(input.runDate),
+    runDate: input.runDate,
+    timeZone: DAILY_FRITZ_TIME_ZONE,
+    generationVersion: DAILY_FRITZ_GENERATION_VERSION,
+    seedVersion: DAILY_FRITZ_SEED_VERSION,
+    productRulesVersion: DAILY_FRITZ_RULES_VERSION,
+    gameRulesVersion: GAME_RULES_VERSION,
+    transcriptProtocolVersion: DAILY_FRITZ_TRANSCRIPT_PROTOCOL_VERSION,
+    verifierVersion: DAILY_FRITZ_VERIFIER_VERSION,
+    fritzPolicyVersion: FRITZ_POLICY_VERSION,
+    fritzPolicyContract: getFritzPolicyContract(FRITZ_POLICY_VERSION),
+    rankingVersion: DAILY_FRITZ_RANKING_VERSION,
+    seed: getDailyFritzSeed(input.runDate),
+    fritzTier: input.fritzTier ?? 'elite',
+    dealSize,
+    winningScore: input.winningScore ?? 60,
+    games,
+  };
+  const challenge: DailyFritzPublishedChallenge = {
+    ...content,
+    status: 'live',
+    contentDigest: digestDailyFritzChallengeContent(content),
+    publishedAt: input.publishedAt ?? new Date().toISOString(),
+    invalidatedAt: null,
+    invalidationReason: null,
+  };
+  assertValidDailyFritzPublishedChallenge(challenge);
+  return challenge;
+}

--- a/server/src/dailyFritzTelemetry.test.ts
+++ b/server/src/dailyFritzTelemetry.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DAILY_FRITZ_EVENT_TYPES,
+  classifyDailyFritzFailure,
+  isDailyFritzEventType,
+} from './dailyFritzTelemetry';
+
+describe('Daily Fritz telemetry contract', () => {
+  it('uses a unique canonical lifecycle taxonomy', () => {
+    expect(new Set(DAILY_FRITZ_EVENT_TYPES).size).toBe(DAILY_FRITZ_EVENT_TYPES.length);
+    expect(isDailyFritzEventType('first_move')).toBe(true);
+    expect(isDailyFritzEventType('made_up_event')).toBe(false);
+  });
+
+  it.each([
+    ['stale_revision', 'command', 'authoritative_refresh'],
+    ['authority_contract_unsupported', 'challenge', 'client_update_required'],
+    ['operation_id_reused', 'verification', 'terminal_integrity_failure'],
+    ['database_unavailable', 'persistence', 'transparent_retry'],
+  ] as const)('classifies %s consistently', (code, phase, recoveryClass) => {
+    expect(classifyDailyFritzFailure(code)).toEqual({ phase, recoveryClass });
+  });
+});

--- a/server/src/dailyFritzTelemetry.ts
+++ b/server/src/dailyFritzTelemetry.ts
@@ -1,0 +1,98 @@
+export const DAILY_FRITZ_TELEMETRY_VERSION = 1 as const;
+
+export const DAILY_FRITZ_EVENT_TYPES = [
+  'mode_impression',
+  'start_requested',
+  'attempt_started',
+  'attempt_resumed',
+  'first_move',
+  'hand_started',
+  'hand_verified',
+  'next_hand_replayed',
+  'game_started',
+  'game_recorded',
+  'set_continued',
+  'attempt_completed',
+  'attempt_abandoned',
+  'verification_failed',
+  'command_conflict',
+  'recovery_started',
+  'recovery_succeeded',
+  'recovery_failed',
+  'request_failed',
+  'retry_request',
+  'review_opened',
+  'leaderboard_opened',
+  'share_requested',
+  'share_completed',
+] as const;
+
+export type DailyFritzEventType = typeof DAILY_FRITZ_EVENT_TYPES[number];
+
+export type DailyFritzFailurePhase =
+  | 'challenge'
+  | 'start'
+  | 'verification'
+  | 'command'
+  | 'persistence'
+  | 'recovery'
+  | 'submission'
+  | 'unknown';
+
+export type DailyFritzRecoveryClass =
+  | 'transparent_retry'
+  | 'authoritative_refresh'
+  | 'client_update_required'
+  | 'terminal_integrity_failure'
+  | 'not_applicable';
+
+const UPDATE_REQUIRED = new Set([
+  'authority_contract_unsupported',
+  'incompatible_version',
+  'unsupported_protocol',
+  'unsupported_policy',
+]);
+const AUTHORITATIVE_REFRESH = new Set([
+  'stale_revision',
+  'command_slot_conflict',
+  'fritz_state_mismatch',
+  'wrong_actor',
+  'state_digest_mismatch',
+  'attempt_not_active',
+]);
+const TERMINAL_INTEGRITY = new Set([
+  'challenge_mismatch',
+  'challenge_publication_mismatch',
+  'operation_id_reused',
+  'transcript_digest_mismatch',
+  'illegal_action',
+]);
+
+export function isDailyFritzEventType(value: unknown): value is DailyFritzEventType {
+  return typeof value === 'string'
+    && (DAILY_FRITZ_EVENT_TYPES as readonly string[]).includes(value);
+}
+
+export function classifyDailyFritzFailure(code: string | null | undefined): {
+  phase: DailyFritzFailurePhase;
+  recoveryClass: DailyFritzRecoveryClass;
+} {
+  const normalized = code?.trim().toLowerCase() || '';
+  if (!normalized) return { phase: 'unknown', recoveryClass: 'not_applicable' };
+  if (UPDATE_REQUIRED.has(normalized)) {
+    return { phase: 'challenge', recoveryClass: 'client_update_required' };
+  }
+  if (AUTHORITATIVE_REFRESH.has(normalized)) {
+    return { phase: normalized === 'stale_revision' ? 'command' : 'verification', recoveryClass: 'authoritative_refresh' };
+  }
+  if (TERMINAL_INTEGRITY.has(normalized)) {
+    return {
+      phase: normalized.startsWith('challenge_') ? 'challenge' : 'verification',
+      recoveryClass: 'terminal_integrity_failure',
+    };
+  }
+  if (/timeout|network|unavailable|rate_limit|persistence/.test(normalized)) {
+    return { phase: 'persistence', recoveryClass: 'transparent_retry' };
+  }
+  return { phase: 'unknown', recoveryClass: 'authoritative_refresh' };
+}

--- a/server/src/dbIdempotencySchema.test.ts
+++ b/server/src/dbIdempotencySchema.test.ts
@@ -68,4 +68,85 @@ describe('DB idempotency schema guardrails', () => {
 
     expect(sql).toContain('unique (tournament_id, round, match_number)');
   });
+
+  it('ships immutable, idempotent Daily Fritz challenge publication', () => {
+    const sql = compactSql(readRepoFile(
+      'supabase/migrations/2026-08-01_daily_fritz_published_challenges.sql',
+    ));
+    expect(sql).toContain('create table if not exists public.daily_fritz_published_challenges');
+    expect(sql).toContain('unique (run_date, contract_version)');
+    expect(sql).toContain('unique (content_digest)');
+    expect(sql).toContain('create trigger protect_daily_fritz_published_challenge');
+    expect(sql).toContain('daily_fritz_published_challenge_is_immutable');
+    expect(sql).toContain('daily_fritz_invalidated_challenge_is_final');
+    expect(sql).toContain('daily_fritz_published_challenge_delete_forbidden');
+    expect(sql).toContain('create or replace function public.publish_daily_fritz_challenge');
+    expect(sql).toContain('on conflict (challenge_id) do nothing');
+    expect(sql).toContain('daily_fritz_challenge_identity_conflict');
+    expect(sql).toContain('grant execute on function public.publish_daily_fritz_challenge');
+    expect(sql).toContain('create or replace function public.invalidate_daily_fritz_challenge');
+    expect(sql).toContain('v_invalidated_at timestamptz := now()');
+    expect(sql).toContain('grant execute on function public.invalidate_daily_fritz_challenge');
+  });
+
+  it('ships Daily Fritz CAS, durable receipts, normalized authority, and outbox primitives', () => {
+    const sql = compactSql(readRepoFile(
+      'supabase/migrations/2026-08-01_daily_fritz_command_primitives.sql',
+    ));
+    expect(sql).toContain('add column if not exists revision bigint not null default 0');
+    expect(sql).toContain('add column if not exists current_game_number int not null default 1');
+    expect(sql).toContain('foreign key (challenge_id) references public.daily_fritz_published_challenges(challenge_id)');
+    expect(sql).toContain('create table if not exists public.daily_fritz_attempt_operations');
+    expect(sql).toContain('unique (attempt_id, operation_id)');
+    expect(sql).toContain('unique (user_id, challenge_id, operation_id)');
+    expect(sql).toContain('create table if not exists public.daily_fritz_verified_hands');
+    expect(sql).toContain('primary key (attempt_id, game_number, hand_index)');
+    expect(sql).toContain('create table if not exists public.daily_fritz_verified_games');
+    expect(sql).toContain('primary key (attempt_id, game_number)');
+    expect(sql).toContain('create table if not exists public.daily_fritz_outbox');
+    expect(sql).toContain('where delivered_at is null');
+    expect(sql).toContain('daily_fritz_attempt_operations_no_client_access');
+  });
+
+  it('ships transactional Daily Fritz start and mutation commands', () => {
+    const sql = compactSql(readRepoFile(
+      'supabase/migrations/2026-08-01_daily_fritz_transactional_commands.sql',
+    ));
+    expect(sql).toContain('create or replace function public.start_daily_fritz_attempt_command');
+    expect(sql).toContain('pg_advisory_xact_lock');
+    expect(sql).toContain('for update');
+    expect(sql).toContain("'operation_id_reused'");
+    expect(sql).toContain('create or replace function public.commit_daily_fritz_attempt_command');
+    expect(sql).toContain("'stale_revision'");
+    expect(sql).toContain("'command_slot_conflict'");
+    expect(sql.indexOf('where id = p_attempt_id and user_id = p_user_id for update'))
+      .toBeLessThan(sql.indexOf('where attempt_id = p_attempt_id and operation_id = p_operation_id'));
+    expect(sql).toContain('revision = revision + 1');
+    expect(sql).toContain('insert into public.daily_fritz_verified_hands');
+    expect(sql).toContain('daily_fritz_terminal_hand_receipt_required');
+    expect(sql).toContain('insert into public.daily_fritz_verified_games');
+    expect(sql).toContain("jsonb_array_length(p_new_result->'games')");
+    expect(sql).toContain('update public.verified_single_player_matches');
+    expect(sql).toContain('insert into public.daily_fritz_attempt_operations');
+    expect(sql).toContain('insert into public.daily_fritz_outbox');
+    expect(sql).toContain('grant execute on function public.commit_daily_fritz_attempt_command');
+  });
+
+  it('ships canonical Daily Fritz funnel, failure taxonomy, and outbox projection', () => {
+    const sql = compactSql(readRepoFile(
+      'supabase/migrations/2026-08-01_daily_fritz_canonical_telemetry.sql',
+    ));
+    expect(sql).toContain("'mode_impression'");
+    expect(sql).toContain("'first_move'");
+    expect(sql).toContain("'recovery_succeeded'");
+    expect(sql).toContain('create or replace function public.project_daily_fritz_outbox_event');
+    expect(sql).toContain("'outbox:' || new.id::text");
+    expect(sql).toContain('create or replace view public.daily_fritz_funnel_metrics');
+    expect(sql).toContain('create or replace view public.daily_fritz_failure_metrics');
+    expect(sql).toContain('create or replace view public.daily_fritz_retention_metrics');
+    expect(sql).toContain('next_day_returned_users');
+    expect(sql).toContain('seven_day_returned_users');
+    expect(sql).toContain('analytics_projected_at');
+    expect(sql).toContain('idx_daily_fritz_events_user_retention');
+  });
 });

--- a/server/src/http/routes/dailyFritz.ts
+++ b/server/src/http/routes/dailyFritz.ts
@@ -82,6 +82,25 @@ import {
 import { startDailyFritzRequestDiagnostics } from './dailyFritzRequestDiagnostics';
 import { listDailyFritzEvents, listDailyFritzPersistedMetrics, recordDailyFritzEvent, type DailyFritzEventInput } from '../stores/dailyFritzEventStore';
 import { getDailyFritzMetricRates, getDailyFritzMetrics, incrementDailyFritzMetric } from './dailyFritzMetrics';
+import {
+  buildDailyFritzPublishedChallenge,
+  canonicalizeDailyFritzChallenge,
+} from '../../dailyFritzPublishedChallenge';
+import {
+  invalidateDailyFritzPublishedChallenge,
+  publishDailyFritzChallenge,
+} from '../stores/dailyFritzPublishedChallengeStore';
+import {
+  commitDailyFritzAttemptCommand,
+  startDailyFritzAttemptCommand,
+} from '../stores/dailyFritzCommandStore';
+import { isDailyFritzEventType } from '../../dailyFritzTelemetry';
+import { isDailyFritzTransactionalAuthorityEnabled } from '../../dailyFritzAuthorityFeature';
+import type { DailyFritzPublishedChallenge } from '../../dailyFritzPublishedChallenge';
+import {
+  loadDailyFritzPublishedAuthority,
+  resolveDailyFritzPublishedGameAuthority,
+} from './dailyFritzPublishedAuthority';
 
 export {
   buildRecordedDailyFritzAttemptResult,
@@ -108,6 +127,24 @@ async function recordDailyFritzEventBestEffort(event: DailyFritzEventInput): Pro
 
 type DailyFritzActiveGameProgress = { gameNumber: DailyFritzSetGameNumber; you: number; fritz: number };
 const DAILY_FRITZ_COMPETITIVE_VERIFICATION_AVAILABLE = true;
+const DAILY_FRITZ_TRANSACTIONAL_COMMANDS_ENABLED =
+  isDailyFritzTransactionalAuthorityEnabled();
+const isRecoverableDailyFritzCommandConflict = (code: string | null): boolean =>
+  code === 'stale_revision' || code === 'command_slot_conflict';
+
+function rejectModernAttemptWhenAuthorityDisabled(
+  attempt: DailyFritzAttemptRecord,
+  res: Response,
+): boolean {
+  if (!attempt.challengeId || DAILY_FRITZ_TRANSACTIONAL_COMMANDS_ENABLED) return false;
+  res.status(503).json({
+    error: 'Daily Fritz verified authority is temporarily unavailable. Your progress is safe.',
+    code: 'authority_temporarily_unavailable',
+    recoverable: true,
+    recovery_action: 'retry',
+  });
+  return true;
+}
 
 function writeVerifiedHand(
   result: Record<string, unknown> | null,
@@ -197,6 +234,7 @@ function verifyAttemptHand(input: {
   userId: string;
   gameNumber: DailyFritzSetGameNumber;
   handIndex: number;
+  publishedChallenge: DailyFritzPublishedChallenge | null;
 }) {
   const expectedSeed = getDailyFritzSeed(input.run.runDate);
   if (input.run.seed !== expectedSeed) {
@@ -207,29 +245,43 @@ function verifyAttemptHand(input: {
   }
   const progress = readActiveGameProgress(input.attempt.result, input.gameNumber);
   const authorityContract = readDailyFritzAuthorityContract(input.attempt.result);
-  const deal = getDailyFritzHandForGame(input.run, input.gameNumber, input.handIndex);
-  const drawWinner = resolveDailyFritzDrawWinner({
-    runDate: input.run.runDate,
-    gameNumber: input.gameNumber,
-    metadata: input.run.metadata,
-  });
+  const publishedAuthority = input.publishedChallenge
+    ? resolveDailyFritzPublishedGameAuthority({
+        challenge: input.publishedChallenge,
+        gameNumber: input.gameNumber,
+        handIndex: input.handIndex,
+      })
+    : null;
+  const deal = publishedAuthority?.deal
+    ?? getDailyFritzHandForGame(input.run, input.gameNumber, input.handIndex);
+  const drawWinner = publishedAuthority?.drawWinner
+    ?? resolveDailyFritzDrawWinner({
+      runDate: input.run.runDate,
+      gameNumber: input.gameNumber,
+      metadata: input.run.metadata,
+    });
+  const challengeId = input.publishedChallenge?.challengeId
+    ?? buildDailyFritzChallengeId(input.run.runDate);
+  const fritzTier = input.publishedChallenge?.fritzTier ?? input.run.fritzTier;
+  const winningScore = input.publishedChallenge?.winningScore ?? input.run.winningScore;
+  const dealSize = input.publishedChallenge?.dealSize ?? input.run.dealSize;
   return verifyDailyFritzHand({
     transcript: input.transcript,
     initialState: createOfficialDailyFritzHandState({
       deal,
       handIndex: input.handIndex,
       drawWinner,
-      winningScore: input.run.winningScore,
-      dealSize: input.run.dealSize,
+      winningScore,
+      dealSize,
       playerScore: progress.you,
       fritzScore: progress.fritz,
     }),
-    expectedChallengeId: buildDailyFritzChallengeId(input.run.runDate),
+    expectedChallengeId: challengeId,
     expectedAttemptId: input.attempt.id,
     expectedGameNumber: input.gameNumber,
     expectedHandIndex: input.handIndex,
     userId: input.userId,
-    fritzTier: input.run.fritzTier,
+    fritzTier,
     expectedFritzPolicyVersion: authorityContract?.fritzPolicyVersion,
     expectedFritzPolicyContract: authorityContract?.fritzPolicyContract,
     requireStateDigests: authorityContract?.stateDigestRequired === true,
@@ -428,6 +480,7 @@ export function registerDailyFritzRoutes(app: Application): void {
       deal_size: run.dealSize,
       winning_score: run.winningScore,
       attempt_status: attempt?.status ?? 'none',
+      authority_revision: attempt?.revision ?? null,
       verification_protocol_version:
         attemptAuthorityContract?.transcriptProtocolVersion
         ?? DAILY_FRITZ_VERIFICATION_PROTOCOL_VERSION,
@@ -535,11 +588,12 @@ export function registerDailyFritzRoutes(app: Application): void {
     }
 
     let attempt = await getDailyFritzAttempt(runDate, authenticatedUserId);
+    if (attempt && rejectModernAttemptWhenAuthorityDisabled(attempt, res)) return;
     if (attempt?.status === 'completed' || attempt?.status === 'abandoned') {
       res.status(409).json({ error: 'Today’s Daily Fritz attempt is already locked.', status: attempt.status });
       return;
     }
-    const existingAuthorityContract = readDailyFritzAuthorityContract(attempt?.result ?? null);
+    let existingAuthorityContract = readDailyFritzAuthorityContract(attempt?.result ?? null);
     const canResumePinnedContract = Boolean(
       attempt
       && existingAuthorityContract
@@ -570,6 +624,66 @@ export function registerDailyFritzRoutes(app: Application): void {
       });
       return;
     }
+    let createdTransactionally = false;
+    if (!attempt && DAILY_FRITZ_TRANSACTIONAL_COMMANDS_ENABLED) {
+      const policyVersion = isSupportedFritzPolicyVersion(requestedFritz)
+        ? requestedFritz
+        : FRITZ_POLICY_VERSION;
+      const initialAuthorityContract = buildDailyFritzAuthorityContract({
+        fritzPolicyVersion: policyVersion,
+        challengeId: buildDailyFritzChallengeId(run.runDate),
+        runFingerprint: buildDailyFritzRunFingerprint(run),
+        clientRelease: requestedClientRelease,
+        transcriptProtocolVersion: requestedProtocol,
+        stateDigestRequired: true,
+      });
+      const initialResult = {
+        ...writeDailyFritzAuthorityContract(null, initialAuthorityContract),
+        verification_status: 'in_progress',
+      };
+      const publishedChallenge = buildDailyFritzPublishedChallenge({
+        runDate: run.runDate,
+        fritzTier: run.fritzTier,
+        dealSize: run.dealSize,
+        winningScore: run.winningScore,
+        publishedAt: run.generatedAt,
+      });
+      if (
+        canonicalizeDailyFritzChallenge(publishedChallenge.games[0].hands)
+        !== canonicalizeDailyFritzChallenge(run.handDeals)
+      ) {
+        res.status(409).json({
+          error: 'Published Daily Fritz authority does not match the stored run.',
+          code: 'challenge_publication_mismatch',
+        });
+        return;
+      }
+      await publishDailyFritzChallenge(publishedChallenge);
+      const command = await startDailyFritzAttemptCommand<Record<string, unknown>>({
+        userId: authenticatedUserId,
+        challengeId: publishedChallenge.challengeId,
+        operationId: `start:${publishedChallenge.challengeId}`,
+        authorityResult: initialResult,
+      });
+      if (command.outcome !== 'committed' || !command.response) {
+        res.status(command.errorCode === 'operation_id_reused' ? 409 : 422).json({
+          error: 'Daily Fritz attempt could not be started transactionally.',
+          code: command.errorCode ?? 'transactional_start_failed',
+          authority_revision: command.committedRevision,
+        });
+        return;
+      }
+      const commandAttemptId = typeof command.response.attempt_id === 'string'
+        ? command.response.attempt_id
+        : '';
+      attempt = commandAttemptId
+        ? await getDailyFritzAttemptById(commandAttemptId, authenticatedUserId)
+        : null;
+      if (!attempt) throw new Error('Transactional Daily Fritz attempt was not readable after commit.');
+      existingAuthorityContract = readDailyFritzAuthorityContract(attempt.result);
+      createdTransactionally = command.response.created === true;
+      incrementDailyFritzMetric(createdTransactionally ? 'attempt_started' : 'retry_request');
+    }
     if (!attempt) {
       attempt = await createDailyFritzAttempt(runDate, authenticatedUserId);
       incrementDailyFritzMetric('attempt_started');
@@ -582,7 +696,7 @@ export function registerDailyFritzRoutes(app: Application): void {
         idempotencyKey: `${attempt.id}:attempt_started`,
         payload: { verificationCapable: supportsVerifier },
       });
-    } else {
+    } else if (!createdTransactionally) {
       incrementDailyFritzMetric('retry_request');
       await recordDailyFritzEventBestEffort({
         attemptId: attempt.id,
@@ -640,18 +754,29 @@ export function registerDailyFritzRoutes(app: Application): void {
     const currentGameNumber = needsCompletion ? null : getCurrentDailyFritzGameNumber(attempt.result);
     const gameNumberForDraw: DailyFritzSetGameNumber = (currentGameNumber ?? 1) as DailyFritzSetGameNumber;
     const currentGameScores = readActiveGameProgress(attempt.result, gameNumberForDraw);
-    const handDeal = getDailyFritzHandForGame(run, gameNumberForDraw, attempt.currentHandIndex);
-    const drawWinner: DailyFritzDrawWinner = resolveDailyFritzDrawWinner({
-      runDate: run.runDate,
-      gameNumber: gameNumberForDraw,
-      metadata: run.metadata,
-    });
-    const drawTiles: DailyFritzDrawTiles = resolveDailyFritzDrawTiles({
-      runDate: run.runDate,
-      gameNumber: gameNumberForDraw,
-      metadata: run.metadata,
-      drawWinner,
-    });
+    const publishedAuthority = await loadDailyFritzPublishedAuthority({ attempt, run });
+    const publishedGameAuthority = publishedAuthority
+      ? resolveDailyFritzPublishedGameAuthority({
+          challenge: publishedAuthority,
+          gameNumber: gameNumberForDraw,
+          handIndex: attempt.currentHandIndex,
+        })
+      : null;
+    const handDeal = publishedGameAuthority?.deal
+      ?? getDailyFritzHandForGame(run, gameNumberForDraw, attempt.currentHandIndex);
+    const drawWinner: DailyFritzDrawWinner = publishedGameAuthority?.drawWinner
+      ?? resolveDailyFritzDrawWinner({
+        runDate: run.runDate,
+        gameNumber: gameNumberForDraw,
+        metadata: run.metadata,
+      });
+    const drawTiles: DailyFritzDrawTiles = publishedGameAuthority?.drawTiles
+      ?? resolveDailyFritzDrawTiles({
+        runDate: run.runDate,
+        gameNumber: gameNumberForDraw,
+        metadata: run.metadata,
+        drawWinner,
+      });
     console.log('[daily-fritz:start] draw package', {
       runDate: run.runDate,
       gameNumber: gameNumberForDraw,
@@ -668,8 +793,9 @@ export function registerDailyFritzRoutes(app: Application): void {
       ok: true,
       attempt_id: attempt.id,
       verified_match_id: verifiedMatchId,
+      authority_revision: attempt.revision,
       run_date: run.runDate,
-      challenge_id: buildDailyFritzChallengeId(run.runDate),
+      challenge_id: publishedAuthority?.challengeId ?? buildDailyFritzChallengeId(run.runDate),
       rules_version: DAILY_FRITZ_RULES_VERSION,
       seed_version: DAILY_FRITZ_SEED_VERSION,
       run_fingerprint: buildDailyFritzRunFingerprint(run),
@@ -750,6 +876,7 @@ export function registerDailyFritzRoutes(app: Application): void {
       res.status(404).json({ error: 'Daily Fritz attempt not found.' });
       return;
     }
+    if (rejectModernAttemptWhenAuthorityDisabled(attempt, res)) return;
     if (runDateFromClient && runDateFromClient !== attempt.runDate) {
       res.status(400).json({ error: 'Daily Fritz run date does not match this attempt.' });
       return;
@@ -780,6 +907,7 @@ export function registerDailyFritzRoutes(app: Application): void {
       res.status(404).json({ error: 'Daily Fritz run not found.' });
       return;
     }
+    const publishedAuthority = await loadDailyFritzPublishedAuthority({ attempt, run });
     if (completedHandIndex > attempt.currentHandIndex) {
       res.status(400).json({ error: 'Requested completed hand is ahead of the persisted attempt.' });
       return;
@@ -789,19 +917,25 @@ export function registerDailyFritzRoutes(app: Application): void {
       currentHandIndex: number,
       options: { replayed?: boolean; ignored?: boolean } = {},
     ) => {
-      const hand = getDailyFritzHandForGame(run, gameNumber, currentHandIndex);
+      const publishedGameAuthority = publishedAuthority
+        ? resolveDailyFritzPublishedGameAuthority({
+            challenge: publishedAuthority,
+            gameNumber,
+            handIndex: currentHandIndex,
+          })
+        : null;
+      const hand = publishedGameAuthority?.deal
+        ?? getDailyFritzHandForGame(run, gameNumber, currentHandIndex);
       const scores = readActiveGameProgress(attempt.result, gameNumber);
-      const drawWinner: DailyFritzDrawWinner = resolveDailyFritzDrawWinner({
-        runDate: run.runDate,
-        gameNumber,
-        metadata: run.metadata,
-      });
-      const drawTiles: DailyFritzDrawTiles = resolveDailyFritzDrawTiles({
-        runDate: run.runDate,
-        gameNumber,
-        metadata: run.metadata,
-        drawWinner,
-      });
+      const drawWinner: DailyFritzDrawWinner = publishedGameAuthority?.drawWinner
+        ?? resolveDailyFritzDrawWinner({ runDate: run.runDate, gameNumber, metadata: run.metadata });
+      const drawTiles: DailyFritzDrawTiles = publishedGameAuthority?.drawTiles
+        ?? resolveDailyFritzDrawTiles({
+          runDate: run.runDate,
+          gameNumber,
+          metadata: run.metadata,
+          drawWinner,
+        });
       console.log('[daily-fritz-next-hand] draw package', {
         attemptId,
         runDate: run.runDate,
@@ -825,6 +959,7 @@ export function registerDailyFritzRoutes(app: Application): void {
         current_game_number: gameNumber,
         set_result: attempt.result ?? null,
         current_hand_index: currentHandIndex,
+        authority_revision: attempt.revision,
         current_game_scores: { you: scores.you, fritz: scores.fritz },
         hand,
         draw_winner: drawWinner,
@@ -884,7 +1019,26 @@ export function registerDailyFritzRoutes(app: Application): void {
           completedHandIndex,
           userId: authenticatedUserId,
         });
-        res.status(409).json({ error: 'Daily Fritz hand was already verified with different evidence.' });
+        incrementDailyFritzMetric('command_conflict', 'verified_hand_conflict');
+        await recordDailyFritzEventBestEffort({
+          attemptId,
+          runDate: attempt.runDate,
+          userId: authenticatedUserId,
+          requestId: diagnostics.requestId,
+          eventType: 'command_conflict',
+          gameNumber,
+          handIndex: completedHandIndex,
+          verifierCode: 'verified_hand_conflict',
+          idempotencyKey: `${attemptId}:command_conflict:${gameNumber}:${completedHandIndex}:${diagnostics.requestId}`,
+          payload: { reason: 'verified_hand_evidence_differs' },
+        });
+        res.status(409).json({
+          error: 'Daily Fritz advanced on another session. Resume from the authoritative state.',
+          code: 'verified_hand_conflict',
+          recoverable: true,
+          recovery_action: 'reload_official_hand',
+          authority_revision: attempt.revision,
+        });
         return;
       }
       incrementDailyFritzMetric('next_hand_replayed');
@@ -919,6 +1073,7 @@ export function registerDailyFritzRoutes(app: Application): void {
       userId: authenticatedUserId,
       gameNumber,
       handIndex: completedHandIndex,
+      publishedChallenge: publishedAuthority,
     });
     if (verified.terminalState.gameOver) {
       res.status(409).json({ error: 'Daily Fritz game is complete; finalize the verified game.' });
@@ -936,9 +1091,53 @@ export function registerDailyFritzRoutes(app: Application): void {
       fritz: verified.result.fritzScoreAfter,
     });
     attempt.currentHandIndex += 1;
-    const saved = await upsertDailyFritzAttempt(attempt);
+    let saved: DailyFritzAttemptRecord;
+    const transactionalHand = Boolean(attempt.challengeId && DAILY_FRITZ_TRANSACTIONAL_COMMANDS_ENABLED);
+    if (transactionalHand) {
+      const command = await commitDailyFritzAttemptCommand<Record<string, unknown>>({
+        userId: authenticatedUserId,
+        attemptId: attempt.id,
+        operationId: `hand:${gameNumber}:${completedHandIndex}`,
+        commandType: 'accept_verified_hand',
+        expectedRevision: attempt.revision,
+        next: {
+          status: 'started',
+          currentGameNumber: gameNumber,
+          currentHandIndex: attempt.currentHandIndex,
+          result: attempt.result,
+        },
+        handReceipt: verified.result,
+        outbox: {
+          eventType: 'hand_verified',
+          payload: {
+            gameNumber,
+            handIndex: completedHandIndex,
+            transcriptDigest: verified.result.transcriptDigest,
+          },
+        },
+      });
+      if (command.outcome !== 'committed') {
+        const recoverable = isRecoverableDailyFritzCommandConflict(command.errorCode);
+        res.status(409).json({
+          error: recoverable
+            ? 'Daily Fritz advanced on another session. Resume from the authoritative state.'
+            : 'Daily Fritz could not commit the verified hand.',
+          code: command.errorCode ?? 'transactional_hand_commit_failed',
+          recoverable,
+          recovery_action: recoverable ? 'reload_official_hand' : null,
+          authority_revision: command.committedRevision,
+          authoritative_state: command.response,
+        });
+        return;
+      }
+      saved = await getDailyFritzAttemptById(attempt.id, authenticatedUserId)
+        ?? (() => { throw new Error('Committed Daily Fritz hand was not readable.'); })();
+      attempt.revision = saved.revision;
+    } else {
+      saved = await upsertDailyFritzAttempt(attempt);
+    }
     incrementDailyFritzMetric('hand_verified');
-    await recordDailyFritzEventBestEffort({
+    if (!transactionalHand) await recordDailyFritzEventBestEffort({
       attemptId,
       runDate: attempt.runDate,
       userId: authenticatedUserId,
@@ -1023,6 +1222,7 @@ export function registerDailyFritzRoutes(app: Application): void {
       res.status(404).json({ error: 'Daily Fritz attempt not found.' });
       return;
     }
+    if (rejectModernAttemptWhenAuthorityDisabled(attempt, res)) return;
     if (runDateFromClient && runDateFromClient !== attempt.runDate) {
       res.status(400).json({ error: 'Daily Fritz run date does not match this attempt.' });
       return;
@@ -1040,6 +1240,7 @@ export function registerDailyFritzRoutes(app: Application): void {
       res.status(404).json({ error: 'Daily Fritz run not found.' });
       return;
     }
+    const publishedAuthority = await loadDailyFritzPublishedAuthority({ attempt, run });
     const parsedTranscript = transcriptInput == null ? null : parseTranscriptForRequest(transcriptInput);
     if (!parsedTranscript && requiresVerifiedDailyFritzEvidence(attempt.result)) {
       res.status(426).json({ error: 'This attempt requires verified game evidence. Update required.' });
@@ -1131,6 +1332,7 @@ export function registerDailyFritzRoutes(app: Application): void {
     let fritzScore = Math.round(legacyFritzScore);
     let movesUsed = Math.round(legacyMovesUsed);
     let handsPlayed = Math.round(legacyHandsPlayed);
+    let terminalHandReceipt: VerifiedDailyFritzHandRecord | null = null;
     if (parsedTranscript) {
       const verified = verifyAttemptHand({
         transcript: parsedTranscript,
@@ -1139,6 +1341,7 @@ export function registerDailyFritzRoutes(app: Application): void {
         userId: authenticatedUserId,
         gameNumber,
         handIndex: attempt.currentHandIndex,
+        publishedChallenge: publishedAuthority,
       });
       playerScore = verified.result.playerScoreAfter;
       fritzScore = verified.result.fritzScoreAfter;
@@ -1146,6 +1349,7 @@ export function registerDailyFritzRoutes(app: Application): void {
         res.status(409).json({ error: 'Daily Fritz game is not complete.' });
         return;
       }
+      terminalHandReceipt = verified.result;
       attempt.result = pinAuthorityContractFromVerifiedTranscript({
         result: attempt.result,
         run,
@@ -1196,8 +1400,64 @@ export function registerDailyFritzRoutes(app: Application): void {
     });
     if (!setResult.setWinner) {
       attempt.currentHandIndex = 0;
+      attempt.currentGameNumber = Math.min(gameNumber + 1, 3) as DailyFritzSetGameNumber;
     }
-    const saved = await upsertDailyFritzAttempt(attempt);
+    let saved: DailyFritzAttemptRecord;
+    const transactionalGame = Boolean(attempt.challengeId && DAILY_FRITZ_TRANSACTIONAL_COMMANDS_ENABLED);
+    if (transactionalGame) {
+      const authorityGame = readAuthorityLedger(attempt.result).games.find(
+        (game) => game.gameNumber === gameNumber,
+      );
+      if (!authorityGame) throw new Error('Verified Daily Fritz game receipt is missing.');
+      const command = await commitDailyFritzAttemptCommand<Record<string, unknown>>({
+        userId: authenticatedUserId,
+        attemptId: attempt.id,
+        operationId: `game:${gameNumber}:record`,
+        commandType: 'record_verified_game',
+        expectedRevision: attempt.revision,
+        next: {
+          status: 'started',
+          currentGameNumber: setResult.setWinner ? gameNumber : attempt.currentGameNumber,
+          currentHandIndex: setResult.setWinner ? attempt.currentHandIndex : 0,
+          result: attempt.result ?? {},
+        },
+        gameReceipt: {
+          ...authorityGame,
+          pointDiff: gameResult.pointDiff,
+          playerWon: gameResult.playerWon,
+          actionCount: movesUsed,
+          handsPlayed,
+        },
+        handReceipt: terminalHandReceipt,
+        outbox: {
+          eventType: 'game_recorded',
+          payload: {
+            gameNumber,
+            playerScore,
+            fritzScore,
+            setWinner: setResult.setWinner ?? null,
+          },
+        },
+      });
+      if (command.outcome !== 'committed') {
+        const recoverable = isRecoverableDailyFritzCommandConflict(command.errorCode);
+        res.status(409).json({
+          error: recoverable
+            ? 'Daily Fritz advanced on another session. Resume from the authoritative state.'
+            : 'Daily Fritz could not commit the verified game.',
+          code: command.errorCode ?? 'transactional_game_commit_failed',
+          recoverable,
+          recovery_action: recoverable ? 'reload_official_hand' : null,
+          authority_revision: command.committedRevision,
+          authoritative_state: command.response,
+        });
+        return;
+      }
+      saved = await getDailyFritzAttemptById(attempt.id, authenticatedUserId)
+        ?? (() => { throw new Error('Committed Daily Fritz game was not readable.'); })();
+    } else {
+      saved = await upsertDailyFritzAttempt(attempt);
+    }
     const savedSetResult = normalizeDailyFritzSetResult(saved.result);
     const recordedGame = (savedSetResult ?? setResult).games.find(
       (game: DailyFritzSetGameResult) => game.gameNumber === gameNumber,
@@ -1215,7 +1475,7 @@ export function registerDailyFritzRoutes(app: Application): void {
     }
     incrementDailyFritzMetric('game_recorded');
     const eventTranscriptDigest = parsedTranscript ? digestDailyFritzTranscript(parsedTranscript) : null;
-    await recordDailyFritzEventBestEffort({
+    if (!transactionalGame) await recordDailyFritzEventBestEffort({
       attemptId,
       runDate: attempt.runDate,
       userId: authenticatedUserId,
@@ -1235,6 +1495,7 @@ export function registerDailyFritzRoutes(app: Application): void {
     });
     res.json({
       ok: true,
+      authority_revision: saved.revision,
       set_result: savedSetResult ?? setResult,
       next_game_number: setResult.setWinner ? null : Math.min(setResult.games.length + 1, 3),
     });
@@ -1296,6 +1557,7 @@ export function registerDailyFritzRoutes(app: Application): void {
       res.status(404).json({ error: 'Daily Fritz attempt not found.' });
       return;
     }
+    if (rejectModernAttemptWhenAuthorityDisabled(attempt, res)) return;
     if (runDateFromClient && runDateFromClient !== attempt.runDate) {
       res.status(400).json({ error: 'Daily Fritz run date does not match this attempt.' });
       return;
@@ -1329,6 +1591,7 @@ export function registerDailyFritzRoutes(app: Application): void {
       res.json({
         ok: true,
         replayed: true,
+        authority_revision: attempt.revision,
         rank,
         leaderboard_preview: leaderboard.slice(0, 10).map(({ userId: _userId, ...entry }) => entry),
       });
@@ -1394,9 +1657,62 @@ export function registerDailyFritzRoutes(app: Application): void {
           moves_used: attempt.movesUsed,
           hands_played: attempt.handsPlayed,
         };
-    await upsertDailyFritzAttempt(attempt);
+    const transactionalCompletion = Boolean(
+      attempt.challengeId && DAILY_FRITZ_TRANSACTIONAL_COMMANDS_ENABLED,
+    );
+    if (transactionalCompletion) {
+      const command = await commitDailyFritzAttemptCommand<Record<string, unknown>>({
+        userId: authenticatedUserId,
+        attemptId: attempt.id,
+        operationId: 'finalize:set',
+        commandType: 'finalize_verified_attempt',
+        expectedRevision: attempt.revision,
+        next: {
+          status: 'completed',
+          currentGameNumber: attempt.currentGameNumber,
+          currentHandIndex: attempt.currentHandIndex,
+          result: attempt.result ?? {},
+          finalScore: attempt.finalScore,
+          opponentScore: attempt.opponentScore,
+          pointDiff: attempt.pointDiff,
+          won: attempt.won,
+          movesUsed: attempt.movesUsed,
+          handsPlayed: attempt.handsPlayed,
+          completionHash: serverReceipt,
+        },
+        outbox: {
+          eventType: 'attempt_completed',
+          payload: {
+            verified: isVerified,
+            finalScore: attempt.finalScore,
+            opponentScore: attempt.opponentScore,
+            setOutcome: `${attempt.finalScore}-${attempt.opponentScore}`,
+            setWinner: setResult?.setWinner ?? null,
+            movesUsed: attempt.movesUsed,
+            handsPlayed: attempt.handsPlayed,
+          },
+        },
+      });
+      if (command.outcome !== 'committed') {
+        const recoverable = isRecoverableDailyFritzCommandConflict(command.errorCode);
+        res.status(409).json({
+          error: recoverable
+            ? 'Daily Fritz completed on another session. Loading the authoritative result.'
+            : 'Daily Fritz could not commit the verified completion.',
+          code: command.errorCode ?? 'transactional_completion_failed',
+          recoverable,
+          recovery_action: recoverable ? 'reload_official_hand' : null,
+          authority_revision: command.committedRevision,
+          authoritative_state: command.response,
+        });
+        return;
+      }
+      attempt.revision = command.committedRevision ?? attempt.revision + 1;
+    } else {
+      await upsertDailyFritzAttempt(attempt);
+    }
     incrementDailyFritzMetric('attempt_completed');
-    await recordDailyFritzEventBestEffort({
+    if (!transactionalCompletion) await recordDailyFritzEventBestEffort({
       attemptId,
       runDate,
       userId: authenticatedUserId,
@@ -1412,13 +1728,15 @@ export function registerDailyFritzRoutes(app: Application): void {
       },
     });
 
-    const verifiedMatch = await getVerifiedSinglePlayerMatch(verifiedMatchId);
-    if (verifiedMatch && verifiedMatch.userId === authenticatedUserId) {
-      verifiedMatch.status = 'completed';
-      verifiedMatch.completedAt = attempt.completedAt;
-      verifiedMatch.completionHash = serverReceipt;
-      verifiedMatch.completionResult = attempt.result;
-      await persistVerifiedSinglePlayerMatch(verifiedMatch);
+    if (!transactionalCompletion) {
+      const verifiedMatch = await getVerifiedSinglePlayerMatch(verifiedMatchId);
+      if (verifiedMatch && verifiedMatch.userId === authenticatedUserId) {
+        verifiedMatch.status = 'completed';
+        verifiedMatch.completedAt = attempt.completedAt;
+        verifiedMatch.completionHash = serverReceipt;
+        verifiedMatch.completionResult = attempt.result;
+        await persistVerifiedSinglePlayerMatch(verifiedMatch);
+      }
     }
 
     const leaderboard = await buildDailyFritzLeaderboard(runDate);
@@ -1427,6 +1745,7 @@ export function registerDailyFritzRoutes(app: Application): void {
       : null;
     res.json({
       ok: true,
+      authority_revision: attempt.revision,
       rank,
       leaderboard_preview: leaderboard.slice(0, 10).map(({ userId: _userId, ...entry }) => entry),
     });
@@ -1461,21 +1780,64 @@ export function registerDailyFritzRoutes(app: Application): void {
       res.status(401).json({ error: 'Unauthorized' });
       return;
     }
-    const runDate = getPacificDateKey();
-    const attempt = await getDailyFritzAttempt(runDate, authenticatedUserId);
+    const attempt = await getDailyFritzAttemptById(attemptId, authenticatedUserId);
     if (!attempt || attempt.id !== attemptId) {
       res.status(404).json({ error: 'Daily Fritz attempt not found.' });
       return;
     }
-    if (attempt.status === 'completed' || attempt.status === 'abandoned') {
+    if (rejectModernAttemptWhenAuthorityDisabled(attempt, res)) return;
+    const runDate = attempt.runDate;
+    if (attempt.status === 'abandoned') {
+      res.json({ ok: true, replayed: true, authority_revision: attempt.revision });
+      return;
+    }
+    if (attempt.status === 'completed') {
       res.status(409).json({ error: 'Daily Fritz attempt is already locked.', status: attempt.status });
       return;
     }
     attempt.status = 'abandoned';
     attempt.completedAt = new Date().toISOString();
-    await upsertDailyFritzAttempt(attempt);
+    const transactionalAbandon = Boolean(
+      attempt.challengeId && DAILY_FRITZ_TRANSACTIONAL_COMMANDS_ENABLED,
+    );
+    if (transactionalAbandon) {
+      const command = await commitDailyFritzAttemptCommand<Record<string, unknown>>({
+        userId: authenticatedUserId,
+        attemptId: attempt.id,
+        operationId: 'abandon:set',
+        commandType: 'abandon_attempt',
+        expectedRevision: attempt.revision,
+        next: {
+          status: 'abandoned',
+          currentGameNumber: attempt.currentGameNumber,
+          currentHandIndex: attempt.currentHandIndex,
+          result: attempt.result ?? {},
+        },
+        outbox: {
+          eventType: 'attempt_abandoned',
+          payload: { previousRevision: attempt.revision },
+        },
+      });
+      if (command.outcome !== 'committed') {
+        const recoverable = isRecoverableDailyFritzCommandConflict(command.errorCode);
+        res.status(409).json({
+          error: recoverable
+            ? 'Daily Fritz changed on another session. Loading the authoritative state.'
+            : 'Daily Fritz could not commit the abandonment.',
+          code: command.errorCode ?? 'transactional_abandon_failed',
+          recoverable,
+          recovery_action: recoverable ? 'reload_official_hand' : null,
+          authority_revision: command.committedRevision,
+          authoritative_state: command.response,
+        });
+        return;
+      }
+      attempt.revision = command.committedRevision ?? attempt.revision + 1;
+    } else {
+      await upsertDailyFritzAttempt(attempt);
+    }
     incrementDailyFritzMetric('attempt_abandoned');
-    await recordDailyFritzEventBestEffort({
+    if (!transactionalAbandon) await recordDailyFritzEventBestEffort({
       attemptId,
       runDate,
       userId: authenticatedUserId,
@@ -1484,7 +1846,7 @@ export function registerDailyFritzRoutes(app: Application): void {
       idempotencyKey: `${attemptId}:attempt_abandoned`,
       payload: { completedAt: attempt.completedAt },
     });
-    if (attempt.verifiedMatchId) {
+    if (!transactionalAbandon && attempt.verifiedMatchId) {
       const verifiedMatch = await getVerifiedSinglePlayerMatch(attempt.verifiedMatchId);
       if (verifiedMatch && verifiedMatch.userId === authenticatedUserId) {
         verifiedMatch.status = 'abandoned';
@@ -1492,7 +1854,7 @@ export function registerDailyFritzRoutes(app: Application): void {
         await persistVerifiedSinglePlayerMatch(verifiedMatch);
       }
     }
-    res.json({ ok: true });
+    res.json({ ok: true, authority_revision: attempt.revision });
   } catch (error) {
     incrementDailyFritzMetric('request_failed');
     await recordDailyFritzEventBestEffort({
@@ -1508,6 +1870,65 @@ export function registerDailyFritzRoutes(app: Application): void {
     });
    }
 });
+
+  app.post('/api/daily-fritz/telemetry', async (req, res) => {
+  const authenticatedUserId = await getAuthenticatedUserId(req);
+  if (!authenticatedUserId) {
+    res.status(401).json({ error: 'Unauthorized' });
+    return;
+  }
+  const eventType = req.body?.event_type;
+  const eventId = typeof req.body?.event_id === 'string' ? req.body.event_id.trim() : '';
+  const attemptId = typeof req.body?.attempt_id === 'string' ? req.body.attempt_id.trim() : '';
+  const clientEvents = new Set([
+    'mode_impression', 'start_requested', 'first_move',
+    'recovery_started', 'recovery_succeeded', 'recovery_failed',
+    'review_opened', 'leaderboard_opened', 'share_requested', 'share_completed',
+  ]);
+  if (!isDailyFritzEventType(eventType) || !clientEvents.has(eventType) || eventId.length < 8 || eventId.length > 160) {
+    res.status(400).json({ error: 'A valid Daily Fritz client event and event_id are required.' });
+    return;
+  }
+  const attempt = attemptId
+    ? await getDailyFritzAttemptById(attemptId, authenticatedUserId)
+    : null;
+  if (attemptId && !attempt) {
+    res.status(404).json({ error: 'Daily Fritz attempt not found.' });
+    return;
+  }
+  const payload = req.body?.payload && typeof req.body.payload === 'object'
+    ? req.body.payload as Record<string, unknown>
+    : {};
+  if (JSON.stringify(payload).length > 4_096) {
+    res.status(413).json({ error: 'Daily Fritz telemetry payload is too large.' });
+    return;
+  }
+  try {
+    await recordDailyFritzEvent({
+      attemptId: attempt?.id ?? null,
+      runDate: attempt?.runDate
+        ?? (typeof req.body?.run_date === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(req.body.run_date)
+          ? req.body.run_date : null),
+      userId: authenticatedUserId,
+      eventType,
+      idempotencyKey: `client:${authenticatedUserId}:${eventId}`,
+      challengeId: attempt?.challengeId
+        ?? (typeof req.body?.challenge_id === 'string' ? req.body.challenge_id.slice(0, 200) : null),
+      authorityRevision: attempt?.revision ?? null,
+      source: 'client',
+      sessionId: typeof req.body?.session_id === 'string' ? req.body.session_id.slice(0, 160) : null,
+      clientRelease: typeof req.body?.client_release === 'string' ? req.body.client_release.slice(0, 120) : null,
+      durationMs: Number.isInteger(req.body?.duration_ms) && req.body.duration_ms >= 0
+        ? Math.min(req.body.duration_ms, 86_400_000) : null,
+      verifierCode: typeof req.body?.failure_code === 'string' ? req.body.failure_code.slice(0, 120) : null,
+      payload,
+    });
+    res.status(202).json({ ok: true });
+  } catch (error) {
+    incrementDailyFritzMetric('event_persistence_failed');
+    res.status(503).json({ error: 'Daily Fritz telemetry is temporarily unavailable.' });
+  }
+  });
 
   app.get('/api/daily-fritz/metrics', async (req, res) => {
   const suppliedAdminSecret = req.get('x-admin-secret') ?? req.query.admin_key;
@@ -1611,6 +2032,15 @@ export function registerDailyFritzRoutes(app: Application): void {
       invalidatedAt: generated.invalidatedAt,
       metadata: generated.metadata,
     });
+    if (DAILY_FRITZ_TRANSACTIONAL_COMMANDS_ENABLED) {
+      await publishDailyFritzChallenge(buildDailyFritzPublishedChallenge({
+        runDate: saved.runDate,
+        fritzTier: saved.fritzTier,
+        dealSize: saved.dealSize,
+        winningScore: saved.winningScore,
+        publishedAt: saved.generatedAt,
+      }));
+    }
     res.json({ ok: true, run_date: saved.runDate, seed: getDailyFritzSeed(saved.runDate) });
   } catch (error) {
     res.status(500).json({
@@ -1636,11 +2066,24 @@ export function registerDailyFritzRoutes(app: Application): void {
       res.status(404).json({ error: 'Daily Fritz run not found.' });
       return;
     }
-    run.status = 'invalidated';
-    run.invalidatedAt = new Date().toISOString();
-    run.metadata = { ...(run.metadata ?? {}), invalidation_reason: reason || null };
-    await upsertDailyFritzRun(run);
-    res.json({ ok: true });
+    if (!DAILY_FRITZ_TRANSACTIONAL_COMMANDS_ENABLED) {
+      run.status = 'invalidated';
+      run.invalidatedAt = new Date().toISOString();
+      run.metadata = { ...(run.metadata ?? {}), invalidation_reason: reason || null };
+      await upsertDailyFritzRun(run);
+      res.json({ ok: true, status: run.status });
+      return;
+    }
+    await publishDailyFritzChallenge(buildDailyFritzPublishedChallenge({
+      runDate: run.runDate,
+      fritzTier: run.fritzTier,
+      dealSize: run.dealSize,
+      winningScore: run.winningScore,
+      publishedAt: run.generatedAt,
+    }));
+    const invalidated = await invalidateDailyFritzPublishedChallenge(runDate, reason);
+    dailyFritzRunCache.delete(runDate);
+    res.json({ ok: true, challenge_id: invalidated.challengeId, status: invalidated.status });
   } catch (error) {
     res.status(500).json({
       error: error instanceof Error ? error.message : 'Failed to invalidate Daily Fritz run.',

--- a/server/src/http/routes/dailyFritzMetrics.ts
+++ b/server/src/http/routes/dailyFritzMetrics.ts
@@ -9,6 +9,7 @@ export type DailyFritzMetricName =
   | 'verification_failed'
   | 'retry_request'
   | 'mutation_request'
+  | 'command_conflict'
   | 'event_persistence_failed';
 
 type MetricBucket = {

--- a/server/src/http/routes/dailyFritzOperationalRoutes.test.ts
+++ b/server/src/http/routes/dailyFritzOperationalRoutes.test.ts
@@ -1,10 +1,33 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { Application } from 'express';
 
-const { listEventsMock, listMetricsMock } = vi.hoisted(() => ({
+const {
+  authUserMock,
+  getAttemptByIdMock,
+  listEventsMock,
+  listMetricsMock,
+  recordEventMock,
+} = vi.hoisted(() => ({
+  authUserMock: vi.fn(),
+  getAttemptByIdMock: vi.fn(),
   listEventsMock: vi.fn(),
   listMetricsMock: vi.fn(),
+  recordEventMock: vi.fn(),
 }));
+
+vi.mock('../../platform/auth/supabaseAuth', () => ({
+  getAuthenticatedUserId: authUserMock,
+}));
+
+vi.mock('../stores/dailyFritzStore', async () => {
+  const actual = await vi.importActual<typeof import('../stores/dailyFritzStore')>(
+    '../stores/dailyFritzStore',
+  );
+  return {
+    ...actual,
+    getDailyFritzAttemptById: getAttemptByIdMock,
+  };
+});
 
 vi.mock('../stores/dailyFritzEventStore', async () => {
   const actual = await vi.importActual<typeof import('../stores/dailyFritzEventStore')>(
@@ -14,6 +37,7 @@ vi.mock('../stores/dailyFritzEventStore', async () => {
     ...actual,
     listDailyFritzEvents: listEventsMock,
     listDailyFritzPersistedMetrics: listMetricsMock,
+    recordDailyFritzEvent: recordEventMock,
   };
 });
 
@@ -32,7 +56,12 @@ function makeHarness() {
   return async function request(
     method: 'GET' | 'POST',
     path: string,
-    input: { adminSecret?: string; params?: Record<string, string>; query?: Record<string, string> } = {},
+    input: {
+      adminSecret?: string;
+      body?: Record<string, unknown>;
+      params?: Record<string, string>;
+      query?: Record<string, string>;
+    } = {},
   ) {
     const handler = routes.get(`${method} ${path}`);
     if (!handler) throw new Error(`Missing route ${method} ${path}`);
@@ -46,6 +75,7 @@ function makeHarness() {
       headers: input.adminSecret ? { 'x-admin-secret': input.adminSecret } : {},
       params: input.params ?? {},
       query: input.query ?? {},
+      body: input.body ?? {},
       method,
       path,
       get(name: string) { return name.toLowerCase() === 'x-admin-secret' ? input.adminSecret : undefined; },
@@ -59,6 +89,9 @@ describe('Daily Fritz operational routes', () => {
     delete process.env.ADMIN_SECRET;
     listEventsMock.mockReset();
     listMetricsMock.mockReset();
+    recordEventMock.mockReset();
+    getAttemptByIdMock.mockReset();
+    authUserMock.mockReset();
   });
 
   it('protects operational metrics and event timelines with the admin secret', async () => {
@@ -98,5 +131,62 @@ describe('Daily Fritz operational routes', () => {
       persisted_metrics: [{ eventType: 'attempt_completed', total: 2 }],
     });
     expect(listMetricsMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('accepts only authenticated, allowlisted client telemetry with an idempotent identity', async () => {
+    authUserMock.mockResolvedValue('user-1');
+    getAttemptByIdMock.mockResolvedValue({
+      id: 'attempt-1',
+      runDate: '2026-08-01',
+      challengeId: 'daily-fritz:2026-08-01:v1',
+      revision: 7,
+    });
+    recordEventMock.mockResolvedValue(undefined);
+    const request = makeHarness();
+    const body = {
+      event_type: 'recovery_succeeded',
+      event_id: 'attempt-1:recovery_succeeded:resume-1',
+      attempt_id: 'attempt-1',
+      session_id: 'session-1',
+      client_release: 'test-release',
+      duration_ms: 1234,
+      payload: { recovery_reason: 'refresh' },
+    };
+
+    await expect(request('POST', '/api/daily-fritz/telemetry', { body })).resolves.toMatchObject({
+      status: 202,
+      body: { ok: true },
+    });
+    expect(recordEventMock).toHaveBeenCalledWith(expect.objectContaining({
+      attemptId: 'attempt-1',
+      userId: 'user-1',
+      eventType: 'recovery_succeeded',
+      idempotencyKey: 'client:user-1:attempt-1:recovery_succeeded:resume-1',
+      challengeId: 'daily-fritz:2026-08-01:v1',
+      authorityRevision: 7,
+      source: 'client',
+    }));
+
+    await request('POST', '/api/daily-fritz/telemetry', { body });
+    expect(recordEventMock.mock.calls[1]?.[0].idempotencyKey)
+      .toBe(recordEventMock.mock.calls[0]?.[0].idempotencyKey);
+  });
+
+  it('rejects authority events and attempts not owned by the authenticated user', async () => {
+    authUserMock.mockResolvedValue('user-1');
+    getAttemptByIdMock.mockResolvedValue(null);
+    const request = makeHarness();
+
+    await expect(request('POST', '/api/daily-fritz/telemetry', {
+      body: { event_type: 'attempt_completed', event_id: 'client-event-123' },
+    })).resolves.toMatchObject({ status: 400 });
+    await expect(request('POST', '/api/daily-fritz/telemetry', {
+      body: {
+        event_type: 'first_move',
+        event_id: 'client-event-456',
+        attempt_id: 'someone-elses-attempt',
+      },
+    })).resolves.toMatchObject({ status: 404 });
+    expect(recordEventMock).not.toHaveBeenCalled();
   });
 });

--- a/server/src/http/routes/dailyFritzPublishedAuthority.test.ts
+++ b/server/src/http/routes/dailyFritzPublishedAuthority.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { buildDailyFritzPublishedChallenge } from '../../dailyFritzPublishedChallenge';
+import {
+  assertDailyFritzAttemptPinsPublishedChallenge,
+  resolveDailyFritzPublishedGameAuthority,
+} from './dailyFritzPublishedAuthority';
+
+const challenge = buildDailyFritzPublishedChallenge({
+  runDate: '2026-08-01',
+  fritzTier: 'elite',
+  dealSize: 7,
+  winningScore: 60,
+  publishedAt: '2026-08-01T07:00:00.000Z',
+});
+
+function attempt() {
+  return {
+    id: 'attempt-1', runDate: challenge.runDate, userId: 'user-1', status: 'started' as const,
+    currentHandIndex: 0, currentGameNumber: 1 as const, revision: 1,
+    challengeId: challenge.challengeId, challengeContractVersion: challenge.contractVersion,
+    generationVersion: challenge.generationVersion, gameRulesVersion: challenge.gameRulesVersion,
+    transcriptProtocolVersion: challenge.transcriptProtocolVersion,
+    fritzPolicyVersion: challenge.fritzPolicyVersion, rankingVersion: challenge.rankingVersion,
+    authoritySchemaVersion: 1, startedAt: challenge.publishedAt, completedAt: null,
+    verifiedMatchId: null, completionHash: null, result: null, finalScore: null,
+    opponentScore: null, pointDiff: null, won: null, movesUsed: null, handsPlayed: null,
+  };
+}
+
+describe('Daily Fritz published authority resolver', () => {
+  it('uses the exact published hand and draw package', () => {
+    const resolved = resolveDailyFritzPublishedGameAuthority({ challenge, gameNumber: 2, handIndex: 3 });
+    expect(resolved.deal).toEqual(challenge.games[1].hands[3]);
+    expect(resolved.drawWinner).toBe(challenge.games[1].drawWinner);
+    expect(resolved.drawTiles).toEqual(challenge.games[1].drawTiles);
+  });
+
+  it('retains the pinned v1 generator for deterministic overflow hands', () => {
+    const first = resolveDailyFritzPublishedGameAuthority({ challenge, gameNumber: 3, handIndex: 20 });
+    const second = resolveDailyFritzPublishedGameAuthority({ challenge, gameNumber: 3, handIndex: 20 });
+    expect(second.deal).toEqual(first.deal);
+  });
+
+  it('rejects any attempt version drift', () => {
+    expect(() => assertDailyFritzAttemptPinsPublishedChallenge({
+      ...attempt(), fritzPolicyVersion: challenge.fritzPolicyVersion + 1,
+    }, challenge)).toThrow('daily_fritz_attempt_challenge_version_mismatch');
+  });
+});

--- a/server/src/http/routes/dailyFritzPublishedAuthority.ts
+++ b/server/src/http/routes/dailyFritzPublishedAuthority.ts
@@ -1,0 +1,99 @@
+import {
+  DAILY_FRITZ_GENERATION_VERSION,
+  assertValidDailyFritzPublishedChallenge,
+  type DailyFritzPublishedChallenge,
+} from '../../dailyFritzPublishedChallenge';
+import {
+  generateSingleDailyFritzGameHand,
+  type DailyFritzDrawTiles,
+  type DailyFritzDrawWinner,
+  type DailyFritzHandDeal,
+  type DailyFritzSetGameNumber,
+} from '../../dailyFritz';
+import type {
+  DailyFritzAttemptRecord,
+  DailyFritzRunRecord,
+} from '../stores/dailyFritzStore';
+import { getDailyFritzPublishedChallenge } from '../stores/dailyFritzPublishedChallengeStore';
+
+export type DailyFritzPublishedGameAuthority = {
+  deal: DailyFritzHandDeal;
+  drawWinner: DailyFritzDrawWinner;
+  drawTiles: DailyFritzDrawTiles;
+};
+
+export function assertDailyFritzAttemptPinsPublishedChallenge(
+  attempt: DailyFritzAttemptRecord,
+  challenge: DailyFritzPublishedChallenge,
+): void {
+  const incompatible =
+    attempt.challengeId !== challenge.challengeId
+    || attempt.runDate !== challenge.runDate
+    || attempt.challengeContractVersion !== challenge.contractVersion
+    || attempt.generationVersion !== challenge.generationVersion
+    || attempt.gameRulesVersion !== challenge.gameRulesVersion
+    || attempt.transcriptProtocolVersion !== challenge.transcriptProtocolVersion
+    || attempt.fritzPolicyVersion !== challenge.fritzPolicyVersion
+    || attempt.rankingVersion !== challenge.rankingVersion;
+  if (incompatible) throw new Error('daily_fritz_attempt_challenge_version_mismatch');
+  if (challenge.status !== 'live') throw new Error('daily_fritz_published_challenge_unavailable');
+}
+
+export function assertDailyFritzRunMatchesPublishedChallenge(
+  run: DailyFritzRunRecord,
+  challenge: DailyFritzPublishedChallenge,
+): void {
+  if (
+    run.runDate !== challenge.runDate
+    || run.seed !== challenge.seed
+    || run.fritzTier !== challenge.fritzTier
+    || run.dealSize !== challenge.dealSize
+    || run.winningScore !== challenge.winningScore
+  ) {
+    throw new Error('daily_fritz_legacy_run_publication_mismatch');
+  }
+}
+
+export function resolveDailyFritzPublishedGameAuthority(input: {
+  challenge: DailyFritzPublishedChallenge;
+  gameNumber: DailyFritzSetGameNumber;
+  handIndex: number;
+}): DailyFritzPublishedGameAuthority {
+  assertValidDailyFritzPublishedChallenge(input.challenge);
+  if (!Number.isInteger(input.handIndex) || input.handIndex < 0) {
+    throw new Error('daily_fritz_invalid_published_hand_index');
+  }
+  const game = input.challenge.games[input.gameNumber - 1];
+  if (!game || game.gameNumber !== input.gameNumber) {
+    throw new Error('daily_fritz_published_game_missing');
+  }
+  const deal = game.hands[input.handIndex]
+    ?? (() => {
+      if (input.challenge.generationVersion !== DAILY_FRITZ_GENERATION_VERSION) {
+        throw new Error('daily_fritz_historical_generator_unavailable');
+      }
+      return generateSingleDailyFritzGameHand(
+        input.challenge.runDate,
+        input.gameNumber,
+        input.handIndex,
+        input.challenge.dealSize,
+      );
+    })();
+  return {
+    deal,
+    drawWinner: game.drawWinner,
+    drawTiles: game.drawTiles,
+  };
+}
+
+export async function loadDailyFritzPublishedAuthority(input: {
+  attempt: DailyFritzAttemptRecord;
+  run: DailyFritzRunRecord;
+}): Promise<DailyFritzPublishedChallenge | null> {
+  if (!input.attempt.challengeId) return null;
+  const challenge = await getDailyFritzPublishedChallenge(input.attempt.challengeId);
+  if (!challenge) throw new Error('daily_fritz_published_challenge_missing');
+  assertDailyFritzAttemptPinsPublishedChallenge(input.attempt, challenge);
+  assertDailyFritzRunMatchesPublishedChallenge(input.run, challenge);
+  return challenge;
+}

--- a/server/src/http/stores/dailyFritzAuthorityReadiness.test.ts
+++ b/server/src/http/stores/dailyFritzAuthorityReadiness.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../supabaseUtils', () => ({ supabaseFetch: vi.fn() }));
+
+import { supabaseFetch } from '../../supabaseUtils';
+import {
+  getDailyFritzAuthoritySchemaAvailability,
+  probeDailyFritzAuthoritySchema,
+  resetDailyFritzAuthorityReadinessForTests,
+} from './dailyFritzAuthorityReadiness';
+
+describe('Daily Fritz authority schema readiness', () => {
+  const original = process.env.DAILY_FRITZ_TRANSACTIONAL_COMMANDS;
+  beforeEach(() => {
+    resetDailyFritzAuthorityReadinessForTests();
+    vi.mocked(supabaseFetch).mockReset();
+  });
+  afterEach(() => {
+    if (original === undefined) delete process.env.DAILY_FRITZ_TRANSACTIONAL_COMMANDS;
+    else process.env.DAILY_FRITZ_TRANSACTIONAL_COMMANDS = original;
+  });
+
+  it('does not require expanded schema while the rollout gate is disabled', async () => {
+    delete process.env.DAILY_FRITZ_TRANSACTIONAL_COMMANDS;
+    await expect(probeDailyFritzAuthoritySchema()).resolves.toBe(true);
+    expect(supabaseFetch).not.toHaveBeenCalled();
+  });
+
+  it('probes every authority surface before reporting ready', async () => {
+    process.env.DAILY_FRITZ_TRANSACTIONAL_COMMANDS = 'true';
+    vi.mocked(supabaseFetch).mockResolvedValue([]);
+    await expect(probeDailyFritzAuthoritySchema()).resolves.toBe(true);
+    expect(supabaseFetch).toHaveBeenCalledTimes(6);
+    expect(getDailyFritzAuthoritySchemaAvailability()).toBe(true);
+  });
+
+  it('fails readiness closed when any required authority surface is unavailable', async () => {
+    process.env.DAILY_FRITZ_TRANSACTIONAL_COMMANDS = 'true';
+    vi.mocked(supabaseFetch).mockRejectedValueOnce(new Error('missing column'));
+    await expect(probeDailyFritzAuthoritySchema()).resolves.toBe(false);
+    expect(getDailyFritzAuthoritySchemaAvailability()).toBe(false);
+  });
+});

--- a/server/src/http/stores/dailyFritzAuthorityReadiness.ts
+++ b/server/src/http/stores/dailyFritzAuthorityReadiness.ts
@@ -1,0 +1,45 @@
+import { isDailyFritzTransactionalAuthorityEnabled } from '../../dailyFritzAuthorityFeature';
+import { supabaseFetch } from '../../supabaseUtils';
+
+let available: boolean | null = null;
+
+export function getDailyFritzAuthoritySchemaAvailability(): boolean | null {
+  return available;
+}
+
+export async function probeDailyFritzAuthoritySchema(): Promise<boolean> {
+  if (!isDailyFritzTransactionalAuthorityEnabled()) {
+    available = true;
+    return true;
+  }
+  try {
+    await Promise.all([
+      supabaseFetch('/rest/v1/daily_fritz_attempts?select=revision,current_game_number,challenge_id&limit=0', {
+        method: 'GET', timeoutMs: 3_000,
+      }),
+      supabaseFetch('/rest/v1/daily_fritz_published_challenges?select=challenge_id,content_digest&limit=0', {
+        method: 'GET', timeoutMs: 3_000,
+      }),
+      supabaseFetch('/rest/v1/daily_fritz_attempt_operations?select=operation_id,committed_revision&limit=0', {
+        method: 'GET', timeoutMs: 3_000,
+      }),
+      supabaseFetch('/rest/v1/daily_fritz_verified_hands?select=attempt_id,hand_index&limit=0', {
+        method: 'GET', timeoutMs: 3_000,
+      }),
+      supabaseFetch('/rest/v1/daily_fritz_outbox?select=event_type,analytics_projected_at&limit=0', {
+        method: 'GET', timeoutMs: 3_000,
+      }),
+      supabaseFetch('/rest/v1/daily_fritz_events?select=event_version,failure_phase,recovery_class&limit=0', {
+        method: 'GET', timeoutMs: 3_000,
+      }),
+    ]);
+    available = true;
+  } catch {
+    available = false;
+  }
+  return available;
+}
+
+export function resetDailyFritzAuthorityReadinessForTests(): void {
+  available = null;
+}

--- a/server/src/http/stores/dailyFritzCommandStore.test.ts
+++ b/server/src/http/stores/dailyFritzCommandStore.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  commitDailyFritzAttemptCommand,
+  digestDailyFritzCommand,
+  startDailyFritzAttemptCommand,
+  type DailyFritzCommandStoreDeps,
+} from './dailyFritzCommandStore';
+
+describe('Daily Fritz transactional command store', () => {
+  it('hashes semantic command payloads canonically', () => {
+    expect(digestDailyFritzCommand({ b: 2, a: { y: 2, x: 1 } }))
+      .toBe(digestDailyFritzCommand({ a: { x: 1, y: 2 }, b: 2 }));
+  });
+
+  it('starts with a durable operation identity and server-derived user identity', async () => {
+    const fetch = vi.fn(async () => [{
+      outcome: 'committed', error_code: null, replayed: false,
+      committed_revision: 1, response: { attempt_id: 'attempt-1', revision: 1 },
+    }]) as DailyFritzCommandStoreDeps['fetch'];
+    const result = await startDailyFritzAttemptCommand({
+      userId: 'user-1', challengeId: 'daily-fritz:2026-08-01:r2:s1',
+      operationId: 'operation-1', authorityResult: { verification_status: 'in_progress' },
+    }, { fetch });
+
+    expect(result).toMatchObject({ outcome: 'committed', committedRevision: 1 });
+    const body = JSON.parse(String(fetch.mock.calls[0]?.[1]?.body));
+    expect(body).toMatchObject({
+      p_user_id: 'user-1', p_operation_id: 'operation-1',
+      p_challenge_id: 'daily-fritz:2026-08-01:r2:s1',
+    });
+    expect(body.p_request_digest).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('sends expected revision, normalized receipt, and outbox in one RPC', async () => {
+    const fetch = vi.fn(async () => [{
+      outcome: 'committed', error_code: null, replayed: false,
+      committed_revision: 8, response: { attempt_id: 'attempt-1', revision: 8 },
+    }]) as DailyFritzCommandStoreDeps['fetch'];
+    const receipt = {
+      gameNumber: 1, handIndex: 2, transcriptDigest: 'a'.repeat(64),
+      actionCount: 14, playerScoreAfter: 20, fritzScoreAfter: 15,
+      winner: 'player', verificationVersion: 2,
+    };
+    await commitDailyFritzAttemptCommand({
+      userId: 'user-1', attemptId: 'attempt-1', operationId: 'operation-2',
+      commandType: 'accept_verified_hand', expectedRevision: 7,
+      next: {
+        status: 'started', currentGameNumber: 1, currentHandIndex: 3,
+        result: { verification_status: 'in_progress' },
+      },
+      handReceipt: receipt,
+      outbox: { eventType: 'hand_verified', payload: { gameNumber: 1, handIndex: 2 } },
+    }, { fetch });
+
+    const body = JSON.parse(String(fetch.mock.calls[0]?.[1]?.body));
+    expect(body).toMatchObject({
+      p_expected_revision: 7,
+      p_new_current_hand_index: 3,
+      p_hand_receipt: receipt,
+      p_outbox_event_type: 'hand_verified',
+    });
+    expect(body.p_request_digest).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('preserves durable replay and stale-revision outcomes', async () => {
+    const fetch = vi.fn(async () => [{
+      outcome: 'rejected', error_code: 'stale_revision', replayed: true,
+      committed_revision: 9, response: { attempt_id: 'attempt-1', revision: 9 },
+    }]) as DailyFritzCommandStoreDeps['fetch'];
+    const result = await commitDailyFritzAttemptCommand({
+      userId: 'user-1', attemptId: 'attempt-1', operationId: 'operation-stale',
+      commandType: 'abandon_attempt', expectedRevision: 8,
+      next: { status: 'abandoned', currentGameNumber: 2, currentHandIndex: 0, result: {} },
+      outbox: { eventType: 'attempt_abandoned', payload: {} },
+    }, { fetch });
+    expect(result).toMatchObject({
+      outcome: 'rejected', errorCode: 'stale_revision', replayed: true, committedRevision: 9,
+    });
+  });
+});

--- a/server/src/http/stores/dailyFritzCommandStore.ts
+++ b/server/src/http/stores/dailyFritzCommandStore.ts
@@ -1,0 +1,146 @@
+import { createHash } from 'crypto';
+import { canonicalizeDailyFritzChallenge } from '../../dailyFritzPublishedChallenge';
+import { supabaseFetch } from '../../supabaseUtils';
+
+export type DailyFritzCommandType =
+  | 'accept_verified_hand'
+  | 'record_verified_game'
+  | 'finalize_verified_attempt'
+  | 'abandon_attempt';
+
+export type DailyFritzCommandOutcome = 'committed' | 'rejected' | 'conflict';
+
+export type DailyFritzCommandRow<TResponse extends Record<string, unknown>> = {
+  outcome: DailyFritzCommandOutcome;
+  error_code: string | null;
+  replayed: boolean;
+  committed_revision: number | null;
+  response: TResponse | null;
+};
+
+export type DailyFritzCommandResult<TResponse extends Record<string, unknown>> = {
+  outcome: DailyFritzCommandOutcome;
+  errorCode: string | null;
+  replayed: boolean;
+  committedRevision: number | null;
+  response: TResponse | null;
+};
+
+export type DailyFritzCommandStoreDeps = { fetch: typeof supabaseFetch };
+const DEFAULT_DEPS: DailyFritzCommandStoreDeps = { fetch: supabaseFetch };
+
+export function digestDailyFritzCommand(value: unknown): string {
+  return createHash('sha256')
+    .update(canonicalizeDailyFritzChallenge(value))
+    .digest('hex');
+}
+
+function normalizeCommandResult<TResponse extends Record<string, unknown>>(
+  rows: DailyFritzCommandRow<TResponse>[] | undefined,
+): DailyFritzCommandResult<TResponse> {
+  const row = rows?.[0];
+  if (!row) throw new Error('Daily Fritz command did not return a durable outcome.');
+  return {
+    outcome: row.outcome,
+    errorCode: row.error_code,
+    replayed: row.replayed,
+    committedRevision: row.committed_revision == null ? null : Number(row.committed_revision),
+    response: row.response,
+  };
+}
+
+export async function startDailyFritzAttemptCommand<TResponse extends Record<string, unknown>>(
+  input: {
+    userId: string;
+    challengeId: string;
+    operationId: string;
+    authorityResult: Record<string, unknown>;
+  },
+  deps: DailyFritzCommandStoreDeps = DEFAULT_DEPS,
+): Promise<DailyFritzCommandResult<TResponse>> {
+  const requestDigest = digestDailyFritzCommand({
+    commandType: 'start_attempt',
+    challengeId: input.challengeId,
+    authorityResult: input.authorityResult,
+  });
+  const rows = await deps.fetch<DailyFritzCommandRow<TResponse>[]>(
+    '/rest/v1/rpc/start_daily_fritz_attempt_command',
+    {
+      method: 'POST',
+      body: JSON.stringify({
+        p_user_id: input.userId,
+        p_challenge_id: input.challengeId,
+        p_operation_id: input.operationId,
+        p_request_digest: requestDigest,
+        p_authority_result: input.authorityResult,
+      }),
+    },
+  );
+  return normalizeCommandResult(rows);
+}
+
+export async function commitDailyFritzAttemptCommand<TResponse extends Record<string, unknown>>(
+  input: {
+    userId: string;
+    attemptId: string;
+    operationId: string;
+    commandType: DailyFritzCommandType;
+    expectedRevision: number;
+    next: {
+      status: 'started' | 'completed' | 'abandoned';
+      currentGameNumber: 1 | 2 | 3;
+      currentHandIndex: number;
+      result: Record<string, unknown>;
+      finalScore?: number | null;
+      opponentScore?: number | null;
+      pointDiff?: number | null;
+      won?: boolean | null;
+      movesUsed?: number | null;
+      handsPlayed?: number | null;
+      completionHash?: string | null;
+    };
+    handReceipt?: Record<string, unknown> | null;
+    gameReceipt?: Record<string, unknown> | null;
+    outbox: { eventType: string; payload: Record<string, unknown> };
+  },
+  deps: DailyFritzCommandStoreDeps = DEFAULT_DEPS,
+): Promise<DailyFritzCommandResult<TResponse>> {
+  const requestDigest = digestDailyFritzCommand({
+    commandType: input.commandType,
+    attemptId: input.attemptId,
+    expectedRevision: input.expectedRevision,
+    next: input.next,
+    handReceipt: input.handReceipt ?? null,
+    gameReceipt: input.gameReceipt ?? null,
+  });
+  const rows = await deps.fetch<DailyFritzCommandRow<TResponse>[]>(
+    '/rest/v1/rpc/commit_daily_fritz_attempt_command',
+    {
+      method: 'POST',
+      body: JSON.stringify({
+        p_user_id: input.userId,
+        p_attempt_id: input.attemptId,
+        p_operation_id: input.operationId,
+        p_command_type: input.commandType,
+        p_request_digest: requestDigest,
+        p_expected_revision: input.expectedRevision,
+        p_new_status: input.next.status,
+        p_new_current_game_number: input.next.currentGameNumber,
+        p_new_current_hand_index: input.next.currentHandIndex,
+        p_new_result: input.next.result,
+        p_final_score: input.next.finalScore ?? null,
+        p_opponent_score: input.next.opponentScore ?? null,
+        p_point_diff: input.next.pointDiff ?? null,
+        p_won: input.next.won ?? null,
+        p_moves_used: input.next.movesUsed ?? null,
+        p_hands_played: input.next.handsPlayed ?? null,
+        p_completion_hash: input.next.completionHash ?? null,
+        p_hand_receipt: input.handReceipt ?? null,
+        p_game_receipt: input.gameReceipt ?? null,
+        p_outbox_event_type: input.outbox.eventType,
+        p_outbox_payload: input.outbox.payload,
+      }),
+    },
+  );
+  return normalizeCommandResult(rows);
+}

--- a/server/src/http/stores/dailyFritzEventStore.test.ts
+++ b/server/src/http/stores/dailyFritzEventStore.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('../../supabaseUtils', () => ({ supabaseFetch: vi.fn() }));
 
@@ -11,7 +11,12 @@ import {
 } from './dailyFritzEventStore';
 
 describe('Daily Fritz event store', () => {
+  const originalAuthority = process.env.DAILY_FRITZ_TRANSACTIONAL_COMMANDS;
   beforeEach(() => vi.mocked(supabaseFetch).mockReset());
+  afterEach(() => {
+    if (originalAuthority === undefined) delete process.env.DAILY_FRITZ_TRANSACTIONAL_COMMANDS;
+    else process.env.DAILY_FRITZ_TRANSACTIONAL_COMMANDS = originalAuthority;
+  });
 
   it('writes a normalized idempotent event to PostgREST', async () => {
     vi.mocked(supabaseFetch).mockResolvedValue(undefined);
@@ -105,5 +110,27 @@ describe('Daily Fritz event store', () => {
     const firstBody = vi.mocked(supabaseFetch).mock.calls[0]?.[1]?.body;
     const secondBody = vi.mocked(supabaseFetch).mock.calls[1]?.[1]?.body;
     expect(secondBody).toBe(firstBody);
+  });
+
+  it('writes canonical dimensions only after the authority schema is enabled', async () => {
+    vi.mocked(supabaseFetch).mockResolvedValue(undefined);
+    process.env.DAILY_FRITZ_TRANSACTIONAL_COMMANDS = 'true';
+    await recordDailyFritzEvent({
+      eventType: 'recovery_failed',
+      verifierCode: 'stale_revision',
+      challengeId: 'daily-fritz:2026-08-01:r2:s1',
+      authorityRevision: 4,
+      source: 'client',
+      idempotencyKey: 'recovery-failed-1',
+    });
+    const body = JSON.parse(String(vi.mocked(supabaseFetch).mock.calls[0]?.[1]?.body))[0];
+    expect(body).toMatchObject({
+      challenge_id: 'daily-fritz:2026-08-01:r2:s1',
+      authority_revision: 4,
+      event_version: 1,
+      source: 'client',
+      failure_phase: 'command',
+      recovery_class: 'authoritative_refresh',
+    });
   });
 });

--- a/server/src/http/stores/dailyFritzEventStore.ts
+++ b/server/src/http/stores/dailyFritzEventStore.ts
@@ -1,19 +1,18 @@
 import { supabaseFetch } from '../../supabaseUtils';
+import {
+  DAILY_FRITZ_TELEMETRY_VERSION,
+  classifyDailyFritzFailure,
+  type DailyFritzEventType,
+  type DailyFritzFailurePhase,
+  type DailyFritzRecoveryClass,
+} from '../../dailyFritzTelemetry';
+import { isDailyFritzTransactionalAuthorityEnabled } from '../../dailyFritzAuthorityFeature';
+
+export type { DailyFritzEventType } from '../../dailyFritzTelemetry';
 
 export const DAILY_FRITZ_EVENT_WRITE_TIMEOUT_MS = 2_500;
 
 let dailyFritzEventsPersistenceAvailable: boolean | null = null;
-
-export type DailyFritzEventType =
-  | 'attempt_started'
-  | 'hand_verified'
-  | 'next_hand_replayed'
-  | 'game_recorded'
-  | 'attempt_completed'
-  | 'attempt_abandoned'
-  | 'verification_failed'
-  | 'request_failed'
-  | 'retry_request';
 
 export type DailyFritzEventInput = {
   attemptId?: string | null;
@@ -26,6 +25,14 @@ export type DailyFritzEventInput = {
   statusCode?: number | null;
   verifierCode?: string | null;
   transcriptDigest?: string | null;
+  challengeId?: string | null;
+  authorityRevision?: number | null;
+  source?: 'server' | 'client' | 'outbox';
+  sessionId?: string | null;
+  clientRelease?: string | null;
+  durationMs?: number | null;
+  failurePhase?: DailyFritzFailurePhase | null;
+  recoveryClass?: DailyFritzRecoveryClass | null;
   idempotencyKey: string;
   payload?: Record<string, unknown>;
 };
@@ -46,6 +53,7 @@ export type DailyFritzPersistedMetricRow = {
  * retries safe even when a client loses the response after the DB write.
  */
 export async function recordDailyFritzEvent(event: DailyFritzEventInput): Promise<void> {
+  const failure = classifyDailyFritzFailure(event.verifierCode);
   await supabaseFetch('/rest/v1/daily_fritz_events?on_conflict=idempotency_key', {
     method: 'POST',
     headers: {
@@ -63,6 +71,17 @@ export async function recordDailyFritzEvent(event: DailyFritzEventInput): Promis
       status_code: event.statusCode ?? null,
       verifier_code: event.verifierCode ?? null,
       transcript_digest: event.transcriptDigest ?? null,
+      ...(isDailyFritzTransactionalAuthorityEnabled() ? {
+        challenge_id: event.challengeId ?? null,
+        authority_revision: event.authorityRevision ?? null,
+        event_version: DAILY_FRITZ_TELEMETRY_VERSION,
+        source: event.source ?? 'server',
+        session_id: event.sessionId ?? null,
+        client_release: event.clientRelease ?? null,
+        duration_ms: event.durationMs ?? null,
+        failure_phase: event.failurePhase ?? failure.phase,
+        recovery_class: event.recoveryClass ?? failure.recoveryClass,
+      } : {}),
       idempotency_key: event.idempotencyKey,
       payload: event.payload ?? {},
     }]),

--- a/server/src/http/stores/dailyFritzPublishedChallengeStore.test.ts
+++ b/server/src/http/stores/dailyFritzPublishedChallengeStore.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from 'vitest';
+import { buildDailyFritzPublishedChallenge, getDailyFritzPublishedChallengeContent } from '../../dailyFritzPublishedChallenge';
+import {
+  getDailyFritzPublishedChallenge,
+  invalidateDailyFritzPublishedChallenge,
+  publishDailyFritzChallenge,
+  type DailyFritzPublishedChallengeRow,
+  type DailyFritzPublishedChallengeStoreDeps,
+} from './dailyFritzPublishedChallengeStore';
+
+function rowFor(
+  challenge: ReturnType<typeof buildDailyFritzPublishedChallenge>,
+): DailyFritzPublishedChallengeRow {
+  return {
+    challenge_id: challenge.challengeId,
+    run_date: challenge.runDate,
+    contract_version: challenge.contractVersion,
+    generation_version: challenge.generationVersion,
+    seed_version: challenge.seedVersion,
+    product_rules_version: challenge.productRulesVersion,
+    game_rules_version: challenge.gameRulesVersion,
+    transcript_protocol_version: challenge.transcriptProtocolVersion,
+    verifier_version: challenge.verifierVersion,
+    fritz_policy_version: challenge.fritzPolicyVersion,
+    fritz_policy_contract: challenge.fritzPolicyContract,
+    ranking_version: challenge.rankingVersion,
+    time_zone: challenge.timeZone,
+    content_digest: challenge.contentDigest,
+    package: getDailyFritzPublishedChallengeContent(challenge),
+    status: challenge.status,
+    published_at: challenge.publishedAt,
+    invalidated_at: challenge.invalidatedAt,
+    invalidation_reason: challenge.invalidationReason,
+  };
+}
+
+describe('Daily Fritz published challenge store', () => {
+  it('publishes through the identity-conflict-safe RPC', async () => {
+    const challenge = buildDailyFritzPublishedChallenge({
+      runDate: '2026-08-01',
+      publishedAt: '2026-08-01T07:00:00.000Z',
+    });
+    const fetch = vi.fn(async () => [rowFor(challenge)]) as DailyFritzPublishedChallengeStoreDeps['fetch'];
+
+    await expect(publishDailyFritzChallenge(challenge, { fetch }))
+      .resolves.toMatchObject({ challengeId: challenge.challengeId, contentDigest: challenge.contentDigest });
+    expect(fetch).toHaveBeenCalledWith(
+      '/rest/v1/rpc/publish_daily_fritz_challenge',
+      expect.objectContaining({ method: 'POST' }),
+    );
+    const body = JSON.parse(String(fetch.mock.calls[0]?.[1]?.body));
+    expect(body.p_package).not.toHaveProperty('publishedAt');
+    expect(body.p_content_digest).toBe(challenge.contentDigest);
+  });
+
+  it('reads and validates immutable package/column parity', async () => {
+    const challenge = buildDailyFritzPublishedChallenge({ runDate: '2026-08-01' });
+    const fetch = vi.fn(async () => [rowFor(challenge)]) as DailyFritzPublishedChallengeStoreDeps['fetch'];
+    await expect(getDailyFritzPublishedChallenge(challenge.challengeId, { fetch }))
+      .resolves.toMatchObject({ challengeId: challenge.challengeId });
+  });
+
+  it('fails closed when indexed version columns disagree with package authority', async () => {
+    const challenge = buildDailyFritzPublishedChallenge({ runDate: '2026-08-01' });
+    const fetch = vi.fn(async () => [{ ...rowFor(challenge), game_rules_version: 999 }]) as DailyFritzPublishedChallengeStoreDeps['fetch'];
+    await expect(getDailyFritzPublishedChallenge(challenge.challengeId, { fetch }))
+      .rejects.toThrow('columns do not match');
+  });
+
+  it('invalidates legacy and published authority through one RPC', async () => {
+    const live = buildDailyFritzPublishedChallenge({ runDate: '2026-08-01' });
+    const invalidated = {
+      ...live,
+      status: 'invalidated' as const,
+      invalidatedAt: '2026-08-01T20:00:00.000Z',
+      invalidationReason: 'operator test',
+    };
+    const fetch = vi.fn(async () => [rowFor(invalidated)]) as DailyFritzPublishedChallengeStoreDeps['fetch'];
+    await expect(invalidateDailyFritzPublishedChallenge(live.runDate, 'operator test', { fetch }))
+      .resolves.toMatchObject({ status: 'invalidated', invalidationReason: 'operator test' });
+    expect(fetch).toHaveBeenCalledWith(
+      '/rest/v1/rpc/invalidate_daily_fritz_challenge',
+      expect.objectContaining({ method: 'POST' }),
+    );
+  });
+});

--- a/server/src/http/stores/dailyFritzPublishedChallengeStore.ts
+++ b/server/src/http/stores/dailyFritzPublishedChallengeStore.ts
@@ -1,0 +1,128 @@
+import { supabaseFetch } from '../../supabaseUtils';
+import {
+  assertValidDailyFritzPublishedChallenge,
+  getDailyFritzPublishedChallengeContent,
+  type DailyFritzPublishedChallenge,
+  type DailyFritzPublishedChallengeContent,
+} from '../../dailyFritzPublishedChallenge';
+import type { DailyFritzRunStatus } from '../../dailyFritz';
+
+export type DailyFritzPublishedChallengeRow = {
+  challenge_id: string;
+  run_date: string;
+  contract_version: number;
+  generation_version: number;
+  seed_version: number;
+  product_rules_version: number;
+  game_rules_version: number;
+  transcript_protocol_version: number;
+  verifier_version: number;
+  fritz_policy_version: number;
+  fritz_policy_contract: string;
+  ranking_version: number;
+  time_zone: string;
+  content_digest: string;
+  package: DailyFritzPublishedChallengeContent;
+  status: DailyFritzRunStatus;
+  published_at: string;
+  invalidated_at: string | null;
+  invalidation_reason: string | null;
+};
+
+export type DailyFritzPublishedChallengeStoreDeps = {
+  fetch: typeof supabaseFetch;
+};
+
+const DEFAULT_DEPS: DailyFritzPublishedChallengeStoreDeps = { fetch: supabaseFetch };
+
+export function toDailyFritzPublishedChallenge(
+  row: DailyFritzPublishedChallengeRow,
+): DailyFritzPublishedChallenge {
+  const challenge = {
+    ...row.package,
+    status: row.status,
+    contentDigest: row.content_digest,
+    publishedAt: row.published_at,
+    invalidatedAt: row.invalidated_at,
+    invalidationReason: row.invalidation_reason,
+  } as DailyFritzPublishedChallenge;
+  assertValidDailyFritzPublishedChallenge(challenge);
+  if (
+    row.challenge_id !== challenge.challengeId
+    || row.run_date !== challenge.runDate
+    || row.contract_version !== challenge.contractVersion
+    || row.generation_version !== challenge.generationVersion
+    || row.seed_version !== challenge.seedVersion
+    || row.product_rules_version !== challenge.productRulesVersion
+    || row.game_rules_version !== challenge.gameRulesVersion
+    || row.transcript_protocol_version !== challenge.transcriptProtocolVersion
+    || row.verifier_version !== challenge.verifierVersion
+    || row.fritz_policy_version !== challenge.fritzPolicyVersion
+    || row.fritz_policy_contract !== challenge.fritzPolicyContract
+    || row.ranking_version !== challenge.rankingVersion
+    || row.time_zone !== challenge.timeZone
+  ) {
+    throw new Error('Published Daily Fritz challenge columns do not match the immutable package.');
+  }
+  return challenge;
+}
+
+export async function getDailyFritzPublishedChallenge(
+  challengeId: string,
+  deps: DailyFritzPublishedChallengeStoreDeps = DEFAULT_DEPS,
+): Promise<DailyFritzPublishedChallenge | null> {
+  const rows = await deps.fetch<DailyFritzPublishedChallengeRow[]>(
+    `/rest/v1/daily_fritz_published_challenges?select=*&challenge_id=eq.${encodeURIComponent(challengeId)}&limit=1`,
+    { method: 'GET' },
+  );
+  return rows?.[0] ? toDailyFritzPublishedChallenge(rows[0]) : null;
+}
+
+export async function publishDailyFritzChallenge(
+  challenge: DailyFritzPublishedChallenge,
+  deps: DailyFritzPublishedChallengeStoreDeps = DEFAULT_DEPS,
+): Promise<DailyFritzPublishedChallenge> {
+  assertValidDailyFritzPublishedChallenge(challenge);
+  const rows = await deps.fetch<DailyFritzPublishedChallengeRow[]>(
+    '/rest/v1/rpc/publish_daily_fritz_challenge',
+    {
+      method: 'POST',
+      body: JSON.stringify({
+        p_challenge_id: challenge.challengeId,
+        p_run_date: challenge.runDate,
+        p_contract_version: challenge.contractVersion,
+        p_generation_version: challenge.generationVersion,
+        p_seed_version: challenge.seedVersion,
+        p_product_rules_version: challenge.productRulesVersion,
+        p_game_rules_version: challenge.gameRulesVersion,
+        p_transcript_protocol_version: challenge.transcriptProtocolVersion,
+        p_verifier_version: challenge.verifierVersion,
+        p_fritz_policy_version: challenge.fritzPolicyVersion,
+        p_fritz_policy_contract: challenge.fritzPolicyContract,
+        p_ranking_version: challenge.rankingVersion,
+        p_time_zone: challenge.timeZone,
+        p_content_digest: challenge.contentDigest,
+        p_package: getDailyFritzPublishedChallengeContent(challenge),
+        p_published_at: challenge.publishedAt,
+      }),
+    },
+  );
+  if (!rows?.[0]) throw new Error('Daily Fritz challenge publication was not confirmed.');
+  return toDailyFritzPublishedChallenge(rows[0]);
+}
+
+export async function invalidateDailyFritzPublishedChallenge(
+  runDate: string,
+  reason: string,
+  deps: DailyFritzPublishedChallengeStoreDeps = DEFAULT_DEPS,
+): Promise<DailyFritzPublishedChallenge> {
+  const rows = await deps.fetch<DailyFritzPublishedChallengeRow[]>(
+    '/rest/v1/rpc/invalidate_daily_fritz_challenge',
+    {
+      method: 'POST',
+      body: JSON.stringify({ p_run_date: runDate, p_reason: reason }),
+    },
+  );
+  if (!rows?.[0]) throw new Error('Daily Fritz challenge invalidation was not confirmed.');
+  return toDailyFritzPublishedChallenge(rows[0]);
+}

--- a/server/src/http/stores/dailyFritzStore.dealAuthority.test.ts
+++ b/server/src/http/stores/dailyFritzStore.dealAuthority.test.ts
@@ -1,11 +1,17 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 import { generateDailyFritzRun } from '../../dailyFritz';
 import {
   buildDailyFritzRunFingerprint,
   getDailyFritzHandForGame,
+  toDailyFritzAttemptRow,
 } from './dailyFritzStore';
 
 describe('Daily Fritz run deal authority', () => {
+  const originalAuthority = process.env.DAILY_FRITZ_TRANSACTIONAL_COMMANDS;
+  afterEach(() => {
+    if (originalAuthority === undefined) delete process.env.DAILY_FRITZ_TRANSACTIONAL_COMMANDS;
+    else process.env.DAILY_FRITZ_TRANSACTIONAL_COMMANDS = originalAuthority;
+  });
   it('prefers persisted game-1 hand deals over regenerated tiles', () => {
     const run = generateDailyFritzRun('2026-07-24', 'elite', 7, 60);
     const mutated = {
@@ -49,5 +55,22 @@ describe('Daily Fritz run deal authority', () => {
       )),
     };
     expect(buildDailyFritzRunFingerprint(altered)).not.toBe(a);
+  });
+
+  it('omits expanded columns until migration rollout is explicitly enabled', () => {
+    const record = {
+      id: 'attempt-1', runDate: '2026-08-01', userId: 'user-1', status: 'started' as const,
+      currentHandIndex: 0, currentGameNumber: 1 as const, revision: 2,
+      challengeId: 'challenge-1', challengeContractVersion: 1, generationVersion: 1,
+      gameRulesVersion: 1, transcriptProtocolVersion: 2, fritzPolicyVersion: 2,
+      rankingVersion: 1, authoritySchemaVersion: 1, startedAt: '2026-08-01T07:00:00Z',
+      completedAt: null, verifiedMatchId: null, completionHash: null, result: null,
+      finalScore: null, opponentScore: null, pointDiff: null, won: null,
+      movesUsed: null, handsPlayed: null,
+    };
+    delete process.env.DAILY_FRITZ_TRANSACTIONAL_COMMANDS;
+    expect(toDailyFritzAttemptRow(record)).not.toHaveProperty('revision');
+    process.env.DAILY_FRITZ_TRANSACTIONAL_COMMANDS = 'true';
+    expect(toDailyFritzAttemptRow(record)).toMatchObject({ revision: 2, challenge_id: 'challenge-1' });
   });
 });

--- a/server/src/http/stores/dailyFritzStore.ts
+++ b/server/src/http/stores/dailyFritzStore.ts
@@ -19,6 +19,15 @@ import {
 } from '../../dailyFritzSkunk';
 import { supabaseFetch } from '../../supabaseUtils';
 import { getPacificDateKey } from '../../shared/pacificDate';
+import { isDailyFritzTransactionalAuthorityEnabled } from '../../dailyFritzAuthorityFeature';
+
+const DAILY_FRITZ_ATTEMPT_LEGACY_COLUMNS =
+  'id,run_date,user_id,status,current_hand_index,started_at,completed_at,verified_match_id,completion_hash,result,final_score,opponent_score,point_diff,won,moves_used,hands_played';
+const DAILY_FRITZ_ATTEMPT_AUTHORITY_COLUMNS =
+  'current_game_number,revision,challenge_id,challenge_contract_version,generation_version,game_rules_version,transcript_protocol_version,fritz_policy_version,ranking_version,authority_schema_version';
+const getDailyFritzAttemptSelect = (): string => isDailyFritzTransactionalAuthorityEnabled()
+  ? `${DAILY_FRITZ_ATTEMPT_LEGACY_COLUMNS},${DAILY_FRITZ_ATTEMPT_AUTHORITY_COLUMNS}`
+  : DAILY_FRITZ_ATTEMPT_LEGACY_COLUMNS;
 
 export type DailyFritzRunRow = {
   run_date: string;
@@ -39,6 +48,16 @@ export type DailyFritzAttemptRow = {
   user_id: string;
   status: DailyFritzAttemptStatus;
   current_hand_index: number;
+  current_game_number?: number;
+  revision?: number;
+  challenge_id?: string | null;
+  challenge_contract_version?: number | null;
+  generation_version?: number | null;
+  game_rules_version?: number | null;
+  transcript_protocol_version?: number | null;
+  fritz_policy_version?: number | null;
+  ranking_version?: number | null;
+  authority_schema_version?: number;
   started_at: string;
   completed_at: string | null;
   verified_match_id: string | null;
@@ -79,6 +98,16 @@ export type DailyFritzAttemptRecord = {
   userId: string;
   status: DailyFritzAttemptStatus;
   currentHandIndex: number;
+  currentGameNumber: DailyFritzSetGameNumber;
+  revision: number;
+  challengeId: string | null;
+  challengeContractVersion: number | null;
+  generationVersion: number | null;
+  gameRulesVersion: number | null;
+  transcriptProtocolVersion: number | null;
+  fritzPolicyVersion: number | null;
+  rankingVersion: number | null;
+  authoritySchemaVersion: number;
   startedAt: string;
   completedAt: string | null;
   verifiedMatchId: string | null;
@@ -194,6 +223,16 @@ export function toDailyFritzAttemptRecord(row: DailyFritzAttemptRow): DailyFritz
     userId: row.user_id,
     status: row.status,
     currentHandIndex: Number(row.current_hand_index) || 0,
+    currentGameNumber: normalizeDailyFritzSetGameNumber(Number(row.current_game_number)) ?? 1,
+    revision: Math.max(0, Number(row.revision) || 0),
+    challengeId: typeof row.challenge_id === 'string' ? row.challenge_id : null,
+    challengeContractVersion: row.challenge_contract_version == null ? null : Number(row.challenge_contract_version),
+    generationVersion: row.generation_version == null ? null : Number(row.generation_version),
+    gameRulesVersion: row.game_rules_version == null ? null : Number(row.game_rules_version),
+    transcriptProtocolVersion: row.transcript_protocol_version == null ? null : Number(row.transcript_protocol_version),
+    fritzPolicyVersion: row.fritz_policy_version == null ? null : Number(row.fritz_policy_version),
+    rankingVersion: row.ranking_version == null ? null : Number(row.ranking_version),
+    authoritySchemaVersion: Math.max(1, Number(row.authority_schema_version) || 1),
     startedAt: row.started_at,
     completedAt: row.completed_at,
     verifiedMatchId: row.verified_match_id,
@@ -215,6 +254,18 @@ export function toDailyFritzAttemptRow(record: DailyFritzAttemptRecord): DailyFr
     user_id: record.userId,
     status: record.status,
     current_hand_index: record.currentHandIndex,
+    ...(isDailyFritzTransactionalAuthorityEnabled() ? {
+      current_game_number: record.currentGameNumber,
+      revision: record.revision,
+      challenge_id: record.challengeId,
+      challenge_contract_version: record.challengeContractVersion,
+      generation_version: record.generationVersion,
+      game_rules_version: record.gameRulesVersion,
+      transcript_protocol_version: record.transcriptProtocolVersion,
+      fritz_policy_version: record.fritzPolicyVersion,
+      ranking_version: record.rankingVersion,
+      authority_schema_version: record.authoritySchemaVersion,
+    } : {}),
     started_at: record.startedAt,
     completed_at: record.completedAt,
     verified_match_id: record.verifiedMatchId,
@@ -485,7 +536,7 @@ export async function ensureDailyFritzRunForDate(
 }
 export async function getDailyFritzAttempt(runDate: string, userId: string): Promise<DailyFritzAttemptRecord | null> {
   const rows = await supabaseFetch<DailyFritzAttemptRow[]>(
-    `/rest/v1/daily_fritz_attempts?select=id,run_date,user_id,status,current_hand_index,started_at,completed_at,verified_match_id,completion_hash,result,final_score,opponent_score,point_diff,won,moves_used,hands_played&run_date=eq.${encodeURIComponent(runDate)}&user_id=eq.${encodeURIComponent(userId)}&limit=1`,
+    `/rest/v1/daily_fritz_attempts?select=${getDailyFritzAttemptSelect()}&run_date=eq.${encodeURIComponent(runDate)}&user_id=eq.${encodeURIComponent(userId)}&limit=1`,
     { method: 'GET' },
   );
   return rows[0] ? toDailyFritzAttemptRecord(rows[0]) : null;
@@ -496,7 +547,7 @@ export async function getDailyFritzAttemptById(
   userId: string,
 ): Promise<DailyFritzAttemptRecord | null> {
   const rows = await supabaseFetch<DailyFritzAttemptRow[]>(
-    `/rest/v1/daily_fritz_attempts?select=id,run_date,user_id,status,current_hand_index,started_at,completed_at,verified_match_id,completion_hash,result,final_score,opponent_score,point_diff,won,moves_used,hands_played&id=eq.${encodeURIComponent(attemptId)}&user_id=eq.${encodeURIComponent(userId)}&limit=1`,
+    `/rest/v1/daily_fritz_attempts?select=${getDailyFritzAttemptSelect()}&id=eq.${encodeURIComponent(attemptId)}&user_id=eq.${encodeURIComponent(userId)}&limit=1`,
     { method: 'GET' },
   );
   return rows[0] ? toDailyFritzAttemptRecord(rows[0]) : null;
@@ -541,7 +592,7 @@ export async function createDailyFritzAttempt(runDate: string, userId: string): 
 
 export async function listDailyFritzAttemptsForDate(runDate: string): Promise<DailyFritzAttemptRecord[]> {
   const rows = await supabaseFetch<DailyFritzAttemptRow[]>(
-    `/rest/v1/daily_fritz_attempts?select=id,run_date,user_id,status,current_hand_index,started_at,completed_at,verified_match_id,completion_hash,result,final_score,opponent_score,point_diff,won,moves_used,hands_played&run_date=eq.${encodeURIComponent(runDate)}&status=eq.completed&order=completed_at.asc,id.asc`,
+    `/rest/v1/daily_fritz_attempts?select=${getDailyFritzAttemptSelect()}&run_date=eq.${encodeURIComponent(runDate)}&status=eq.completed&order=completed_at.asc,id.asc`,
     { method: 'GET' },
   );
   return rows.map(toDailyFritzAttemptRecord);
@@ -550,7 +601,7 @@ export async function listDailyFritzAttemptsForDate(runDate: string): Promise<Da
 export async function listDailyFritzAttemptsForUser(userId: string, limit = 10): Promise<DailyFritzAttemptRecord[]> {
   const bounded = Math.max(1, Math.min(30, Math.floor(limit)));
   const rows = await supabaseFetch<DailyFritzAttemptRow[]>(
-    `/rest/v1/daily_fritz_attempts?select=id,run_date,user_id,status,current_hand_index,started_at,completed_at,verified_match_id,completion_hash,result,final_score,opponent_score,point_diff,won,moves_used,hands_played&user_id=eq.${encodeURIComponent(userId)}&status=eq.completed&order=run_date.desc,completed_at.desc&limit=${bounded}`,
+    `/rest/v1/daily_fritz_attempts?select=${getDailyFritzAttemptSelect()}&user_id=eq.${encodeURIComponent(userId)}&status=eq.completed&order=run_date.desc,completed_at.desc&limit=${bounded}`,
     { method: 'GET' },
   );
   return rows.map(toDailyFritzAttemptRecord);

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -281,6 +281,11 @@ import {
   getDailyFritzEventsPersistenceAvailability,
   probeDailyFritzEventsPersistence,
 } from './http/stores/dailyFritzEventStore';
+import {
+  getDailyFritzAuthoritySchemaAvailability,
+  probeDailyFritzAuthoritySchema,
+} from './http/stores/dailyFritzAuthorityReadiness';
+import { isDailyFritzTransactionalAuthorityEnabled } from './dailyFritzAuthorityFeature';
 import { registerRoomEventsRoutes } from './http/routes/roomEvents';
 import {
   listCompletedDailyFritzDatesForUser,
@@ -786,6 +791,9 @@ registerHealthRoutes({
   isRoomMatchLogsPersistenceAvailable,
   getDailyFritzEventsPersistenceAvailability,
   probeDailyFritzEventsPersistence,
+  isDailyFritzTransactionalAuthorityEnabled,
+  getDailyFritzAuthoritySchemaAvailability,
+  probeDailyFritzAuthoritySchema,
 });
 
 server.listen(PORT, () => {
@@ -807,6 +815,16 @@ server.listen(PORT, () => {
     })
     .catch((err) => {
       console.warn('[daily-fritz-events] startup probe error', err instanceof Error ? err.message : err);
+    });
+  void probeDailyFritzAuthoritySchema()
+    .then((ok) => {
+      console.log('[daily-fritz-authority] startup probe', {
+        enabled: isDailyFritzTransactionalAuthorityEnabled(),
+        schemaAvailable: ok,
+      });
+    })
+    .catch((err) => {
+      console.warn('[daily-fritz-authority] startup probe error', err instanceof Error ? err.message : err);
     });
   const serverUrl = config.serverUrl;
   if (serverUrl) {

--- a/server/src/platform/health/registerHealthRoutes.ts
+++ b/server/src/platform/health/registerHealthRoutes.ts
@@ -78,6 +78,9 @@ export type HealthRouteDeps = {
   isRoomMatchLogsPersistenceAvailable: () => boolean;
   getDailyFritzEventsPersistenceAvailability: () => boolean | null;
   probeDailyFritzEventsPersistence: () => Promise<boolean>;
+  isDailyFritzTransactionalAuthorityEnabled: () => boolean;
+  getDailyFritzAuthoritySchemaAvailability: () => boolean | null;
+  probeDailyFritzAuthoritySchema: () => Promise<boolean>;
 };
 
 export function registerHealthRoutes(deps: HealthRouteDeps): void {
@@ -92,6 +95,9 @@ export function registerHealthRoutes(deps: HealthRouteDeps): void {
     isRoomMatchLogsPersistenceAvailable,
     getDailyFritzEventsPersistenceAvailability,
     probeDailyFritzEventsPersistence,
+    isDailyFritzTransactionalAuthorityEnabled,
+    getDailyFritzAuthoritySchemaAvailability,
+    probeDailyFritzAuthoritySchema,
   } = deps;
 
   const getRuntimeStatusPayload = () => {
@@ -150,6 +156,17 @@ export function registerHealthRoutes(deps: HealthRouteDeps): void {
             return { ok: available, available };
           })()
         : { ok: false, available: false };
+    const dailyFritzAuthority =
+      requiredEnvOk && supabase.ok
+        ? await (async () => {
+            const enabled = isDailyFritzTransactionalAuthorityEnabled();
+            if (enabled && getDailyFritzAuthoritySchemaAvailability() !== true) {
+              await probeDailyFritzAuthoritySchema();
+            }
+            const available = !enabled || getDailyFritzAuthoritySchemaAvailability() === true;
+            return { ok: available, available, enabled };
+          })()
+        : { ok: false, available: false, enabled: isDailyFritzTransactionalAuthorityEnabled() };
 
     const todayPt = getPacificDateKey();
     let dailyPuzzleLadder: ReturnType<typeof assessDailyPuzzleLadderReadiness> & { ok: boolean };
@@ -182,7 +199,8 @@ export function registerHealthRoutes(deps: HealthRouteDeps): void {
     }
 
     const shuttingDown = isGracefulShutdownInProgress();
-    const ok = !shuttingDown && requiredEnvOk && supabase.ok && dailyPuzzleLadder.ok && dailyFritzEvents.ok;
+    const ok = !shuttingDown && requiredEnvOk && supabase.ok && dailyPuzzleLadder.ok
+      && dailyFritzEvents.ok && dailyFritzAuthority.ok;
 
     res.status(ok ? 200 : 503).json({
       ...getRuntimeStatusPayload(),
@@ -194,6 +212,7 @@ export function registerHealthRoutes(deps: HealthRouteDeps): void {
         supabase,
         roomMatchLogs,
         dailyFritzEvents,
+        dailyFritzAuthority,
         dailyPuzzleLadder,
       },
     });

--- a/server/src/scheduled/dailyWarmup.ts
+++ b/server/src/scheduled/dailyWarmup.ts
@@ -1,6 +1,9 @@
 import { dailyFritzRunCache, ensureDailyFritzRunForDate } from '../http/stores/dailyFritzStore';
+import { buildDailyFritzPublishedChallenge } from '../dailyFritzPublishedChallenge';
+import { publishDailyFritzChallenge } from '../http/stores/dailyFritzPublishedChallengeStore';
 import { ensureDailyPuzzleLadderForDate } from '../seedDailyPuzzleLadder';
 import { getNextPacificWarmupAt, getPacificDateKeyDaysFromNow } from '../shared/pacificDate';
+import { isDailyFritzTransactionalAuthorityEnabled } from '../dailyFritzAuthorityFeature';
 
 export function isTruthyEnvFlag(value: string | undefined): boolean {
   if (!value) return false;
@@ -30,12 +33,23 @@ async function warmDailyFritzRuns(reason: 'startup' | 'scheduled', runDates: str
         const beforeCached = dailyFritzRunCache.has(runDate);
         const warmedStartedAt = Date.now();
         const run = await ensureDailyFritzRunForDate(runDate);
+        const published = run && isDailyFritzTransactionalAuthorityEnabled()
+          ? await publishDailyFritzChallenge(buildDailyFritzPublishedChallenge({
+              runDate: run.runDate,
+              fritzTier: run.fritzTier,
+              dealSize: run.dealSize,
+              winningScore: run.winningScore,
+              publishedAt: run.generatedAt,
+            }))
+          : null;
         return {
           runDate,
           ms: Date.now() - warmedStartedAt,
           beforeCached,
           afterCached: dailyFritzRunCache.has(runDate),
           status: run?.status ?? null,
+          challengeId: published?.challengeId ?? null,
+          challengeDigest: published?.contentDigest ?? null,
         };
       }),
     );

--- a/server/src/testing/dailyFritzTranscriptDriver.test.ts
+++ b/server/src/testing/dailyFritzTranscriptDriver.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { FRITZ_POLICY_VERSION } from '@racehorse/game-core';
+import { generateSingleDailyFritzGameHand, getDailyFritzDrawWinner } from '../dailyFritz';
+import { verifyDailyFritzHand, createOfficialDailyFritzHandState } from '../dailyFritzVerifier';
+import { buildDailyFritzChallengeId } from '../dailyFritzIdentity';
+import { buildHonestDailyFritzHandTranscript } from './dailyFritzTranscriptDriver';
+
+describe('Daily Fritz protocol driver', () => {
+  it('produces evidence accepted by the real verifier with state digests required', () => {
+    const runDate = '2026-08-01';
+    const deal = generateSingleDailyFritzGameHand(runDate, 1, 0, 7);
+    const drawWinner = getDailyFritzDrawWinner(runDate, 1);
+    const input = {
+      challengeId: buildDailyFritzChallengeId(runDate),
+      attemptId: '00000000-0000-4000-8000-000000000001',
+      gameNumber: 1 as const,
+      handIndex: 0,
+      deal,
+      drawWinner,
+      winningScore: 60,
+      dealSize: 7 as const,
+      playerScore: 0,
+      fritzScore: 0,
+      fritzTier: 'elite' as const,
+      fritzPolicyVersion: FRITZ_POLICY_VERSION,
+    };
+    const driven = buildHonestDailyFritzHandTranscript(input);
+    const verified = verifyDailyFritzHand({
+      transcript: driven.transcript,
+      initialState: createOfficialDailyFritzHandState(input),
+      expectedChallengeId: input.challengeId,
+      expectedAttemptId: input.attemptId,
+      expectedGameNumber: 1,
+      expectedHandIndex: 0,
+      userId: 'user-1',
+      fritzTier: input.fritzTier,
+      expectedFritzPolicyVersion: input.fritzPolicyVersion,
+      expectedFritzPolicyContract: driven.transcript.fritzPolicyContract,
+      requireStateDigests: true,
+    });
+    expect(verified.terminalState.handOver).toBe(true);
+    expect(verified.result.actionCount).toBe(driven.transcript.actions.length);
+  });
+});

--- a/server/src/testing/dailyFritzTranscriptDriver.ts
+++ b/server/src/testing/dailyFritzTranscriptDriver.ts
@@ -1,0 +1,119 @@
+import {
+  DAILY_FRITZ_AUTHORITY_STATE_DIGEST_VERSION,
+  DAILY_FRITZ_TRANSCRIPT_PROTOCOL_VERSION,
+  GAME_RULES_VERSION,
+  applyGameCommand,
+  canDraw,
+  chooseOfficialFritzDecisionForVersion,
+  getDailyFritzAuthorityStateDigest,
+  getFritzPolicyContract,
+  getLegalMoves,
+  type DailyFritzTranscript,
+  type DailyFritzTranscriptAction,
+  type GameCommand,
+  type GameState,
+} from '@racehorse/game-core';
+import type { DailyFritzDrawWinner, DailyFritzHandDeal, DailyFritzTier } from '../dailyFritz';
+import { createOfficialDailyFritzHandState } from '../dailyFritzVerifier';
+
+export type DailyFritzProtocolHandInput = {
+  challengeId: string;
+  attemptId: string;
+  gameNumber: 1 | 2 | 3;
+  handIndex: number;
+  deal: DailyFritzHandDeal;
+  drawWinner: DailyFritzDrawWinner;
+  winningScore: number;
+  dealSize: 7 | 14;
+  playerScore: number;
+  fritzScore: number;
+  fritzTier: DailyFritzTier;
+  fritzPolicyVersion: 1 | 2;
+  clientRelease?: string;
+  playerPolicy?: 'first_legal' | 'last_legal';
+};
+
+/**
+ * Drives the real shared core and official Fritz policy to produce protocol
+ * evidence. This is test/soak infrastructure, not a second gameplay engine.
+ */
+export function buildHonestDailyFritzHandTranscript(input: DailyFritzProtocolHandInput): {
+  transcript: DailyFritzTranscript;
+  terminalState: GameState;
+} {
+  let state = createOfficialDailyFritzHandState({
+    deal: input.deal,
+    handIndex: input.handIndex,
+    drawWinner: input.drawWinner,
+    winningScore: input.winningScore,
+    dealSize: input.dealSize,
+    playerScore: input.playerScore,
+    fritzScore: input.fritzScore,
+  });
+  const actions: DailyFritzTranscriptAction[] = [];
+
+  for (let sequence = 0; sequence < 512 && !state.handOver; sequence += 1) {
+    const actorId = state.playerIds[state.currentPlayerIndex];
+    const actor = actorId === 'player' ? 'player' as const : 'fritz' as const;
+    const preStateDigest = getDailyFritzAuthorityStateDigest(state);
+    const decision = actor === 'fritz'
+      ? chooseOfficialFritzDecisionForVersion({
+          version: input.fritzPolicyVersion,
+          state,
+          participantId: 'fritz',
+          tier: input.fritzTier,
+        })
+      : (() => {
+          const legalPlays = getLegalMoves(state, 'player').filter((move) => move.type === 'play');
+          const play = input.playerPolicy === 'last_legal'
+            ? legalPlays[legalPlays.length - 1]
+            : legalPlays[0];
+          if (play?.type === 'play') {
+            return { kind: 'play' as const, tile: play.tile, position: play.position };
+          }
+          return canDraw(state, 'player')
+            ? { kind: 'draw' as const }
+            : { kind: 'pass' as const };
+        })();
+    const action: DailyFritzTranscriptAction = decision.kind === 'play'
+      ? { sequence, actor, kind: 'play', tile: decision.tile, position: decision.position, preStateDigest }
+      : { sequence, actor, kind: decision.kind, preStateDigest };
+    actions.push(action);
+    const command: GameCommand = action.kind === 'play'
+      ? {
+          version: 1,
+          commandId: `protocol-driver:${input.gameNumber}:${input.handIndex}:${sequence}`,
+          sequence: state.sequence,
+          actorId,
+          kind: 'play',
+          tile: action.tile,
+          position: action.position,
+        }
+      : {
+          version: 1,
+          commandId: `protocol-driver:${input.gameNumber}:${input.handIndex}:${sequence}`,
+          sequence: state.sequence,
+          actorId,
+          kind: action.kind,
+        };
+    state = applyGameCommand(state, command).state;
+  }
+
+  if (!state.handOver) throw new Error('Daily Fritz protocol driver exceeded 512 actions.');
+  return {
+    terminalState: state,
+    transcript: {
+      protocolVersion: DAILY_FRITZ_TRANSCRIPT_PROTOCOL_VERSION,
+      rulesVersion: GAME_RULES_VERSION,
+      fritzPolicyVersion: input.fritzPolicyVersion,
+      fritzPolicyContract: getFritzPolicyContract(input.fritzPolicyVersion),
+      stateDigestVersion: DAILY_FRITZ_AUTHORITY_STATE_DIGEST_VERSION,
+      clientRelease: input.clientRelease ?? 'daily-fritz-authority-soak',
+      challengeId: input.challengeId,
+      attemptId: input.attemptId,
+      gameNumber: input.gameNumber,
+      handIndex: input.handIndex,
+      actions,
+    },
+  };
+}

--- a/server/tsconfig.scripts.json
+++ b/server/tsconfig.scripts.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": ["scripts/**/*.ts", "src/**/*.ts"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/server/vitest.config.ts
+++ b/server/vitest.config.ts
@@ -4,5 +4,10 @@ export default defineConfig({
   test: {
     exclude: ['**/node_modules/**', '**/dist/**'],
     include: ['src/**/*.test.ts'],
+    // The server suite imports several large route/game graphs. Multiple fork
+    // heaps exceed GitHub's runner memory near the end of an otherwise green
+    // run. One isolated worker is faster than CI retries and completes in ~15s.
+    fileParallelism: false,
+    maxWorkers: 1,
   },
 });

--- a/supabase/README.md
+++ b/supabase/README.md
@@ -18,6 +18,61 @@ VITE_ADMIN_EMAIL=you@example.com
 8. Start the client normally (`npm run dev` in `client/`).
 9. In `supabase/daily_puzzle.sql`, replace `admin@example.com` with the same email as `VITE_ADMIN_EMAIL` before running it.
 
+## Daily Fritz transactional-authority upgrade (2026-08-01)
+
+Keep `DAILY_FRITZ_TRANSACTIONAL_COMMANDS=false` while applying these files in this exact order:
+
+1. `supabase/migrations/2026-08-01_daily_fritz_published_challenges.sql`
+2. `supabase/migrations/2026-08-01_daily_fritz_command_primitives.sql`
+3. `supabase/migrations/2026-08-01_daily_fritz_transactional_commands.sql`
+4. `supabase/migrations/2026-08-01_daily_fritz_canonical_telemetry.sql`
+
+`supabase/verified_matches.sql` must already be installed because transactional
+attempt creation links its verified match in the same transaction.
+
+Verify the expansion before enabling writes:
+
+```sql
+select
+  to_regclass('public.daily_fritz_published_challenges') as published_challenges,
+  to_regclass('public.daily_fritz_attempt_operations') as operation_receipts,
+  to_regclass('public.daily_fritz_verified_hands') as verified_hands,
+  to_regclass('public.daily_fritz_verified_games') as verified_games,
+  to_regclass('public.daily_fritz_outbox') as outbox,
+  to_regclass('public.daily_fritz_funnel_metrics') as funnel_metrics,
+  to_regclass('public.daily_fritz_failure_metrics') as failure_metrics,
+  to_regclass('public.daily_fritz_retention_metrics') as retention_metrics;
+
+select column_name
+from information_schema.columns
+where table_schema = 'public'
+  and table_name = 'daily_fritz_attempts'
+  and column_name in ('revision', 'challenge_id', 'current_game_number')
+order by column_name;
+
+select routine_name
+from information_schema.routines
+where routine_schema = 'public'
+  and routine_name in (
+    'publish_daily_fritz_challenge',
+    'invalidate_daily_fritz_challenge',
+    'start_daily_fritz_attempt_command',
+    'commit_daily_fritz_attempt_command'
+  )
+order by routine_name;
+```
+
+All eight objects, all three columns, and all four routines must be present.
+Then set `DAILY_FRITZ_TRANSACTIONAL_COMMANDS=true` on every server instance and
+redeploy. `/ready` reports `checks.dailyFritzAuthority.enabled=true` and must
+report `available=true` before traffic is considered ready.
+
+Rollback is application-only: set the flag to `false` and redeploy. The schema
+is additive and should remain in place; do not drop authority records during a
+rollback. Legacy attempts remain available. Challenge-bound modern attempts
+fail closed with `authority_temporarily_unavailable` until transactional
+authority is re-enabled; they never fall back to legacy writes.
+
 ## Daily Fritz migration verification
 
 Run this in the Supabase SQL Editor after the migration:

--- a/supabase/daily_fritz.sql
+++ b/supabase/daily_fritz.sql
@@ -119,3 +119,173 @@ create policy "daily_fritz_events_no_client_access"
   to authenticated
   using (false)
   with check (false);
+
+-- Immutable challenge publication. Keep this canonical schema in sync with
+-- migrations/2026-08-01_daily_fritz_published_challenges.sql.
+create table if not exists public.daily_fritz_published_challenges (
+  challenge_id text primary key,
+  run_date date not null,
+  contract_version int not null,
+  generation_version int not null,
+  seed_version int not null,
+  product_rules_version int not null,
+  game_rules_version int not null,
+  transcript_protocol_version int not null,
+  verifier_version int not null,
+  fritz_policy_version int not null,
+  fritz_policy_contract text not null,
+  ranking_version int not null,
+  time_zone text not null,
+  content_digest text not null,
+  package jsonb not null,
+  status text not null check (status in ('live', 'archived', 'invalidated')),
+  published_at timestamptz not null default now(),
+  invalidated_at timestamptz null,
+  invalidation_reason text null,
+  constraint daily_fritz_published_challenges_date_version_key unique (run_date, contract_version),
+  constraint daily_fritz_published_challenges_digest_key unique (content_digest),
+  constraint daily_fritz_published_challenges_digest_format check (content_digest ~ '^[0-9a-f]{64}$'),
+  constraint daily_fritz_published_challenges_invalidation_check check (status <> 'invalidated' or invalidated_at is not null)
+);
+
+create index if not exists idx_daily_fritz_published_challenges_date_status
+  on public.daily_fritz_published_challenges (run_date desc, status);
+
+alter table public.daily_fritz_published_challenges enable row level security;
+
+create or replace function public.protect_daily_fritz_published_challenge()
+returns trigger language plpgsql set search_path = public as $$
+begin
+  if old.status = 'invalidated' and new is distinct from old then
+    raise exception 'daily_fritz_invalidated_challenge_is_final';
+  end if;
+  if old.challenge_id <> new.challenge_id or old.run_date <> new.run_date
+    or old.contract_version <> new.contract_version or old.generation_version <> new.generation_version
+    or old.seed_version <> new.seed_version or old.product_rules_version <> new.product_rules_version
+    or old.game_rules_version <> new.game_rules_version or old.transcript_protocol_version <> new.transcript_protocol_version
+    or old.verifier_version <> new.verifier_version or old.fritz_policy_version <> new.fritz_policy_version
+    or old.fritz_policy_contract <> new.fritz_policy_contract or old.ranking_version <> new.ranking_version
+    or old.time_zone <> new.time_zone or old.content_digest <> new.content_digest
+    or old.package <> new.package or old.published_at <> new.published_at then
+    raise exception 'daily_fritz_published_challenge_is_immutable';
+  end if;
+  return new;
+end;
+$$;
+
+drop trigger if exists protect_daily_fritz_published_challenge on public.daily_fritz_published_challenges;
+create trigger protect_daily_fritz_published_challenge
+before update on public.daily_fritz_published_challenges
+for each row execute function public.protect_daily_fritz_published_challenge();
+
+create or replace function public.prevent_daily_fritz_published_challenge_delete()
+returns trigger language plpgsql set search_path = public as $$
+begin
+  raise exception 'daily_fritz_published_challenge_delete_forbidden';
+end;
+$$;
+drop trigger if exists prevent_daily_fritz_published_challenge_delete on public.daily_fritz_published_challenges;
+create trigger prevent_daily_fritz_published_challenge_delete
+before delete on public.daily_fritz_published_challenges
+for each row execute function public.prevent_daily_fritz_published_challenge_delete();
+
+drop policy if exists "daily_fritz_published_challenges_read" on public.daily_fritz_published_challenges;
+create policy "daily_fritz_published_challenges_read"
+  on public.daily_fritz_published_challenges for select to authenticated using (true);
+
+drop policy if exists "daily_fritz_published_challenges_no_client_write" on public.daily_fritz_published_challenges;
+create policy "daily_fritz_published_challenges_no_client_write"
+  on public.daily_fritz_published_challenges for all to authenticated using (false) with check (false);
+
+-- Transaction command primitives. Keep this canonical schema in sync with
+-- migrations/2026-08-01_daily_fritz_command_primitives.sql.
+alter table public.daily_fritz_attempts
+  add column if not exists revision bigint not null default 0,
+  add column if not exists challenge_id text null,
+  add column if not exists current_game_number int not null default 1 check (current_game_number between 1 and 3),
+  add column if not exists challenge_contract_version int null,
+  add column if not exists generation_version int null,
+  add column if not exists game_rules_version int null,
+  add column if not exists transcript_protocol_version int null,
+  add column if not exists fritz_policy_version int null,
+  add column if not exists ranking_version int null,
+  add column if not exists authority_schema_version int not null default 1;
+
+do $$
+begin
+  if not exists (select 1 from pg_constraint where conname = 'daily_fritz_attempts_challenge_id_fkey' and conrelid = 'public.daily_fritz_attempts'::regclass) then
+    alter table public.daily_fritz_attempts add constraint daily_fritz_attempts_challenge_id_fkey
+      foreign key (challenge_id) references public.daily_fritz_published_challenges(challenge_id) not valid;
+  end if;
+end;
+$$;
+
+create index if not exists idx_daily_fritz_attempts_challenge_user on public.daily_fritz_attempts (challenge_id, user_id);
+create index if not exists idx_daily_fritz_attempts_active_revision on public.daily_fritz_attempts (id, revision) where status = 'started';
+
+create table if not exists public.daily_fritz_attempt_operations (
+  id uuid primary key default gen_random_uuid(),
+  operation_id text not null check (char_length(operation_id) between 8 and 160),
+  attempt_id uuid not null references public.daily_fritz_attempts(id) on delete cascade,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  challenge_id text not null references public.daily_fritz_published_challenges(challenge_id),
+  command_type text not null check (command_type in ('start_attempt', 'accept_verified_hand', 'record_verified_game', 'finalize_verified_attempt', 'abandon_attempt')),
+  request_digest text not null check (request_digest ~ '^[0-9a-f]{64}$'),
+  expected_revision bigint not null check (expected_revision >= 0),
+  committed_revision bigint null check (committed_revision is null or committed_revision >= 0),
+  status text not null check (status in ('committed', 'rejected')),
+  response jsonb null,
+  error_code text null,
+  created_at timestamptz not null default now(),
+  committed_at timestamptz null,
+  unique (attempt_id, operation_id),
+  unique (user_id, challenge_id, operation_id),
+  check ((status = 'committed' and committed_revision is not null and response is not null and error_code is null) or (status = 'rejected' and error_code is not null))
+);
+
+create index if not exists idx_daily_fritz_attempt_operations_replay on public.daily_fritz_attempt_operations (attempt_id, operation_id, request_digest);
+create index if not exists idx_daily_fritz_attempt_operations_created on public.daily_fritz_attempt_operations (created_at desc);
+
+create table if not exists public.daily_fritz_verified_hands (
+  attempt_id uuid not null references public.daily_fritz_attempts(id) on delete cascade,
+  game_number int not null check (game_number between 1 and 3), hand_index int not null check (hand_index >= 0),
+  operation_id text not null, transcript_digest text not null check (transcript_digest ~ '^[0-9a-f]{64}$'),
+  action_count int not null check (action_count > 0), player_score_after int not null check (player_score_after >= 0),
+  fritz_score_after int not null check (fritz_score_after >= 0), winner text null check (winner is null or winner in ('player', 'fritz')),
+  verifier_version int not null, receipt jsonb not null, created_at timestamptz not null default now(),
+  primary key (attempt_id, game_number, hand_index), unique (attempt_id, operation_id)
+);
+
+create table if not exists public.daily_fritz_verified_games (
+  attempt_id uuid not null references public.daily_fritz_attempts(id) on delete cascade,
+  game_number int not null check (game_number between 1 and 3), operation_id text not null,
+  player_score int not null check (player_score >= 0), fritz_score int not null check (fritz_score >= 0), point_diff int not null,
+  player_won boolean not null, action_count int not null check (action_count > 0), hands_played int not null check (hands_played > 0),
+  result_digest text not null check (result_digest ~ '^[0-9a-f]{64}$'), receipt jsonb not null,
+  created_at timestamptz not null default now(), primary key (attempt_id, game_number), unique (attempt_id, operation_id)
+);
+
+create table if not exists public.daily_fritz_outbox (
+  id uuid primary key default gen_random_uuid(), attempt_id uuid null references public.daily_fritz_attempts(id) on delete cascade,
+  challenge_id text not null references public.daily_fritz_published_challenges(challenge_id), operation_id text not null,
+  event_type text not null, event_version int not null default 1, payload jsonb not null,
+  occurred_at timestamptz not null default now(), available_at timestamptz not null default now(), delivered_at timestamptz null,
+  delivery_attempts int not null default 0 check (delivery_attempts >= 0), last_error text null,
+  unique (challenge_id, operation_id, event_type)
+);
+
+create index if not exists idx_daily_fritz_outbox_pending on public.daily_fritz_outbox (available_at, occurred_at) where delivered_at is null;
+
+alter table public.daily_fritz_attempt_operations enable row level security;
+alter table public.daily_fritz_verified_hands enable row level security;
+alter table public.daily_fritz_verified_games enable row level security;
+alter table public.daily_fritz_outbox enable row level security;
+
+drop policy if exists "daily_fritz_attempt_operations_no_client_access" on public.daily_fritz_attempt_operations;
+create policy "daily_fritz_attempt_operations_no_client_access" on public.daily_fritz_attempt_operations for all to authenticated using (false) with check (false);
+drop policy if exists "daily_fritz_verified_hands_no_client_access" on public.daily_fritz_verified_hands;
+create policy "daily_fritz_verified_hands_no_client_access" on public.daily_fritz_verified_hands for all to authenticated using (false) with check (false);
+drop policy if exists "daily_fritz_verified_games_no_client_access" on public.daily_fritz_verified_games;
+create policy "daily_fritz_verified_games_no_client_access" on public.daily_fritz_verified_games for all to authenticated using (false) with check (false);
+drop policy if exists "daily_fritz_outbox_no_client_access" on public.daily_fritz_outbox;
+create policy "daily_fritz_outbox_no_client_access" on public.daily_fritz_outbox for all to authenticated using (false) with check (false);

--- a/supabase/migrations/2026-08-01_daily_fritz_canonical_telemetry.sql
+++ b/supabase/migrations/2026-08-01_daily_fritz_canonical_telemetry.sql
@@ -1,0 +1,133 @@
+alter table public.daily_fritz_events
+  add column if not exists challenge_id text null references public.daily_fritz_published_challenges(challenge_id),
+  add column if not exists authority_revision bigint null check (authority_revision is null or authority_revision >= 0),
+  add column if not exists event_version int not null default 1 check (event_version > 0),
+  add column if not exists source text not null default 'server' check (source in ('server', 'client', 'outbox')),
+  add column if not exists session_id text null,
+  add column if not exists client_release text null,
+  add column if not exists duration_ms int null check (duration_ms is null or duration_ms >= 0),
+  add column if not exists failure_phase text null check (
+    failure_phase is null or failure_phase in (
+      'challenge', 'start', 'verification', 'command', 'persistence',
+      'recovery', 'submission', 'unknown'
+    )
+  ),
+  add column if not exists recovery_class text null check (
+    recovery_class is null or recovery_class in (
+      'transparent_retry', 'authoritative_refresh', 'client_update_required',
+      'terminal_integrity_failure', 'not_applicable'
+    )
+  );
+
+alter table public.daily_fritz_outbox
+  add column if not exists analytics_projected_at timestamptz null;
+
+alter table public.daily_fritz_events
+  drop constraint if exists daily_fritz_events_event_type_check;
+alter table public.daily_fritz_events
+  add constraint daily_fritz_events_event_type_check check (event_type in (
+    'mode_impression', 'start_requested', 'attempt_started', 'attempt_resumed',
+    'first_move', 'hand_started', 'hand_verified', 'next_hand_replayed',
+    'game_started', 'game_recorded', 'set_continued', 'attempt_completed',
+    'attempt_abandoned', 'verification_failed', 'command_conflict',
+    'recovery_started', 'recovery_succeeded', 'recovery_failed',
+    'request_failed', 'retry_request', 'review_opened', 'leaderboard_opened',
+    'share_requested', 'share_completed'
+  ));
+
+create index if not exists idx_daily_fritz_events_challenge_funnel
+  on public.daily_fritz_events (challenge_id, event_type, created_at);
+create index if not exists idx_daily_fritz_events_user_retention
+  on public.daily_fritz_events (user_id, run_date, event_type, created_at);
+create index if not exists idx_daily_fritz_events_failures
+  on public.daily_fritz_events (failure_phase, recovery_class, verifier_code, created_at)
+  where event_type in ('verification_failed', 'command_conflict', 'recovery_failed', 'request_failed');
+
+create or replace function public.project_daily_fritz_outbox_event()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  event_user_id uuid;
+  event_run_date date;
+begin
+  select user_id, run_date into event_user_id, event_run_date
+    from public.daily_fritz_attempts where id = new.attempt_id;
+  insert into public.daily_fritz_events (
+    attempt_id, run_date, user_id, event_type, challenge_id,
+    authority_revision, event_version, source, game_number, hand_index,
+    idempotency_key, payload, created_at
+  ) values (
+    new.attempt_id, event_run_date, event_user_id, new.event_type, new.challenge_id,
+    case when jsonb_typeof(new.payload->'revision') = 'number'
+      then (new.payload->>'revision')::bigint else null end,
+    new.event_version, 'outbox',
+    case when jsonb_typeof(new.payload->'gameNumber') = 'number'
+      then (new.payload->>'gameNumber')::int else null end,
+    case when jsonb_typeof(new.payload->'handIndex') = 'number'
+      then (new.payload->>'handIndex')::int else null end,
+    'outbox:' || new.id::text, new.payload, new.occurred_at
+  ) on conflict (idempotency_key) do nothing;
+  update public.daily_fritz_outbox
+    set analytics_projected_at = now()
+    where id = new.id;
+  return new;
+end;
+$$;
+
+drop trigger if exists daily_fritz_outbox_project_event on public.daily_fritz_outbox;
+create trigger daily_fritz_outbox_project_event
+after insert on public.daily_fritz_outbox
+for each row execute function public.project_daily_fritz_outbox_event();
+
+create or replace view public.daily_fritz_funnel_metrics
+with (security_invoker = true) as
+select run_date, challenge_id, event_type, count(*)::bigint as total,
+  count(distinct user_id)::bigint as unique_users
+from public.daily_fritz_events
+group by run_date, challenge_id, event_type;
+
+create or replace view public.daily_fritz_failure_metrics
+with (security_invoker = true) as
+select run_date, challenge_id, failure_phase, recovery_class, verifier_code,
+  count(*)::bigint as total
+from public.daily_fritz_events
+where event_type in ('verification_failed', 'command_conflict', 'recovery_failed', 'request_failed')
+group by run_date, challenge_id, failure_phase, recovery_class, verifier_code;
+
+create or replace view public.daily_fritz_retention_metrics
+with (security_invoker = true) as
+with cohorts as (
+  select user_id, min(run_date) as cohort_date
+  from public.daily_fritz_events
+  where user_id is not null and run_date is not null
+    and event_type = 'attempt_started'
+  group by user_id
+), active_days as (
+  select distinct user_id, run_date
+  from public.daily_fritz_events
+  where user_id is not null and run_date is not null
+    and event_type in ('mode_impression', 'start_requested', 'attempt_started', 'attempt_resumed', 'first_move')
+)
+select c.cohort_date,
+  count(*)::bigint as cohort_users,
+  count(*) filter (where exists (
+    select 1 from active_days a
+    where a.user_id = c.user_id and a.run_date = c.cohort_date + 1
+  ))::bigint as next_day_returned_users,
+  count(*) filter (where exists (
+    select 1 from active_days a
+    where a.user_id = c.user_id
+      and a.run_date between c.cohort_date + 1 and c.cohort_date + 7
+  ))::bigint as seven_day_returned_users
+from cohorts c
+group by c.cohort_date;
+
+revoke all on public.daily_fritz_funnel_metrics from anon, authenticated;
+revoke all on public.daily_fritz_failure_metrics from anon, authenticated;
+revoke all on public.daily_fritz_retention_metrics from anon, authenticated;
+grant select on public.daily_fritz_funnel_metrics to service_role;
+grant select on public.daily_fritz_failure_metrics to service_role;
+grant select on public.daily_fritz_retention_metrics to service_role;

--- a/supabase/migrations/2026-08-01_daily_fritz_command_primitives.sql
+++ b/supabase/migrations/2026-08-01_daily_fritz_command_primitives.sql
@@ -1,0 +1,152 @@
+alter table public.daily_fritz_attempts
+  add column if not exists revision bigint not null default 0,
+  add column if not exists challenge_id text null,
+  add column if not exists current_game_number int not null default 1 check (current_game_number between 1 and 3),
+  add column if not exists challenge_contract_version int null,
+  add column if not exists generation_version int null,
+  add column if not exists game_rules_version int null,
+  add column if not exists transcript_protocol_version int null,
+  add column if not exists fritz_policy_version int null,
+  add column if not exists ranking_version int null,
+  add column if not exists authority_schema_version int not null default 1;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'daily_fritz_attempts_challenge_id_fkey'
+      and conrelid = 'public.daily_fritz_attempts'::regclass
+  ) then
+    alter table public.daily_fritz_attempts
+      add constraint daily_fritz_attempts_challenge_id_fkey
+      foreign key (challenge_id)
+      references public.daily_fritz_published_challenges(challenge_id)
+      not valid;
+  end if;
+end;
+$$;
+
+create index if not exists idx_daily_fritz_attempts_challenge_user
+  on public.daily_fritz_attempts (challenge_id, user_id);
+create index if not exists idx_daily_fritz_attempts_active_revision
+  on public.daily_fritz_attempts (id, revision)
+  where status = 'started';
+
+create table if not exists public.daily_fritz_attempt_operations (
+  id uuid primary key default gen_random_uuid(),
+  operation_id text not null check (char_length(operation_id) between 8 and 160),
+  attempt_id uuid not null references public.daily_fritz_attempts(id) on delete cascade,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  challenge_id text not null references public.daily_fritz_published_challenges(challenge_id),
+  command_type text not null check (command_type in (
+    'start_attempt', 'accept_verified_hand', 'record_verified_game',
+    'finalize_verified_attempt', 'abandon_attempt'
+  )),
+  request_digest text not null check (request_digest ~ '^[0-9a-f]{64}$'),
+  expected_revision bigint not null check (expected_revision >= 0),
+  committed_revision bigint null check (committed_revision is null or committed_revision >= 0),
+  status text not null check (status in ('committed', 'rejected')),
+  response jsonb null,
+  error_code text null,
+  created_at timestamptz not null default now(),
+  committed_at timestamptz null,
+  constraint daily_fritz_attempt_operations_attempt_operation_key
+    unique (attempt_id, operation_id),
+  constraint daily_fritz_attempt_operations_user_challenge_operation_key
+    unique (user_id, challenge_id, operation_id),
+  constraint daily_fritz_attempt_operations_terminal_shape check (
+    (status = 'committed' and committed_revision is not null and response is not null and error_code is null)
+    or (status = 'rejected' and error_code is not null)
+  )
+);
+
+create index if not exists idx_daily_fritz_attempt_operations_replay
+  on public.daily_fritz_attempt_operations (attempt_id, operation_id, request_digest);
+create index if not exists idx_daily_fritz_attempt_operations_created
+  on public.daily_fritz_attempt_operations (created_at desc);
+
+create table if not exists public.daily_fritz_verified_hands (
+  attempt_id uuid not null references public.daily_fritz_attempts(id) on delete cascade,
+  game_number int not null check (game_number between 1 and 3),
+  hand_index int not null check (hand_index >= 0),
+  operation_id text not null,
+  transcript_digest text not null check (transcript_digest ~ '^[0-9a-f]{64}$'),
+  action_count int not null check (action_count > 0),
+  player_score_after int not null check (player_score_after >= 0),
+  fritz_score_after int not null check (fritz_score_after >= 0),
+  winner text null check (winner is null or winner in ('player', 'fritz')),
+  verifier_version int not null,
+  receipt jsonb not null,
+  created_at timestamptz not null default now(),
+  primary key (attempt_id, game_number, hand_index),
+  constraint daily_fritz_verified_hands_operation_key unique (attempt_id, operation_id)
+);
+
+create index if not exists idx_daily_fritz_verified_hands_attempt_game
+  on public.daily_fritz_verified_hands (attempt_id, game_number, hand_index);
+
+create table if not exists public.daily_fritz_verified_games (
+  attempt_id uuid not null references public.daily_fritz_attempts(id) on delete cascade,
+  game_number int not null check (game_number between 1 and 3),
+  operation_id text not null,
+  player_score int not null check (player_score >= 0),
+  fritz_score int not null check (fritz_score >= 0),
+  point_diff int not null,
+  player_won boolean not null,
+  action_count int not null check (action_count > 0),
+  hands_played int not null check (hands_played > 0),
+  result_digest text not null check (result_digest ~ '^[0-9a-f]{64}$'),
+  receipt jsonb not null,
+  created_at timestamptz not null default now(),
+  primary key (attempt_id, game_number),
+  constraint daily_fritz_verified_games_operation_key unique (attempt_id, operation_id)
+);
+
+create table if not exists public.daily_fritz_outbox (
+  id uuid primary key default gen_random_uuid(),
+  attempt_id uuid null references public.daily_fritz_attempts(id) on delete cascade,
+  challenge_id text not null references public.daily_fritz_published_challenges(challenge_id),
+  operation_id text not null,
+  event_type text not null,
+  event_version int not null default 1,
+  payload jsonb not null,
+  occurred_at timestamptz not null default now(),
+  available_at timestamptz not null default now(),
+  delivered_at timestamptz null,
+  delivery_attempts int not null default 0 check (delivery_attempts >= 0),
+  last_error text null,
+  constraint daily_fritz_outbox_operation_event_key
+    unique (challenge_id, operation_id, event_type)
+);
+
+create index if not exists idx_daily_fritz_outbox_pending
+  on public.daily_fritz_outbox (available_at, occurred_at)
+  where delivered_at is null;
+
+alter table public.daily_fritz_attempt_operations enable row level security;
+alter table public.daily_fritz_verified_hands enable row level security;
+alter table public.daily_fritz_verified_games enable row level security;
+alter table public.daily_fritz_outbox enable row level security;
+
+drop policy if exists "daily_fritz_attempt_operations_no_client_access" on public.daily_fritz_attempt_operations;
+create policy "daily_fritz_attempt_operations_no_client_access"
+  on public.daily_fritz_attempt_operations for all to authenticated using (false) with check (false);
+
+drop policy if exists "daily_fritz_verified_hands_no_client_access" on public.daily_fritz_verified_hands;
+create policy "daily_fritz_verified_hands_no_client_access"
+  on public.daily_fritz_verified_hands for all to authenticated using (false) with check (false);
+
+drop policy if exists "daily_fritz_verified_games_no_client_access" on public.daily_fritz_verified_games;
+create policy "daily_fritz_verified_games_no_client_access"
+  on public.daily_fritz_verified_games for all to authenticated using (false) with check (false);
+
+drop policy if exists "daily_fritz_outbox_no_client_access" on public.daily_fritz_outbox;
+create policy "daily_fritz_outbox_no_client_access"
+  on public.daily_fritz_outbox for all to authenticated using (false) with check (false);
+
+comment on column public.daily_fritz_attempts.revision is
+  'Monotonic compare-and-swap revision. Every committed authority transition increments exactly once.';
+comment on table public.daily_fritz_attempt_operations is
+  'Durable idempotency receipts. The same operation and digest replays its response; digest reuse conflicts.';
+comment on table public.daily_fritz_outbox is
+  'Transactional event outbox. Analytics and social side effects consume this table and never own authority.';

--- a/supabase/migrations/2026-08-01_daily_fritz_published_challenges.sql
+++ b/supabase/migrations/2026-08-01_daily_fritz_published_challenges.sql
@@ -1,0 +1,240 @@
+create table if not exists public.daily_fritz_published_challenges (
+  challenge_id text primary key,
+  run_date date not null,
+  contract_version int not null,
+  generation_version int not null,
+  seed_version int not null,
+  product_rules_version int not null,
+  game_rules_version int not null,
+  transcript_protocol_version int not null,
+  verifier_version int not null,
+  fritz_policy_version int not null,
+  fritz_policy_contract text not null,
+  ranking_version int not null,
+  time_zone text not null,
+  content_digest text not null,
+  package jsonb not null,
+  status text not null check (status in ('live', 'archived', 'invalidated')),
+  published_at timestamptz not null default now(),
+  invalidated_at timestamptz null,
+  invalidation_reason text null,
+  constraint daily_fritz_published_challenges_date_version_key
+    unique (run_date, contract_version),
+  constraint daily_fritz_published_challenges_digest_key
+    unique (content_digest),
+  constraint daily_fritz_published_challenges_digest_format
+    check (content_digest ~ '^[0-9a-f]{64}$'),
+  constraint daily_fritz_published_challenges_invalidation_check
+    check (status <> 'invalidated' or invalidated_at is not null)
+);
+
+create index if not exists idx_daily_fritz_published_challenges_date_status
+  on public.daily_fritz_published_challenges (run_date desc, status);
+
+alter table public.daily_fritz_published_challenges enable row level security;
+
+create or replace function public.protect_daily_fritz_published_challenge()
+returns trigger
+language plpgsql
+set search_path = public
+as $$
+begin
+  if old.status = 'invalidated' and new is distinct from old then
+    raise exception 'daily_fritz_invalidated_challenge_is_final';
+  end if;
+  if old.challenge_id <> new.challenge_id
+    or old.run_date <> new.run_date
+    or old.contract_version <> new.contract_version
+    or old.generation_version <> new.generation_version
+    or old.seed_version <> new.seed_version
+    or old.product_rules_version <> new.product_rules_version
+    or old.game_rules_version <> new.game_rules_version
+    or old.transcript_protocol_version <> new.transcript_protocol_version
+    or old.verifier_version <> new.verifier_version
+    or old.fritz_policy_version <> new.fritz_policy_version
+    or old.fritz_policy_contract <> new.fritz_policy_contract
+    or old.ranking_version <> new.ranking_version
+    or old.time_zone <> new.time_zone
+    or old.content_digest <> new.content_digest
+    or old.package <> new.package
+    or old.published_at <> new.published_at then
+    raise exception 'daily_fritz_published_challenge_is_immutable';
+  end if;
+  return new;
+end;
+$$;
+
+drop trigger if exists protect_daily_fritz_published_challenge
+  on public.daily_fritz_published_challenges;
+create trigger protect_daily_fritz_published_challenge
+before update on public.daily_fritz_published_challenges
+for each row execute function public.protect_daily_fritz_published_challenge();
+
+create or replace function public.prevent_daily_fritz_published_challenge_delete()
+returns trigger
+language plpgsql
+set search_path = public
+as $$
+begin
+  raise exception 'daily_fritz_published_challenge_delete_forbidden';
+end;
+$$;
+
+drop trigger if exists prevent_daily_fritz_published_challenge_delete
+  on public.daily_fritz_published_challenges;
+create trigger prevent_daily_fritz_published_challenge_delete
+before delete on public.daily_fritz_published_challenges
+for each row execute function public.prevent_daily_fritz_published_challenge_delete();
+
+drop policy if exists "daily_fritz_published_challenges_read" on public.daily_fritz_published_challenges;
+create policy "daily_fritz_published_challenges_read"
+  on public.daily_fritz_published_challenges
+  for select
+  to authenticated
+  using (true);
+
+drop policy if exists "daily_fritz_published_challenges_no_client_write" on public.daily_fritz_published_challenges;
+create policy "daily_fritz_published_challenges_no_client_write"
+  on public.daily_fritz_published_challenges
+  for all
+  to authenticated
+  using (false)
+  with check (false);
+
+create or replace function public.publish_daily_fritz_challenge(
+  p_challenge_id text,
+  p_run_date date,
+  p_contract_version int,
+  p_generation_version int,
+  p_seed_version int,
+  p_product_rules_version int,
+  p_game_rules_version int,
+  p_transcript_protocol_version int,
+  p_verifier_version int,
+  p_fritz_policy_version int,
+  p_fritz_policy_contract text,
+  p_ranking_version int,
+  p_time_zone text,
+  p_content_digest text,
+  p_package jsonb,
+  p_published_at timestamptz
+)
+returns setof public.daily_fritz_published_challenges
+language plpgsql
+security definer
+set search_path = public
+as $$
+#variable_conflict use_column
+declare
+  published public.daily_fritz_published_challenges%rowtype;
+begin
+  insert into public.daily_fritz_published_challenges (
+    challenge_id,
+    run_date,
+    contract_version,
+    generation_version,
+    seed_version,
+    product_rules_version,
+    game_rules_version,
+    transcript_protocol_version,
+    verifier_version,
+    fritz_policy_version,
+    fritz_policy_contract,
+    ranking_version,
+    time_zone,
+    content_digest,
+    package,
+    status,
+    published_at
+  ) values (
+    p_challenge_id,
+    p_run_date,
+    p_contract_version,
+    p_generation_version,
+    p_seed_version,
+    p_product_rules_version,
+    p_game_rules_version,
+    p_transcript_protocol_version,
+    p_verifier_version,
+    p_fritz_policy_version,
+    p_fritz_policy_contract,
+    p_ranking_version,
+    p_time_zone,
+    p_content_digest,
+    p_package,
+    'live',
+    p_published_at
+  )
+  on conflict (challenge_id) do nothing;
+
+  select * into published
+    from public.daily_fritz_published_challenges
+    where challenge_id = p_challenge_id
+    for share;
+
+  if not found then
+    raise exception 'daily_fritz_challenge_publication_failed';
+  end if;
+  if published.content_digest <> p_content_digest or published.package <> p_package then
+    raise exception 'daily_fritz_challenge_identity_conflict';
+  end if;
+
+  return next published;
+end;
+$$;
+
+revoke all on function public.publish_daily_fritz_challenge(
+  text, date, int, int, int, int, int, int, int, int, text, int, text, text, jsonb, timestamptz
+) from public;
+revoke all on function public.publish_daily_fritz_challenge(
+  text, date, int, int, int, int, int, int, int, int, text, int, text, text, jsonb, timestamptz
+) from authenticated;
+grant execute on function public.publish_daily_fritz_challenge(
+  text, date, int, int, int, int, int, int, int, int, text, int, text, text, jsonb, timestamptz
+) to service_role;
+
+create or replace function public.invalidate_daily_fritz_challenge(
+  p_run_date date,
+  p_reason text
+)
+returns setof public.daily_fritz_published_challenges
+language plpgsql
+security definer
+set search_path = public
+as $$
+#variable_conflict use_column
+declare
+  published public.daily_fritz_published_challenges%rowtype;
+  v_invalidated_at timestamptz := now();
+begin
+  select * into published
+    from public.daily_fritz_published_challenges
+    where run_date = p_run_date
+    for update;
+  if not found then raise exception 'daily_fritz_published_challenge_missing'; end if;
+  if published.status = 'invalidated' then return next published; return; end if;
+
+  update public.daily_fritz_runs
+    set status = 'invalidated',
+        invalidated_at = v_invalidated_at,
+        metadata = coalesce(metadata, '{}'::jsonb)
+          || jsonb_build_object('invalidation_reason', nullif(trim(p_reason), ''))
+    where run_date = p_run_date;
+  if not found then raise exception 'daily_fritz_legacy_run_missing'; end if;
+
+  update public.daily_fritz_published_challenges
+    set status = 'invalidated',
+        invalidated_at = v_invalidated_at,
+        invalidation_reason = nullif(trim(p_reason), '')
+    where challenge_id = published.challenge_id
+    returning * into published;
+  return next published;
+end;
+$$;
+
+revoke all on function public.invalidate_daily_fritz_challenge(date, text) from public;
+revoke all on function public.invalidate_daily_fritz_challenge(date, text) from authenticated;
+grant execute on function public.invalidate_daily_fritz_challenge(date, text) to service_role;
+
+comment on table public.daily_fritz_published_challenges is
+  'Immutable, content-addressed Daily Fritz challenge packages. Rows are never updated except explicit status invalidation metadata.';

--- a/supabase/migrations/2026-08-01_daily_fritz_transactional_commands.sql
+++ b/supabase/migrations/2026-08-01_daily_fritz_transactional_commands.sql
@@ -1,0 +1,407 @@
+create or replace function public.start_daily_fritz_attempt_command(
+  p_user_id uuid,
+  p_challenge_id text,
+  p_operation_id text,
+  p_request_digest text,
+  p_authority_result jsonb
+)
+returns table (
+  outcome text,
+  error_code text,
+  replayed boolean,
+  committed_revision bigint,
+  response jsonb
+)
+language plpgsql
+security definer
+set search_path = public
+as $$
+#variable_conflict use_column
+declare
+  challenge public.daily_fritz_published_challenges%rowtype;
+  attempt public.daily_fritz_attempts%rowtype;
+  existing_operation public.daily_fritz_attempt_operations%rowtype;
+  v_verified_match_id uuid;
+  created_attempt boolean := false;
+  command_response jsonb;
+begin
+  -- There is no attempt row to lock before the first start. Serialize the
+  -- user/challenge identity across every server instance and transaction.
+  perform pg_advisory_xact_lock(
+    hashtextextended(p_user_id::text || ':' || p_challenge_id, 0)
+  );
+  select * into existing_operation
+    from public.daily_fritz_attempt_operations
+    where user_id = p_user_id
+      and challenge_id = p_challenge_id
+      and operation_id = p_operation_id;
+  if found then
+    if existing_operation.command_type <> 'start_attempt'
+      or existing_operation.request_digest <> p_request_digest then
+      return query select 'conflict', 'operation_id_reused', false,
+        existing_operation.committed_revision, existing_operation.response;
+      return;
+    end if;
+    return query select existing_operation.status, existing_operation.error_code, true,
+      existing_operation.committed_revision, existing_operation.response;
+    return;
+  end if;
+
+  select * into challenge
+    from public.daily_fritz_published_challenges
+    where challenge_id = p_challenge_id
+    for share;
+  if not found or challenge.status <> 'live' then
+    return query select 'rejected', 'challenge_unavailable', false, null::bigint, null::jsonb;
+    return;
+  end if;
+
+  select * into attempt
+    from public.daily_fritz_attempts
+    where run_date = challenge.run_date and user_id = p_user_id
+    for update;
+
+  if not found then
+    insert into public.daily_fritz_attempts (
+      run_date, user_id, status, current_game_number, current_hand_index,
+      revision, challenge_id, challenge_contract_version, generation_version,
+      game_rules_version, transcript_protocol_version, fritz_policy_version,
+      ranking_version, authority_schema_version, result
+    ) values (
+      challenge.run_date, p_user_id, 'started', 1, 0,
+      1, challenge.challenge_id, challenge.contract_version, challenge.generation_version,
+      challenge.game_rules_version, challenge.transcript_protocol_version,
+      challenge.fritz_policy_version, challenge.ranking_version, 1, p_authority_result
+    ) returning * into attempt;
+    created_attempt := true;
+  elsif attempt.challenge_id is distinct from p_challenge_id
+    or attempt.status <> 'started' then
+    return query select 'rejected', 'attempt_not_startable', false,
+      attempt.revision, jsonb_build_object(
+        'attempt_id', attempt.id, 'status', attempt.status, 'revision', attempt.revision
+      );
+    return;
+  end if;
+
+  if attempt.verified_match_id is null then
+    v_verified_match_id := gen_random_uuid();
+    insert into public.verified_single_player_matches (
+      match_id, user_id, local_match_id, mode, opponent_user_id,
+      fritz_tier, status, started_at
+    ) values (
+      v_verified_match_id, p_user_id,
+      'daily-fritz:' || challenge.run_date::text || ':' || attempt.id::text,
+      'fritz', null, challenge.package->>'fritzTier', 'started', now()
+    ) on conflict (user_id, local_match_id) do nothing;
+
+    select match_id into v_verified_match_id
+      from public.verified_single_player_matches
+      where user_id = p_user_id
+        and local_match_id = 'daily-fritz:' || challenge.run_date::text || ':' || attempt.id::text;
+    update public.daily_fritz_attempts
+      set verified_match_id = v_verified_match_id
+      where id = attempt.id
+      returning * into attempt;
+  end if;
+
+  command_response := jsonb_build_object(
+    'attempt_id', attempt.id,
+    'verified_match_id', attempt.verified_match_id,
+    'challenge_id', attempt.challenge_id,
+    'run_date', attempt.run_date,
+    'status', attempt.status,
+    'revision', attempt.revision,
+    'current_game_number', attempt.current_game_number,
+    'current_hand_index', attempt.current_hand_index,
+    'result', attempt.result,
+    'created', created_attempt
+  );
+
+  insert into public.daily_fritz_attempt_operations (
+    operation_id, attempt_id, user_id, challenge_id, command_type,
+    request_digest, expected_revision, committed_revision, status,
+    response, committed_at
+  ) values (
+    p_operation_id, attempt.id, p_user_id, p_challenge_id, 'start_attempt',
+    p_request_digest, 0, attempt.revision, 'committed', command_response, now()
+  );
+
+  insert into public.daily_fritz_outbox (
+    attempt_id, challenge_id, operation_id, event_type, payload
+  ) values (
+    attempt.id, p_challenge_id, p_operation_id,
+    case when created_attempt then 'attempt_started' else 'attempt_resumed' end,
+    jsonb_build_object('revision', attempt.revision)
+  ) on conflict (challenge_id, operation_id, event_type) do nothing;
+
+  return query select 'committed', null::text, false,
+    attempt.revision, command_response;
+end;
+$$;
+
+revoke all on function public.start_daily_fritz_attempt_command(uuid, text, text, text, jsonb) from public;
+revoke all on function public.start_daily_fritz_attempt_command(uuid, text, text, text, jsonb) from authenticated;
+grant execute on function public.start_daily_fritz_attempt_command(uuid, text, text, text, jsonb) to service_role;
+
+create or replace function public.commit_daily_fritz_attempt_command(
+  p_user_id uuid,
+  p_attempt_id uuid,
+  p_operation_id text,
+  p_command_type text,
+  p_request_digest text,
+  p_expected_revision bigint,
+  p_new_status text,
+  p_new_current_game_number int,
+  p_new_current_hand_index int,
+  p_new_result jsonb,
+  p_final_score int default null,
+  p_opponent_score int default null,
+  p_point_diff int default null,
+  p_won boolean default null,
+  p_moves_used int default null,
+  p_hands_played int default null,
+  p_completion_hash text default null,
+  p_hand_receipt jsonb default null,
+  p_game_receipt jsonb default null,
+  p_outbox_event_type text default null,
+  p_outbox_payload jsonb default '{}'::jsonb
+)
+returns table (
+  outcome text,
+  error_code text,
+  replayed boolean,
+  committed_revision bigint,
+  response jsonb
+)
+language plpgsql
+security definer
+set search_path = public
+as $$
+#variable_conflict use_column
+declare
+  attempt public.daily_fritz_attempts%rowtype;
+  existing_operation public.daily_fritz_attempt_operations%rowtype;
+  command_response jsonb;
+  receipt_game int;
+  receipt_hand int;
+begin
+  if p_command_type not in (
+    'accept_verified_hand', 'record_verified_game',
+    'finalize_verified_attempt', 'abandon_attempt'
+  ) then
+    return query select 'rejected', 'unsupported_command', false, null::bigint, null::jsonb;
+    return;
+  end if;
+
+  select * into attempt
+    from public.daily_fritz_attempts
+    where id = p_attempt_id and user_id = p_user_id
+    for update;
+  if not found then
+    return query select 'rejected', 'attempt_not_found', false, null::bigint, null::jsonb;
+    return;
+  end if;
+  -- Receipt lookup must occur after the attempt lock. Otherwise two server
+  -- instances can both observe "no receipt" before either commits.
+  select * into existing_operation
+    from public.daily_fritz_attempt_operations
+    where attempt_id = p_attempt_id and operation_id = p_operation_id;
+  if found then
+    if existing_operation.command_type <> p_command_type
+      or existing_operation.request_digest <> p_request_digest then
+      return query select 'conflict', 'command_slot_conflict', false,
+        existing_operation.committed_revision, existing_operation.response;
+      return;
+    end if;
+    return query select existing_operation.status, existing_operation.error_code, true,
+      existing_operation.committed_revision, existing_operation.response;
+    return;
+  end if;
+  if attempt.challenge_id is null then
+    return query select 'rejected', 'legacy_attempt_read_only', false,
+      attempt.revision, jsonb_build_object('attempt_id', attempt.id, 'revision', attempt.revision);
+    return;
+  end if;
+  if attempt.revision <> p_expected_revision then
+    command_response := jsonb_build_object(
+      'attempt_id', attempt.id, 'status', attempt.status, 'revision', attempt.revision,
+      'current_game_number', attempt.current_game_number,
+      'current_hand_index', attempt.current_hand_index, 'result', attempt.result
+    );
+    insert into public.daily_fritz_attempt_operations (
+      operation_id, attempt_id, user_id, challenge_id, command_type,
+      request_digest, expected_revision, status, response, error_code
+    ) values (
+      p_operation_id, attempt.id, p_user_id, attempt.challenge_id, p_command_type,
+      p_request_digest, p_expected_revision, 'rejected', command_response, 'stale_revision'
+    );
+    return query select 'rejected', 'stale_revision', false, attempt.revision, command_response;
+    return;
+  end if;
+  if attempt.status <> 'started' then
+    return query select 'rejected', 'attempt_not_active', false, attempt.revision,
+      jsonb_build_object('attempt_id', attempt.id, 'status', attempt.status, 'revision', attempt.revision);
+    return;
+  end if;
+
+  if p_command_type = 'accept_verified_hand' then
+    if p_hand_receipt is null then raise exception 'daily_fritz_hand_receipt_required'; end if;
+    receipt_game := (p_hand_receipt->>'gameNumber')::int;
+    receipt_hand := (p_hand_receipt->>'handIndex')::int;
+    if receipt_game <> attempt.current_game_number
+      or receipt_hand <> attempt.current_hand_index
+      or p_new_status <> 'started'
+      or p_new_current_game_number <> attempt.current_game_number
+      or p_new_current_hand_index <> attempt.current_hand_index + 1 then
+      raise exception 'daily_fritz_invalid_hand_transition';
+    end if;
+    insert into public.daily_fritz_verified_hands (
+      attempt_id, game_number, hand_index, operation_id, transcript_digest,
+      action_count, player_score_after, fritz_score_after, winner,
+      verifier_version, receipt
+    ) values (
+      attempt.id, receipt_game, receipt_hand, p_operation_id,
+      p_hand_receipt->>'transcriptDigest', (p_hand_receipt->>'actionCount')::int,
+      (p_hand_receipt->>'playerScoreAfter')::int, (p_hand_receipt->>'fritzScoreAfter')::int,
+      p_hand_receipt->>'winner', (p_hand_receipt->>'verificationVersion')::int,
+      p_hand_receipt
+    );
+  elsif p_command_type = 'record_verified_game' then
+    if p_game_receipt is null then raise exception 'daily_fritz_game_receipt_required'; end if;
+    if p_hand_receipt is null then raise exception 'daily_fritz_terminal_hand_receipt_required'; end if;
+    receipt_game := (p_game_receipt->>'gameNumber')::int;
+    receipt_hand := (p_hand_receipt->>'handIndex')::int;
+    if receipt_game <> attempt.current_game_number
+      or (p_hand_receipt->>'gameNumber')::int <> receipt_game
+      or receipt_hand <> attempt.current_hand_index
+      or p_new_status <> 'started'
+      or jsonb_typeof(p_new_result->'games') <> 'array'
+      or jsonb_array_length(p_new_result->'games') <> receipt_game
+      or (
+        p_new_result ? 'setWinner'
+        and (
+          p_new_current_game_number <> attempt.current_game_number
+          or p_new_current_hand_index <> attempt.current_hand_index
+        )
+      )
+      or (
+        not (p_new_result ? 'setWinner')
+        and (
+          attempt.current_game_number = 3
+          or p_new_current_game_number <> attempt.current_game_number + 1
+          or p_new_current_hand_index <> 0
+        )
+      ) then
+      raise exception 'daily_fritz_invalid_game_transition';
+    end if;
+    insert into public.daily_fritz_verified_hands (
+      attempt_id, game_number, hand_index, operation_id, transcript_digest,
+      action_count, player_score_after, fritz_score_after, winner,
+      verifier_version, receipt
+    ) values (
+      attempt.id, receipt_game, receipt_hand, p_operation_id,
+      p_hand_receipt->>'transcriptDigest', (p_hand_receipt->>'actionCount')::int,
+      (p_hand_receipt->>'playerScoreAfter')::int, (p_hand_receipt->>'fritzScoreAfter')::int,
+      p_hand_receipt->>'winner', (p_hand_receipt->>'verificationVersion')::int,
+      p_hand_receipt
+    );
+    insert into public.daily_fritz_verified_games (
+      attempt_id, game_number, operation_id, player_score, fritz_score,
+      point_diff, player_won, action_count, hands_played, result_digest, receipt
+    ) values (
+      attempt.id, receipt_game, p_operation_id,
+      (p_game_receipt->>'playerScore')::int, (p_game_receipt->>'fritzScore')::int,
+      (p_game_receipt->>'pointDiff')::int, (p_game_receipt->>'playerWon')::boolean,
+      (p_game_receipt->>'actionCount')::int, (p_game_receipt->>'handsPlayed')::int,
+      p_game_receipt->>'resultDigest', p_game_receipt
+    );
+  elsif p_command_type = 'finalize_verified_attempt' then
+    if p_new_status <> 'completed'
+      or coalesce(p_new_result->>'verification_status', '') <> 'verified'
+      or not (p_new_result ? 'setWinner')
+      or jsonb_typeof(p_new_result->'games') <> 'array'
+      or jsonb_array_length(p_new_result->'games') not in (2, 3)
+      or (select count(*) from public.daily_fritz_verified_games where attempt_id = attempt.id) < 2 then
+      raise exception 'daily_fritz_invalid_finalize_transition';
+    end if;
+  elsif p_command_type = 'abandon_attempt' and p_new_status <> 'abandoned' then
+    raise exception 'daily_fritz_invalid_abandon_transition';
+  end if;
+
+  update public.daily_fritz_attempts set
+    status = p_new_status,
+    current_game_number = p_new_current_game_number,
+    current_hand_index = p_new_current_hand_index,
+    result = p_new_result,
+    final_score = p_final_score,
+    opponent_score = p_opponent_score,
+    point_diff = p_point_diff,
+    won = p_won,
+    moves_used = p_moves_used,
+    hands_played = p_hands_played,
+    completion_hash = p_completion_hash,
+    completed_at = case when p_new_status in ('completed', 'abandoned') then now() else completed_at end,
+    revision = revision + 1
+  where id = attempt.id and revision = p_expected_revision
+  returning * into attempt;
+
+  if not found then raise exception 'daily_fritz_revision_changed_during_commit'; end if;
+
+  if p_command_type in ('finalize_verified_attempt', 'abandon_attempt')
+    and attempt.verified_match_id is not null then
+    update public.verified_single_player_matches set
+      status = attempt.status,
+      completed_at = attempt.completed_at,
+      completion_hash = attempt.completion_hash,
+      completion_result = attempt.result
+    where match_id = attempt.verified_match_id and user_id = p_user_id;
+    if not found then raise exception 'daily_fritz_verified_match_missing'; end if;
+  end if;
+
+  command_response := jsonb_build_object(
+    'attempt_id', attempt.id, 'verified_match_id', attempt.verified_match_id,
+    'challenge_id', attempt.challenge_id, 'run_date', attempt.run_date,
+    'status', attempt.status, 'revision', attempt.revision,
+    'current_game_number', attempt.current_game_number,
+    'current_hand_index', attempt.current_hand_index, 'result', attempt.result,
+    'final_score', attempt.final_score, 'opponent_score', attempt.opponent_score,
+    'point_diff', attempt.point_diff, 'won', attempt.won,
+    'moves_used', attempt.moves_used, 'hands_played', attempt.hands_played,
+    'completion_hash', attempt.completion_hash, 'completed_at', attempt.completed_at
+  );
+
+  insert into public.daily_fritz_attempt_operations (
+    operation_id, attempt_id, user_id, challenge_id, command_type,
+    request_digest, expected_revision, committed_revision, status,
+    response, committed_at
+  ) values (
+    p_operation_id, attempt.id, p_user_id, attempt.challenge_id, p_command_type,
+    p_request_digest, p_expected_revision, attempt.revision, 'committed',
+    command_response, now()
+  );
+
+  if p_outbox_event_type is not null then
+    insert into public.daily_fritz_outbox (
+      attempt_id, challenge_id, operation_id, event_type, payload
+    ) values (
+      attempt.id, attempt.challenge_id, p_operation_id, p_outbox_event_type,
+      p_outbox_payload || jsonb_build_object('revision', attempt.revision)
+    ) on conflict (challenge_id, operation_id, event_type) do nothing;
+  end if;
+
+  return query select 'committed', null::text, false, attempt.revision, command_response;
+end;
+$$;
+
+revoke all on function public.commit_daily_fritz_attempt_command(
+  uuid, uuid, text, text, text, bigint, text, int, int, jsonb,
+  int, int, int, boolean, int, int, text, jsonb, jsonb, text, jsonb
+) from public;
+revoke all on function public.commit_daily_fritz_attempt_command(
+  uuid, uuid, text, text, text, bigint, text, int, int, jsonb,
+  int, int, int, boolean, int, int, text, jsonb, jsonb, text, jsonb
+) from authenticated;
+grant execute on function public.commit_daily_fritz_attempt_command(
+  uuid, uuid, text, text, text, bigint, text, int, int, jsonb,
+  int, int, int, boolean, int, int, text, jsonb, jsonb, text, jsonb
+) to service_role;


### PR DESCRIPTION
## Summary
- publish immutable, version-pinned Daily Fritz challenge packages
- commit attempt commands transactionally with revision/CAS and durable idempotency
- add canonical telemetry, readiness checks, and production-like authority soak tooling
- preserve existing best-of-three gameplay and verified leaderboard path

## Validation
- server: 104 files / 579 tests passed
- client: 148 files / 978 tests passed
- client behavior suites: 39 passed
- server/client builds and client typecheck/lint passed
- direct Supabase authority schema readiness probe passed

## Rollout
Requires DAILY_FRITZ_TRANSACTIONAL_COMMANDS=true after the four 2026-08-01 migrations are installed. /ready must report dailyFritzAuthority enabled and available before soak testing.