### PR TITLE
Replay duplicate Daily Fritz clinching games

### DIFF
--- a/server/src/http/routes/dailyFritz.ts
+++ b/server/src/http/routes/dailyFritz.ts
@@ -71,6 +71,7 @@ import {
   hasCompleteDailyFritzGameAuthority,
   hasPriorDailyFritzGameAuthority,
   isIdenticalDailyFritzGameReplay,
+  classifyDailyFritzGameRecordingPosition,
   readAuthorityLedger,
   buildDailyFritzAuthorityContract,
   clientSupportsDailyFritzAuthorityContract,
@@ -1264,13 +1265,9 @@ export function registerDailyFritzRoutes(app: Application): void {
       });
       return;
     }
-    if (currentSetResult.setWinner) {
-      res.status(409).json({ error: 'Daily Fritz set is already decided.' });
-      return;
-    }
-    if (gameNumber !== currentSetResult.games.length + 1) {
-      const existing = currentSetResult.games.find((game) => game.gameNumber === gameNumber);
-      if (existing) {
+    const recordingPosition = classifyDailyFritzGameRecordingPosition(currentSetResult, gameNumber);
+    if (recordingPosition.kind === 'replay') {
+      const existing = recordingPosition.existing;
         const identical = parsedTranscript
           ? (() => {
               const authorityGame = readAuthorityLedger(attempt.result).games.find(
@@ -1319,7 +1316,12 @@ export function registerDailyFritzRoutes(app: Application): void {
           next_game_number: currentSetResult.setWinner ? null : Math.min(currentSetResult.games.length + 1, 3),
         });
         return;
-      }
+    }
+    if (recordingPosition.kind === 'set_decided') {
+      res.status(409).json({ error: 'Daily Fritz set is already decided.' });
+      return;
+    }
+    if (recordingPosition.kind === 'invalid_order') {
       res.status(409).json({ error: 'Daily Fritz game order is invalid.' });
       return;
     }

--- a/server/src/http/routes/dailyFritzVerification.test.ts
+++ b/server/src/http/routes/dailyFritzVerification.test.ts
@@ -10,6 +10,7 @@ import {
   readDailyFritzAuthorityContract,
   writeDailyFritzAuthorityContract,
   requiresVerifiedDailyFritzEvidence,
+  classifyDailyFritzGameRecordingPosition,
 } from './dailyFritzVerificationPolicy';
 import { isDailyFritzAttemptLeaderboardEligible } from '../stores/dailyFritzStore';
 
@@ -77,6 +78,30 @@ describe('Daily Fritz competitive verification boundary', () => {
     expect(isIdenticalDailyFritzGameReplay(existing, existing)).toBe(true);
     expect(isIdenticalDailyFritzGameReplay(existing, { ...existing, playerScore: 600 })).toBe(false);
     expect(isIdenticalDailyFritzGameReplay(existing, { ...existing, fritzScore: 0 })).toBe(false);
+  });
+
+  it('replays a recorded game before enforcing a terminal set', () => {
+    const game = {
+      gameNumber: 1 as const,
+      seed: 'seed',
+      playerWon: true,
+      playerScore: 60,
+      fritzScore: 0,
+      pointDiff: 60,
+      movesUsed: 20,
+      handsPlayed: 3,
+      completedAt: '2026-08-01T12:00:00.000Z',
+    };
+    expect(classifyDailyFritzGameRecordingPosition({
+      games: [game],
+      setWinner: 'player',
+    }, 1)).toEqual({ kind: 'replay', existing: game });
+    expect(classifyDailyFritzGameRecordingPosition({
+      games: [game],
+      setWinner: 'player',
+    }, 2)).toEqual({ kind: 'set_decided' });
+    expect(classifyDailyFritzGameRecordingPosition({ games: [] }, 2))
+      .toEqual({ kind: 'invalid_order' });
   });
 
   it('pins a verifier-capable attempt to transcript evidence', () => {

--- a/server/src/http/routes/dailyFritzVerificationPolicy.ts
+++ b/server/src/http/routes/dailyFritzVerificationPolicy.ts
@@ -237,3 +237,24 @@ export function isIdenticalDailyFritzGameReplay(
     && existing.movesUsed === Math.round(submitted.movesUsed)
     && existing.handsPlayed === Math.round(submitted.handsPlayed);
 }
+
+export type DailyFritzGameRecordingPosition =
+  | { kind: 'next' }
+  | { kind: 'replay'; existing: DailyFritzSetGameResult }
+  | { kind: 'set_decided' }
+  | { kind: 'invalid_order' };
+
+/**
+ * Durable replay always wins over terminal-set rejection. A duplicate response
+ * retry must remain idempotent even when game one clinched the set by skunk.
+ */
+export function classifyDailyFritzGameRecordingPosition(
+  setResult: { games: DailyFritzSetGameResult[]; setWinner?: 'player' | 'fritz' },
+  gameNumber: DailyFritzSetGameNumber,
+): DailyFritzGameRecordingPosition {
+  const existing = setResult.games.find((game) => game.gameNumber === gameNumber);
+  if (existing) return { kind: 'replay', existing };
+  if (setResult.setWinner) return { kind: 'set_decided' };
+  if (gameNumber !== setResult.games.length + 1) return { kind: 'invalid_order' };
+  return { kind: 'next' };
+}


### PR DESCRIPTION
## Root cause
A duplicate record-game request was checked against terminal set state before durable replay detection. If game one clinched by skunk, the committed request succeeded and its concurrent retry received a 409.

## Fix
- classify an existing game as a replay before enforcing set terminality
- preserve terminal rejection for genuinely new games
- add regression coverage for clinching-game replay and invalid ordering

## Validation
- focused server tests: 16 passed
- server build passed
- production canary reproduced the original ordering defect and cleaned up its ephemeral user