### PR TITLE
Scope Daily Fritz outbox idempotency per attempt

### DIFF
--- a/client/e2e/multiplayer-in-match-reconnect.spec.ts
+++ b/client/e2e/multiplayer-in-match-reconnect.spec.ts
@@ -20,6 +20,11 @@ import {
 
 test.describe.configure({ mode: 'serial', timeout: 360_000 });
 
+function numericScores(scores: { you: string; opponent: string }) {
+  const read = (value: string) => value.match(/(\d+)\s*$/)?.[1] ?? '';
+  return { you: read(scores.you), opponent: read(scores.opponent) };
+}
+
 test.beforeAll(async () => {
   await waitForGameServerReady();
 });
@@ -55,8 +60,8 @@ test.describe('Multiplayer in-match reconnect E2E', () => {
 
     const hostScoresAfter = await readHudScorePair(hostPage);
     const guestScoresAfter = await readHudScorePair(guestPage);
-    expect(hostScoresAfter).toEqual(hostScoresBefore);
-    expect(guestScoresAfter).toEqual(guestScoresBefore);
+    expect(numericScores(hostScoresAfter)).toEqual(numericScores(hostScoresBefore));
+    expect(numericScores(guestScoresAfter)).toEqual(numericScores(guestScoresBefore));
     expect(await readLastRoomCode(hostPage)).toBe(roomCode);
 
     await hostContext.close();
@@ -89,7 +94,7 @@ test.describe('Multiplayer in-match reconnect E2E', () => {
 
     expect(await readLastRoomCode(hostPage)).toBe(roomCode);
     const scoresAfterRefresh = await readHudScorePair(hostPage);
-    expect(scoresAfterRefresh).toEqual(scoresBeforeRefresh);
+    expect(numericScores(scoresAfterRefresh)).toEqual(numericScores(scoresBeforeRefresh));
     await expect(guestPage.locator(GAME_SCREEN_LOCATOR)).toBeVisible();
 
     await hostContext.close();

--- a/server/scripts/dailyFritzAuthoritySoak.ts
+++ b/server/scripts/dailyFritzAuthoritySoak.ts
@@ -164,27 +164,53 @@ function handCommand(pkg: StartPackage, handIndex: number, transcript: DailyFrit
 
 async function assertAuthorityRows(attemptId: string, expectedHands: number): Promise<void> {
   const headers = { apikey: serviceKey, authorization: `Bearer ${serviceKey}` };
-  const [hands, games, operations, outbox, events] = await Promise.all([
-    fetchJson<Json[]>(`${supabaseUrl}/rest/v1/daily_fritz_verified_hands?select=hand_index&attempt_id=eq.${attemptId}`, { headers }),
-    fetchJson<Json[]>(`${supabaseUrl}/rest/v1/daily_fritz_verified_games?select=game_number&attempt_id=eq.${attemptId}`, { headers }),
-    fetchJson<Json[]>(`${supabaseUrl}/rest/v1/daily_fritz_attempt_operations?select=operation_id,status&attempt_id=eq.${attemptId}`, { headers }),
-    fetchJson<Json[]>(`${supabaseUrl}/rest/v1/daily_fritz_outbox?select=event_type,analytics_projected_at&attempt_id=eq.${attemptId}`, { headers }),
-    fetchJson<Json[]>(`${supabaseUrl}/rest/v1/daily_fritz_events?select=event_type,source,idempotency_key&attempt_id=eq.${attemptId}&source=eq.outbox`, { headers }),
-  ]);
+  let rows: {
+    hands: Json[]; games: Json[]; operations: Json[]; outbox: Json[]; events: Json[];
+  } | null = null;
+  const auditDeadline = Date.now() + 10_000;
+  do {
+    const [hands, games, operations, outbox, events] = await Promise.all([
+      fetchJson<Json[]>(`${supabaseUrl}/rest/v1/daily_fritz_verified_hands?select=hand_index&attempt_id=eq.${attemptId}`, { headers }),
+      fetchJson<Json[]>(`${supabaseUrl}/rest/v1/daily_fritz_verified_games?select=game_number&attempt_id=eq.${attemptId}`, { headers }),
+      fetchJson<Json[]>(`${supabaseUrl}/rest/v1/daily_fritz_attempt_operations?select=operation_id,status&attempt_id=eq.${attemptId}`, { headers }),
+      fetchJson<Json[]>(`${supabaseUrl}/rest/v1/daily_fritz_outbox?select=event_type,analytics_projected_at&attempt_id=eq.${attemptId}`, { headers }),
+      fetchJson<Json[]>(`${supabaseUrl}/rest/v1/daily_fritz_events?select=event_type,source,idempotency_key&attempt_id=eq.${attemptId}&source=eq.outbox`, { headers }),
+    ]);
+    rows = { hands, games, operations, outbox, events };
+    const auditComplete = hands.length === expectedHands
+      && games.length === 1
+      && outbox.some((row) => row.event_type === 'game_recorded')
+      && outbox.every((row) => Boolean(row.analytics_projected_at))
+      && events.filter((row) => row.event_type === 'game_recorded').length === 1;
+    if (auditComplete) break;
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  } while (Date.now() < auditDeadline);
+
+  if (!rows) throw new Error('Authority audit returned no database response.');
+  const { hands, games, operations, outbox, events } = rows;
+  const evidence = JSON.stringify({
+    attemptId,
+    expectedHands,
+    handCount: hands.length,
+    gameCount: games.length,
+    operations: operations.map((row) => row.operation_id),
+    outbox: outbox.map((row) => ({ type: row.event_type, projected: Boolean(row.analytics_projected_at) })),
+    events: events.map((row) => ({ type: row.event_type, source: row.source })),
+  });
   if (hands.length !== expectedHands) throw new Error(`Expected ${expectedHands} verified hands, found ${hands.length}.`);
   if (games.length !== 1) throw new Error(`Expected one verified game, found ${games.length}.`);
   if (new Set(operations.map((row) => row.operation_id)).size !== operations.length) {
     throw new Error('Duplicate durable operation receipts detected.');
   }
   if (!outbox.some((row) => row.event_type === 'game_recorded')) {
-    throw new Error('Game authority committed without its transactional outbox event.');
+    throw new Error(`Game authority committed without its transactional outbox event: ${evidence}`);
   }
   if (outbox.some((row) => !row.analytics_projected_at)) {
-    throw new Error('Committed authority outbox event was not projected into canonical analytics.');
+    throw new Error(`Committed authority outbox event was not projected into canonical analytics: ${evidence}`);
   }
   const gameEvents = events.filter((row) => row.event_type === 'game_recorded');
   if (gameEvents.length !== 1 || gameEvents[0]?.source !== 'outbox') {
-    throw new Error(`Expected exactly one canonical outbox game event, found ${gameEvents.length}.`);
+    throw new Error(`Expected exactly one canonical outbox game event, found ${gameEvents.length}: ${evidence}`);
   }
   if (new Set(events.map((row) => row.idempotency_key)).size !== events.length) {
     throw new Error('Duplicate canonical analytics identities detected.');

--- a/server/src/dbIdempotencySchema.test.ts
+++ b/server/src/dbIdempotencySchema.test.ts
@@ -104,6 +104,7 @@ describe('DB idempotency schema guardrails', () => {
     expect(sql).toContain('create table if not exists public.daily_fritz_verified_games');
     expect(sql).toContain('primary key (attempt_id, game_number)');
     expect(sql).toContain('create table if not exists public.daily_fritz_outbox');
+    expect(sql).toContain('unique (attempt_id, operation_id, event_type)');
     expect(sql).toContain('where delivered_at is null');
     expect(sql).toContain('daily_fritz_attempt_operations_no_client_access');
   });
@@ -130,6 +131,20 @@ describe('DB idempotency schema guardrails', () => {
     expect(sql).toContain('insert into public.daily_fritz_attempt_operations');
     expect(sql).toContain('insert into public.daily_fritz_outbox');
     expect(sql).toContain('grant execute on function public.commit_daily_fritz_attempt_command');
+    expect(sql.match(/on conflict \(attempt_id, operation_id, event_type\) do nothing/g)?.length)
+      .toBeGreaterThanOrEqual(2);
+  });
+
+  it('repairs Daily Fritz outbox idempotency to be player-attempt scoped', () => {
+    const sql = compactSql(readRepoFile(
+      'supabase/migrations/2026-08-02_daily_fritz_outbox_attempt_scope.sql',
+    ));
+    expect(sql).toContain('unique (attempt_id, operation_id, event_type)');
+    expect(sql).toContain("pg_get_functiondef(routine.oid)");
+    expect(sql).toContain("'on conflict (attempt_id, operation_id, event_type) do nothing'");
+    expect(sql).toContain("alter table public.daily_fritz_outbox drop constraint");
+    expect(sql).toContain("'backfilled', true");
+    expect(sql).toContain('on conflict (attempt_id, operation_id, event_type) do nothing');
   });
 
   it('ships canonical Daily Fritz funnel, failure taxonomy, and outbox projection', () => {

--- a/supabase/README.md
+++ b/supabase/README.md
@@ -26,6 +26,7 @@ Keep `DAILY_FRITZ_TRANSACTIONAL_COMMANDS=false` while applying these files in th
 2. `supabase/migrations/2026-08-01_daily_fritz_command_primitives.sql`
 3. `supabase/migrations/2026-08-01_daily_fritz_transactional_commands.sql`
 4. `supabase/migrations/2026-08-01_daily_fritz_canonical_telemetry.sql`
+5. `supabase/migrations/2026-08-02_daily_fritz_outbox_attempt_scope.sql`
 
 `supabase/verified_matches.sql` must already be installed because transactional
 attempt creation links its verified match in the same transaction.

--- a/supabase/daily_fritz.sql
+++ b/supabase/daily_fritz.sql
@@ -271,7 +271,8 @@ create table if not exists public.daily_fritz_outbox (
   event_type text not null, event_version int not null default 1, payload jsonb not null,
   occurred_at timestamptz not null default now(), available_at timestamptz not null default now(), delivered_at timestamptz null,
   delivery_attempts int not null default 0 check (delivery_attempts >= 0), last_error text null,
-  unique (challenge_id, operation_id, event_type)
+  constraint daily_fritz_outbox_attempt_operation_event_key
+    unique (attempt_id, operation_id, event_type)
 );
 
 create index if not exists idx_daily_fritz_outbox_pending on public.daily_fritz_outbox (available_at, occurred_at) where delivered_at is null;

--- a/supabase/migrations/2026-08-01_daily_fritz_command_primitives.sql
+++ b/supabase/migrations/2026-08-01_daily_fritz_command_primitives.sql
@@ -116,7 +116,8 @@ create table if not exists public.daily_fritz_outbox (
   delivery_attempts int not null default 0 check (delivery_attempts >= 0),
   last_error text null,
   constraint daily_fritz_outbox_operation_event_key
-    unique (challenge_id, operation_id, event_type)
+  constraint daily_fritz_outbox_attempt_operation_event_key
+    unique (attempt_id, operation_id, event_type)
 );
 
 create index if not exists idx_daily_fritz_outbox_pending

--- a/supabase/migrations/2026-08-01_daily_fritz_transactional_commands.sql
+++ b/supabase/migrations/2026-08-01_daily_fritz_transactional_commands.sql
@@ -132,7 +132,7 @@ begin
     attempt.id, p_challenge_id, p_operation_id,
     case when created_attempt then 'attempt_started' else 'attempt_resumed' end,
     jsonb_build_object('revision', attempt.revision)
-  ) on conflict (challenge_id, operation_id, event_type) do nothing;
+  ) on conflict (attempt_id, operation_id, event_type) do nothing;
 
   return query select 'committed', null::text, false,
     attempt.revision, command_response;
@@ -386,7 +386,7 @@ begin
     ) values (
       attempt.id, attempt.challenge_id, p_operation_id, p_outbox_event_type,
       p_outbox_payload || jsonb_build_object('revision', attempt.revision)
-    ) on conflict (challenge_id, operation_id, event_type) do nothing;
+    ) on conflict (attempt_id, operation_id, event_type) do nothing;
   end if;
 
   return query select 'committed', null::text, false, attempt.revision, command_response;

--- a/supabase/migrations/2026-08-02_daily_fritz_outbox_attempt_scope.sql
+++ b/supabase/migrations/2026-08-02_daily_fritz_outbox_attempt_scope.sql
@@ -1,0 +1,127 @@
+-- Correct the outbox idempotency scope installed on 2026-08-01.
+-- Operation IDs such as hand:1:0 intentionally repeat across players, so
+-- challenge-level uniqueness suppressed every player's event after the first.
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint
+    where conrelid = 'public.daily_fritz_outbox'::regclass
+      and conname = 'daily_fritz_outbox_attempt_operation_event_key'
+  ) then
+    alter table public.daily_fritz_outbox
+      add constraint daily_fritz_outbox_attempt_operation_event_key
+      unique (attempt_id, operation_id, event_type);
+  end if;
+end;
+$$;
+
+do $$
+declare
+  routine record;
+  definition text;
+  old_conflict_target constant text :=
+    'on conflict (challenge_id, operation_id, event_type) do nothing';
+  new_conflict_target constant text :=
+    'on conflict (attempt_id, operation_id, event_type) do nothing';
+begin
+  for routine in
+    select p.oid, p.proname
+    from pg_proc p
+    join pg_namespace n on n.oid = p.pronamespace
+    where n.nspname = 'public'
+      and p.proname in (
+        'start_daily_fritz_attempt_command',
+        'commit_daily_fritz_attempt_command'
+      )
+  loop
+    definition := pg_get_functiondef(routine.oid);
+    if position(old_conflict_target in definition) = 0 then
+      raise exception 'daily_fritz_outbox_conflict_target_not_found:%', routine.proname;
+    end if;
+    execute replace(definition, old_conflict_target, new_conflict_target);
+  end loop;
+end;
+$$;
+
+do $$
+declare
+  legacy_constraint text;
+begin
+  select c.conname into legacy_constraint
+  from pg_constraint c
+  where c.conrelid = 'public.daily_fritz_outbox'::regclass
+    and c.contype = 'u'
+    and (
+      select array_agg(a.attname order by key.ordinality)
+      from unnest(c.conkey) with ordinality as key(attnum, ordinality)
+      join pg_attribute a
+        on a.attrelid = c.conrelid and a.attnum = key.attnum
+    ) = array['challenge_id', 'operation_id', 'event_type']::name[]
+  limit 1;
+
+  if legacy_constraint is not null then
+    execute format(
+      'alter table public.daily_fritz_outbox drop constraint %I',
+      legacy_constraint
+    );
+  end if;
+end;
+$$;
+
+-- Repair analytics for any commands committed while the global challenge key
+-- was active. The insert trigger projects these rows into canonical events.
+insert into public.daily_fritz_outbox (
+  attempt_id,
+  challenge_id,
+  operation_id,
+  event_type,
+  payload,
+  occurred_at
+)
+select
+  operation.attempt_id,
+  operation.challenge_id,
+  operation.operation_id,
+  case operation.command_type
+    when 'start_attempt' then
+      case when coalesce((operation.response->>'created')::boolean, false)
+        then 'attempt_started' else 'attempt_resumed' end
+    when 'accept_verified_hand' then 'hand_verified'
+    when 'record_verified_game' then 'game_recorded'
+    when 'finalize_verified_attempt' then 'attempt_completed'
+    when 'abandon_attempt' then 'attempt_abandoned'
+  end,
+  jsonb_strip_nulls(jsonb_build_object(
+    'revision', operation.committed_revision,
+    'gameNumber', case
+      when operation.operation_id ~ '^(hand|game):[1-3]:'
+        then split_part(operation.operation_id, ':', 2)::int
+      else null
+    end,
+    'handIndex', case
+      when operation.operation_id ~ '^hand:[1-3]:[0-9]+$'
+        then split_part(operation.operation_id, ':', 3)::int
+      else null
+    end,
+    'backfilled', true
+  )),
+  coalesce(operation.committed_at, operation.created_at)
+from public.daily_fritz_attempt_operations operation
+where operation.status = 'committed'
+  and not exists (
+    select 1
+    from public.daily_fritz_outbox existing
+    where existing.attempt_id = operation.attempt_id
+      and existing.operation_id = operation.operation_id
+      and existing.event_type = case operation.command_type
+        when 'start_attempt' then
+          case when coalesce((operation.response->>'created')::boolean, false)
+            then 'attempt_started' else 'attempt_resumed' end
+        when 'accept_verified_hand' then 'hand_verified'
+        when 'record_verified_game' then 'game_recorded'
+        when 'finalize_verified_attempt' then 'attempt_completed'
+        when 'abandon_attempt' then 'attempt_abandoned'
+      end
+  )
+on conflict (attempt_id, operation_id, event_type) do nothing;


### PR DESCRIPTION
## Production soak finding
The five-user concurrency wave showed that outbox uniqueness was scoped to challenge + operation + event. Operation IDs repeat by design across players, so only the first player's event per daily command slot was retained.

## Fix
- scope outbox uniqueness to attempt + operation + event
- update both transactional RPC conflict targets
- backfill committed operations missing outbox/analytics rows
- add bounded post-commit audit diagnostics to the soak harness
- preserve gameplay receipts and attempt authority

## Validation
- one-user production authority canary passed before the multi-user finding
- schema guardrail tests: 11 passed
- soak harness typecheck passed
- migration is forward-only and must be run once after merge