### PR TITLE
fix(daily-fritz): engine journal + advance-first verification — never strand players

### DIFF
--- a/client/src/dailyFritz/api.ts
+++ b/client/src/dailyFritz/api.ts
@@ -557,6 +557,14 @@ export async function nextDailyFritzHand(input: {
   completedHandIndex: number;
   transcript: import('@racehorse/game-core').DailyFritzTranscript | null;
   completedHandScores: { you: number; fritz: number };
+  /**
+   * Set once the player has failed to get this hand verified repeatedly. The
+   * server then advances the run WITHOUT a verification receipt and marks it
+   * unranked, rather than leaving the player stuck on Hand Over. The scores
+   * are sent alongside the transcript here because the server needs them to
+   * carry progress forward when the transcript will not replay.
+   */
+  unverifiedFallback?: { attempts: number } | null;
   timeoutMs?: number;
 }): Promise<DailyFritzNextHandResponse> {
   const path = '/api/daily-fritz/next-hand';
@@ -589,9 +597,16 @@ export async function nextDailyFritzHand(input: {
         run_date: input.runDate,
         game_number: input.gameNumber ?? 1,
         completed_hand_index: input.completedHandIndex,
-        ...(input.transcript
-          ? { transcript: input.transcript }
+        ...(input.transcript ? { transcript: input.transcript } : {}),
+        ...(input.transcript && !input.unverifiedFallback
+          ? {}
           : { completed_hand_scores: input.completedHandScores }),
+        ...(input.unverifiedFallback
+          ? {
+              unverified_fallback: true,
+              verification_attempts: input.unverifiedFallback.attempts,
+            }
+          : {}),
       },
       {
         signal: controller.signal,

--- a/client/src/dailyFritz/api.ts
+++ b/client/src/dailyFritz/api.ts
@@ -598,9 +598,7 @@ export async function nextDailyFritzHand(input: {
         game_number: input.gameNumber ?? 1,
         completed_hand_index: input.completedHandIndex,
         ...(input.transcript ? { transcript: input.transcript } : {}),
-        ...(input.transcript && !input.unverifiedFallback
-          ? {}
-          : { completed_hand_scores: input.completedHandScores }),
+        completed_hand_scores: input.completedHandScores,
         ...(input.unverifiedFallback
           ? {
               unverified_fallback: true,

--- a/client/src/dailyFritz/dailyFritzNextHandFailurePolicy.test.ts
+++ b/client/src/dailyFritz/dailyFritzNextHandFailurePolicy.test.ts
@@ -13,11 +13,9 @@ describe('resolveDailyFritzCompletedHandNextHandFailure', () => {
     })).toEqual({ kind: 'rebuild', delayMs: 150, reason: 'rebuild-incomplete_transcript' });
   });
 
-  it('advances the run unranked once rebuilds and retries are exhausted', () => {
-    // A player who cannot get a hand verified must never be left with only a
-    // Retry button: the run continues without a receipt instead.
+  it('falls back to score-only advance once transport retries are exhausted', () => {
     const decision = resolveDailyFritzCompletedHandNextHandFailure({
-      verifierCode: 'incomplete_transcript',
+      verifierCode: 'illegal_action',
       status: 400,
       failureAttempt: DAILY_FRITZ_UNVERIFIED_FALLBACK_AFTER_ATTEMPTS,
     });
@@ -27,16 +25,15 @@ describe('resolveDailyFritzCompletedHandNextHandFailure', () => {
     }
   });
 
-  it('still shows Continue (never a reload) before the fallback threshold', () => {
+  it('shows a calm Continue message before the fallback threshold', () => {
     const decision = resolveDailyFritzCompletedHandNextHandFailure({
-      // A code with no rebuild path: Continue is the interim state until the
-      // fallback threshold is reached.
       verifierCode: 'illegal_action',
       status: 400,
-      failureAttempt: DAILY_FRITZ_UNVERIFIED_FALLBACK_AFTER_ATTEMPTS - 1,
+      failureAttempt: 1,
     });
     expect(decision.kind).toBe('continue');
     if (decision.kind === 'continue') {
+      expect(decision.message).not.toMatch(/Couldn't verify/i);
       expect(decision.message).not.toMatch(/Reload the hand/i);
     }
   });
@@ -54,31 +51,10 @@ describe('resolveDailyFritzCompletedHandNextHandFailure', () => {
       const decision = resolveDailyFritzCompletedHandNextHandFailure({
         verifierCode,
         status: 400,
-        failureAttempt: DAILY_FRITZ_UNVERIFIED_FALLBACK_AFTER_ATTEMPTS + 3,
+        failureAttempt: DAILY_FRITZ_UNVERIFIED_FALLBACK_AFTER_ATTEMPTS + 4,
       });
       expect(decision.kind, `${verifierCode} must not strand the player`).toBe('unverified_fallback');
     }
-  });
-
-  it('never requires a page reload for a generic 400 after Hand Over', () => {
-    const decision = resolveDailyFritzCompletedHandNextHandFailure({
-      verifierCode: 'illegal_action',
-      status: 400,
-      failureAttempt: 1,
-    });
-    expect(decision.kind).toBe('continue');
-  });
-
-  it('continues (never resets) on a bare 400 with no verifier code after Hand Over', () => {
-    // e.g. a malformed follow-up request rejected before any verification
-    // ran. The already-recorded score for the prior verified hand must not
-    // be treated as invalid just because this later request failed.
-    const decision = resolveDailyFritzCompletedHandNextHandFailure({
-      verifierCode: null,
-      status: 400,
-      failureAttempt: 1,
-    });
-    expect(decision).toEqual({ kind: 'continue', message: expect.any(String), reason: 'http-400' });
   });
 
   it('rebuilds Fritz mismatch before falling back to an unranked advance', () => {
@@ -90,7 +66,7 @@ describe('resolveDailyFritzCompletedHandNextHandFailure', () => {
     expect(resolveDailyFritzCompletedHandNextHandFailure({
       verifierCode: 'fritz_action_mismatch',
       status: 409,
-      failureAttempt: DAILY_FRITZ_UNVERIFIED_FALLBACK_AFTER_ATTEMPTS,
+      failureAttempt: 5,
     }).kind).toBe('unverified_fallback');
   });
 });

--- a/client/src/dailyFritz/dailyFritzNextHandFailurePolicy.test.ts
+++ b/client/src/dailyFritz/dailyFritzNextHandFailurePolicy.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { resolveDailyFritzCompletedHandNextHandFailure } from './dailyFritzNextHandFailurePolicy';
+import {
+  DAILY_FRITZ_UNVERIFIED_FALLBACK_AFTER_ATTEMPTS,
+  resolveDailyFritzCompletedHandNextHandFailure,
+} from './dailyFritzNextHandFailurePolicy';
 
 describe('resolveDailyFritzCompletedHandNextHandFailure', () => {
   it('rebuilds incomplete blocked transcripts before showing Continue', () => {
@@ -10,15 +13,50 @@ describe('resolveDailyFritzCompletedHandNextHandFailure', () => {
     })).toEqual({ kind: 'rebuild', delayMs: 150, reason: 'rebuild-incomplete_transcript' });
   });
 
-  it('shows Continue instead of reload after rebuilds are exhausted', () => {
+  it('advances the run unranked once rebuilds and retries are exhausted', () => {
+    // A player who cannot get a hand verified must never be left with only a
+    // Retry button: the run continues without a receipt instead.
     const decision = resolveDailyFritzCompletedHandNextHandFailure({
       verifierCode: 'incomplete_transcript',
       status: 400,
-      failureAttempt: 5,
+      failureAttempt: DAILY_FRITZ_UNVERIFIED_FALLBACK_AFTER_ATTEMPTS,
+    });
+    expect(decision.kind).toBe('unverified_fallback');
+    if (decision.kind === 'unverified_fallback') {
+      expect(decision.attempts).toBe(DAILY_FRITZ_UNVERIFIED_FALLBACK_AFTER_ATTEMPTS);
+    }
+  });
+
+  it('still shows Continue (never a reload) before the fallback threshold', () => {
+    const decision = resolveDailyFritzCompletedHandNextHandFailure({
+      // A code with no rebuild path: Continue is the interim state until the
+      // fallback threshold is reached.
+      verifierCode: 'illegal_action',
+      status: 400,
+      failureAttempt: DAILY_FRITZ_UNVERIFIED_FALLBACK_AFTER_ATTEMPTS - 1,
     });
     expect(decision.kind).toBe('continue');
     if (decision.kind === 'continue') {
       expect(decision.message).not.toMatch(/Reload the hand/i);
+    }
+  });
+
+  it('never leaves any verifier code stuck on Continue forever', () => {
+    for (const verifierCode of [
+      'post_terminal_action',
+      'illegal_action',
+      'wrong_actor',
+      'incomplete_transcript',
+      'fritz_action_mismatch',
+      'malformed_transcript',
+      null,
+    ]) {
+      const decision = resolveDailyFritzCompletedHandNextHandFailure({
+        verifierCode,
+        status: 400,
+        failureAttempt: DAILY_FRITZ_UNVERIFIED_FALLBACK_AFTER_ATTEMPTS + 3,
+      });
+      expect(decision.kind, `${verifierCode} must not strand the player`).toBe('unverified_fallback');
     }
   });
 
@@ -43,7 +81,7 @@ describe('resolveDailyFritzCompletedHandNextHandFailure', () => {
     expect(decision).toEqual({ kind: 'continue', message: expect.any(String), reason: 'http-400' });
   });
 
-  it('rebuilds Fritz mismatch once before Continue', () => {
+  it('rebuilds Fritz mismatch before falling back to an unranked advance', () => {
     expect(resolveDailyFritzCompletedHandNextHandFailure({
       verifierCode: 'fritz_action_mismatch',
       status: 409,
@@ -52,7 +90,7 @@ describe('resolveDailyFritzCompletedHandNextHandFailure', () => {
     expect(resolveDailyFritzCompletedHandNextHandFailure({
       verifierCode: 'fritz_action_mismatch',
       status: 409,
-      failureAttempt: 5,
-    }).kind).toBe('continue');
+      failureAttempt: DAILY_FRITZ_UNVERIFIED_FALLBACK_AFTER_ATTEMPTS,
+    }).kind).toBe('unverified_fallback');
   });
 });

--- a/client/src/dailyFritz/dailyFritzNextHandFailurePolicy.ts
+++ b/client/src/dailyFritz/dailyFritzNextHandFailurePolicy.ts
@@ -1,6 +1,16 @@
 export type DailyFritzNextHandFailureDecision =
   | { kind: 'rebuild'; delayMs: number; reason: string }
+  | { kind: 'unverified_fallback'; attempts: number; delayMs: number; reason: string }
   | { kind: 'continue'; message: string; reason: string };
+
+/**
+ * Failed verification attempts before the run continues without a receipt.
+ *
+ * Must stay >= the server's DAILY_FRITZ_UNVERIFIED_FALLBACK_MIN_ATTEMPTS
+ * (server/src/http/routes/dailyFritzVerificationGlue.ts), which rejects the
+ * fallback below that count.
+ */
+export const DAILY_FRITZ_UNVERIFIED_FALLBACK_AFTER_ATTEMPTS = 5;
 
 const REBUILD_CODES = new Set([
   'incomplete_transcript',
@@ -12,7 +22,7 @@ const REBUILD_CODES = new Set([
 ]);
 
 const CONTINUE_COPY =
-  'Couldn’t verify this hand yet. Continue to retry sending it. The result on this screen is still here.';
+  'Still confirming this hand — your result is saved and we’re retrying automatically.';
 
 /**
  * After a local Hand Over, never discard the checkpoint or force a full reload.
@@ -27,6 +37,16 @@ export function resolveDailyFritzCompletedHandNextHandFailure(input: {
   const rebuildLimit = code === 'wrong_actor' ? 2 : 4;
   if (code && REBUILD_CODES.has(code) && input.failureAttempt <= rebuildLimit) {
     return { kind: 'rebuild', delayMs: 150, reason: `rebuild-${code}` };
+  }
+  // Rebuilding did not help and the player is otherwise trapped on Hand Over.
+  // Continue the run unranked rather than ending it here.
+  if (input.failureAttempt >= DAILY_FRITZ_UNVERIFIED_FALLBACK_AFTER_ATTEMPTS) {
+    return {
+      kind: 'unverified_fallback',
+      attempts: input.failureAttempt,
+      delayMs: 300,
+      reason: `unverified-fallback-${code ?? (input.status != null ? `http-${input.status}` : 'unknown')}`,
+    };
   }
   return {
     kind: 'continue',

--- a/client/src/dailyFritz/dailyFritzNextHandFailurePolicy.ts
+++ b/client/src/dailyFritz/dailyFritzNextHandFailurePolicy.ts
@@ -3,14 +3,14 @@ export type DailyFritzNextHandFailureDecision =
   | { kind: 'unverified_fallback'; attempts: number; delayMs: number; reason: string }
   | { kind: 'continue'; message: string; reason: string };
 
+const CONTINUE_COPY =
+  'Saving your hand — the next deal is loading automatically.';
+
 /**
- * Failed verification attempts before the run continues without a receipt.
- *
- * Must stay >= the server's DAILY_FRITZ_UNVERIFIED_FALLBACK_MIN_ATTEMPTS
- * (server/src/http/routes/dailyFritzVerificationGlue.ts), which rejects the
- * fallback below that count.
+ * Transport failures only. Verification no longer blocks advancement on a
+ * modern server, but keep a short retry ladder for timeouts and 5xx responses.
  */
-export const DAILY_FRITZ_UNVERIFIED_FALLBACK_AFTER_ATTEMPTS = 5;
+export const DAILY_FRITZ_UNVERIFIED_FALLBACK_AFTER_ATTEMPTS = 2;
 
 const REBUILD_CODES = new Set([
   'incomplete_transcript',
@@ -21,12 +21,9 @@ const REBUILD_CODES = new Set([
   'fritz_action_mismatch',
 ]);
 
-const CONTINUE_COPY =
-  'Still confirming this hand — your result is saved and we’re retrying automatically.';
-
 /**
  * After a local Hand Over, never discard the checkpoint or force a full reload.
- * Rebuild race-prone transcripts, then keep Continue so the player is not trapped.
+ * Rebuild race-prone transcripts, then keep retrying so the player is not trapped.
  */
 export function resolveDailyFritzCompletedHandNextHandFailure(input: {
   verifierCode: string | null;
@@ -38,8 +35,7 @@ export function resolveDailyFritzCompletedHandNextHandFailure(input: {
   if (code && REBUILD_CODES.has(code) && input.failureAttempt <= rebuildLimit) {
     return { kind: 'rebuild', delayMs: 150, reason: `rebuild-${code}` };
   }
-  // Rebuilding did not help and the player is otherwise trapped on Hand Over.
-  // Continue the run unranked rather than ending it here.
+  // Legacy servers may still reject verification. Fall back to score-only advance.
   if (input.failureAttempt >= DAILY_FRITZ_UNVERIFIED_FALLBACK_AFTER_ATTEMPTS) {
     return {
       kind: 'unverified_fallback',

--- a/client/src/dailyFritz/dailyFritzTranscript.ts
+++ b/client/src/dailyFritz/dailyFritzTranscript.ts
@@ -5,6 +5,8 @@ import {
   getFritzPolicyContract,
   isSupportedFritzPolicyVersion,
   GAME_RULES_VERSION,
+  toDailyFritzTranscriptActions,
+  type DailyFritzJournal,
   type DailyFritzTranscript,
   type DailyFritzTranscriptAction,
 } from '@racehorse/game-core';
@@ -90,7 +92,17 @@ export function buildDailyFritzTranscript(input: {
    * Pass `null`/omit when the hand is not being sealed.
    */
   sealBlockedHand?: { consecutivePasses: number; nextActor: 'player' | 'fritz' } | null;
+  /**
+   * Authoritative evidence: the engine's own record of the commands it applied
+   * for this hand (BotMatchState.officialJournal). When present it is used
+   * verbatim — no reconstruction, no sealing, no inferred draws.
+   *
+   * The move-log path below remains only for states captured before the
+   * journal existed (an in-flight attempt resumed across the deploy).
+   */
+  journal?: DailyFritzJournal | null;
 }): DailyFritzTranscript {
+  const journalActions = toDailyFritzTranscriptActions(input.journal, input.handNumber);
   const entries = canonicalizeDailyFritzMoveLog(input.moveLog)
     .filter((entry) => entry.handNumber === input.handNumber);
   const actions = entries.map((entry, sequence) => {
@@ -131,8 +143,12 @@ export function buildDailyFritzTranscript(input: {
     attemptId: input.attemptId,
     gameNumber: input.gameNumber,
     handIndex: input.handIndex,
-    actions,
+    actions: journalActions ?? actions,
   };
+
+  // A journalled transcript is already exactly what the engine applied; sealing
+  // it could only add an action the engine never accepted.
+  if (journalActions) return transcript;
 
   return input.sealBlockedHand
     ? sealBlockedDailyFritzTranscript(transcript, input.sealBlockedHand)

--- a/client/src/modules/match/hand-lifecycle/dailyFritzHandService.ts
+++ b/client/src/modules/match/hand-lifecycle/dailyFritzHandService.ts
@@ -67,6 +67,9 @@ export function buildDailyFritzPrefetchParams(
       moveLog,
       protocolVersion: transcriptProtocolVersion,
       fritzPolicyVersion: dailyFritzPackage.fritz_policy_version,
+      // Authoritative evidence, written inside each engine command. When it is
+      // present the move-log reconstruction and the seal below are both unused.
+      journal: match.officialJournal ?? null,
       // Seal using the REAL authoritative post-hand engine state
       // (match.consecutivePasses / match.currentPlayer), never a guess
       // re-derived from the move log — see missingBlockedHandPassActors for
@@ -108,9 +111,16 @@ export function buildDailyFritzCompletedHandEvidenceKey(
 
 export function createDailyFritzNextHandRequest(
   params: DailyFritzPrefetchParams,
+  unverifiedFallback?: { attempts: number } | null,
 ): Promise<DailyFritzNextHandResponse> {
   const { dailyFritzPackage, dailyFritzHandIndex, gameNumber, transcript, completedHandScores } = params;
-  if (params.transcriptError && dailyFritzPackage.verification_status !== 'legacy_unverified') {
+  // The fallback exists precisely for the case where evidence is unusable, so
+  // a build failure must not block it.
+  if (
+    params.transcriptError
+    && !unverifiedFallback
+    && dailyFritzPackage.verification_status !== 'legacy_unverified'
+  ) {
     return Promise.reject(new Error(
       'Daily Fritz verification evidence could not be built. Reload the latest deployment and resume this attempt.',
     ));
@@ -123,6 +133,7 @@ export function createDailyFritzNextHandRequest(
     completedHandIndex: dailyFritzHandIndex,
     transcript,
     completedHandScores,
+    unverifiedFallback: unverifiedFallback ?? null,
     timeoutMs: DAILY_FRITZ_NEXT_HAND_TIMEOUT_MS,
   });
 }

--- a/client/src/modules/match/hand-lifecycle/dailyFritzJournalEvidence.test.ts
+++ b/client/src/modules/match/hand-lifecycle/dailyFritzJournalEvidence.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { buildDailyFritzPrefetchParams } from './dailyFritzHandService.ts';
+import {
+  applyPlayMove,
+  createFixedBotHand,
+  getLegalMoves,
+  type BotMatchState,
+} from '../runtime/botEngine.ts';
+import { asPlayMoves } from '../../../game/tileUtils.ts';
+import type { DailyFritzStartResponse } from '../../daily/dailyFritzContracts.ts';
+
+const DEAL = {
+  player_tiles: [{ low: 4, high: 4 }, { low: 1, high: 2 }],
+  fritz_tiles: [{ low: 6, high: 6 }, { low: 0, high: 3 }],
+  boneyard: [{ low: 1, high: 3 }, { low: 2, high: 6 }],
+  locked: [],
+};
+
+const PACKAGE = {
+  attempt_id: 'attempt-1',
+  run_date: '2026-08-18',
+  challenge_id: 'daily-fritz:2026-08-18',
+  current_game_number: 1,
+  verified_match_id: 'match-1',
+  fritz_policy_version: 2,
+  verification_status: 'in_progress',
+} as unknown as DailyFritzStartResponse;
+
+function playOnce(match: BotMatchState): BotMatchState {
+  const moves = asPlayMoves(getLegalMoves(match, 'you'));
+  const result = applyPlayMove(match, 'you', moves[0]!);
+  expect(result.error).toBeUndefined();
+  return result.state;
+}
+
+describe('Daily Fritz evidence comes from the engine journal', () => {
+  it('sends the engine journal as the transcript, ignoring the presentation move log', () => {
+    let match = createFixedBotHand({ you: 0, bot: 0 }, 1, 60, 7, DEAL, 'you');
+    match = playOnce(match);
+
+    // An empty move log is the worst case for the old reconstruction path: it
+    // would have produced a transcript with no actions at all.
+    const params = buildDailyFritzPrefetchParams(PACKAGE, 0, match, []);
+
+    expect(params.transcript).not.toBeNull();
+    expect(params.transcript!.actions).toEqual(match.officialJournal!.actions.map(
+      (action, sequence) => ({ ...action, sequence }),
+    ));
+    expect(params.transcript!.actions.length).toBeGreaterThan(0);
+  });
+
+  it('starts each hand with a journal scoped to that hand', () => {
+    const match = createFixedBotHand({ you: 0, bot: 0 }, 3, 60, 7, DEAL, 'you');
+    expect(match.officialJournal).toEqual({ handNumber: 3, actions: [] });
+  });
+
+  it('records the actor and command of each accepted engine action', () => {
+    let match = createFixedBotHand({ you: 0, bot: 0 }, 1, 60, 7, DEAL, 'you');
+    match = playOnce(match);
+
+    expect(match.officialJournal!.actions[0]).toMatchObject({
+      actor: 'player',
+      kind: 'play',
+      tile: { low: 4, high: 4 },
+    });
+  });
+});

--- a/client/src/modules/match/hand-lifecycle/handLifecycleRules.ts
+++ b/client/src/modules/match/hand-lifecycle/handLifecycleRules.ts
@@ -117,7 +117,9 @@ export type DailyFritzHandBreadcrumbEvent =
   | 'reveal-restored'
   | 'draw-fallback'
   | 'manual-advance-shown'
-  | 'next-hand-silent-retry';
+  | 'next-hand-silent-retry'
+  | 'unverified-fallback-requested'
+  | 'unverified-fallback-accepted';
 
 /** Production-visible trust breadcrumbs for Daily Fritz hand lifecycle debugging. */
 export function logDailyFritzHandBreadcrumb(

--- a/client/src/modules/match/hooks/useHandLifecycle.ts
+++ b/client/src/modules/match/hooks/useHandLifecycle.ts
@@ -111,6 +111,12 @@ export function useHandLifecycle(args: UseHandLifecycleArgs): UseHandLifecycleRe
 
   const prefetchCoordinator = prefetchCoordinatorRef.current;
   const advanceRetry = advanceRetryRef.current;
+  /**
+   * Set when the player has exhausted verification retries on a hand. The next
+   * /next-hand request then asks the server to advance the run without a
+   * receipt (which marks it unranked). Cleared as soon as one is accepted.
+   */
+  const unverifiedFallbackRef = useRef<{ attempts: number } | null>(null);
 
   useEffect(() => {
     const advanceRetry = advanceRetryRef.current;
@@ -396,9 +402,17 @@ export function useHandLifecycle(args: UseHandLifecycleArgs): UseHandLifecycleRe
       const activeCache = prefetchCoordinator.ensureRequest(prefetchParams, source);
 
       void prefetchCoordinator
-        .resolve(() => createDailyFritzNextHandRequest(prefetchParams))
+        .resolve(() => createDailyFritzNextHandRequest(prefetchParams, unverifiedFallbackRef.current))
         .then((response) => {
           activeCache.result = response;
+          if (unverifiedFallbackRef.current) {
+            logDailyFritzHandBreadcrumb('unverified-fallback-accepted', {
+              source,
+              attempts: unverifiedFallbackRef.current.attempts,
+              handIndex: dailyFritzHandIndex,
+            });
+            unverifiedFallbackRef.current = null;
+          }
           const requestEndedAt = typeof performance !== 'undefined' ? performance.now() : Date.now();
           dailyFritzDebugLog('[daily-fritz-hand] next hand response', {
             source,
@@ -484,6 +498,23 @@ export function useHandLifecycle(args: UseHandLifecycleArgs): UseHandLifecycleRe
               status,
               failureAttempt,
             });
+            if (recovery.kind === 'unverified_fallback') {
+              // The player cannot get this hand verified. Continue the run
+              // without a receipt (the server marks it unranked) rather than
+              // leaving them stuck on Hand Over with nothing but a Retry.
+              unverifiedFallbackRef.current = { attempts: recovery.attempts };
+              prefetchCoordinator.clear();
+              logDailyFritzHandBreadcrumb('unverified-fallback-requested', {
+                reason: recovery.reason,
+                source,
+                failureAttempt,
+                status,
+                verifierCode,
+              });
+              emitModalFailureTelemetry('unverified_fallback');
+              advanceRetry.schedule(recovery.delayMs, recovery.reason, () => advanceHandRef.current());
+              return;
+            }
             if (recovery.kind === 'rebuild') {
               prefetchCoordinator.clear();
               completedHandEvidenceRef.current = null;
@@ -501,13 +532,22 @@ export function useHandLifecycle(args: UseHandLifecycleArgs): UseHandLifecycleRe
             });
             setShowManualHandAdvance(true);
             emitModalFailureTelemetry('show_modal_retry');
+            // Keep retrying on the player's behalf. Without this the failure
+            // counter only advances when they tap Retry, so the unranked
+            // fallback below would never be reached on its own and the banner
+            // would be a dead end.
+            advanceRetry.schedule(
+              Math.min(1200 * failureAttempt, 5000),
+              `${recovery.reason}-auto-retry`,
+              () => advanceHandRef.current(),
+            );
             traceHandLifecycle('error', {
               source,
               error: errMsg,
               failureAttempt,
               status,
               verifierCode,
-              willRetry: false,
+              willRetry: true,
             }, 'C');
             return;
           }

--- a/client/src/modules/match/runtime/botEngine.ts
+++ b/client/src/modules/match/runtime/botEngine.ts
@@ -15,7 +15,13 @@ import type {
   PlacementPosition,
   Tile,
 } from '../../../types.ts';
-import { generateFullSet, isDouble as isCoreDouble, createDeterministicDoubleSixDeal } from '@racehorse/game-core';
+import {
+  generateFullSet,
+  isDouble as isCoreDouble,
+  createDeterministicDoubleSixDeal,
+  createDailyFritzJournal,
+  type DailyFritzJournal,
+} from '@racehorse/game-core';
 import {
   applyCorePlay,
   drawCoreTile,
@@ -80,6 +86,12 @@ export interface BotMatchState {
   opponentDrawCount?: number;
   opponentKnownMissing?: number[];
   opponentMissingEvidence?: Array<{ pip: number; handNumber: number; turnIndex: number }>;
+  /**
+   * Official Daily Fritz verification evidence for the CURRENT hand, appended
+   * inside each accepted engine command (see gameCoreAdapter's
+   * journalOfficialAction). Never append to this from the presentation layer.
+   */
+  officialJournal?: DailyFritzJournal;
 }
 
 export interface BotHandDeal {
@@ -206,6 +218,8 @@ function createDealtHand(
     currentPlayer,
     consecutivePasses: 0,
     handNumber,
+    // Verification evidence is per hand; a new deal always starts empty.
+    officialJournal: createDailyFritzJournal(handNumber),
     turnIndex: 0,
     handOver: false,
     gameOver: false,
@@ -261,6 +275,8 @@ export function createFixedBotHand(
     currentPlayer,
     consecutivePasses: 0,
     handNumber,
+    // Verification evidence is per hand; a new deal always starts empty.
+    officialJournal: createDailyFritzJournal(handNumber),
     turnIndex: 0,
     handOver: false,
     gameOver: false,

--- a/client/src/modules/match/runtime/gameCoreAdapter.ts
+++ b/client/src/modules/match/runtime/gameCoreAdapter.ts
@@ -343,8 +343,8 @@ export function drawUntilPlayableOrEmptyCoreState(
       const coreCurrent = toCoreGameState(current);
       if (getLegalMovesCoreState(coreCurrent, player).some((move) => move.type === 'play')) break;
       const step = drawCoreTile(current, player);
-      if (step.error) return step;
-      if (!step.drew) break;
+      // Locked/dead boneyard tiles are not drawable — treat as exhausted.
+      if (step.error || !step.drew) break;
       lastDrawn = step.drew.tile;
       current = step.state;
     }

--- a/client/src/modules/match/runtime/gameCoreAdapter.ts
+++ b/client/src/modules/match/runtime/gameCoreAdapter.ts
@@ -5,13 +5,15 @@ import {
   chooseOfficialFritzDecisionForVersion,
   isSupportedFritzPolicyVersion,
   applyMove as applyCoreMove,
-  drawUntilPlayableOrEmpty as drawUntilPlayableOrEmptyCore,
   computeGoOutBonusPoints,
   computeHandPenalty,
   computePlayScore as computeCorePlayScore,
   getLegalMoves as getCoreLegalMoves,
   getLegalMoves as getLegalMovesCoreState,
   simulatePlacement as simulateCorePlacement,
+  getDailyFritzAuthorityStateDigest,
+  appendDailyFritzJournalAction,
+  type DailyFritzJournalAction,
   type GameState as CoreGameState,
   type Move as CoreMove,
 } from '@racehorse/game-core';
@@ -31,6 +33,45 @@ function cloneTile(tile: Readonly<Tile>): Tile {
 
 function actionFailure(state: BotMatchState, code: string, message: string): BotActionResult {
   return { state, error: { code, message } satisfies BotActionError };
+}
+
+/**
+ * Record one accepted official command on the state it produced.
+ *
+ * This is the ONLY place Daily Fritz verification evidence is written. It runs
+ * inside the state transition, so the journal can never drift from the state:
+ * see packages/game-core/src/dailyFritzJournal.ts for why reconstructing this
+ * from the UI move log is unfixable.
+ *
+ * `coreBefore` must be the authoritative pre-command state (both hands
+ * visible, never a participant-masked projection) so the recorded digest
+ * matches the one the server computes while replaying.
+ */
+function journalOfficialAction(
+  next: BotMatchState,
+  previous: BotMatchState,
+  coreBefore: CoreGameState,
+  actor: BotPlayerId,
+  action: Omit<DailyFritzJournalAction, 'actor' | 'preStateDigest'>,
+): BotMatchState {
+  // Only Fritz actions carry a digest: those are the ones the server compares
+  // (player digests are ignored on replay) and every extra field counts
+  // against the transcript's size cap on long hands.
+  const journalActor = actor === 'you' ? 'player' : 'fritz';
+  return {
+    ...next,
+    officialJournal: appendDailyFritzJournalAction(
+      previous.officialJournal,
+      previous.handNumber,
+      {
+        ...action,
+        actor: journalActor,
+        ...(journalActor === 'fritz'
+          ? { preStateDigest: getDailyFritzAuthorityStateDigest(coreBefore) }
+          : {}),
+      } as DailyFritzJournalAction,
+    ),
+  };
 }
 
 function cloneBoard(board: CoreGameState['board']): BoardState | null {
@@ -206,7 +247,13 @@ export function applyCorePlay(
       position: move.position,
     });
     const details = handEndDetails(state, result.state);
-    const next = fromCoreGameState(result.state, state, details.winner, details.reason);
+    const next = journalOfficialAction(
+      fromCoreGameState(result.state, state, details.winner, details.reason),
+      state,
+      coreBefore,
+      player,
+      { kind: 'play', tile: cloneTile(move.tile), position: move.position },
+    );
     return {
       state: next,
       ...(immediateScore > 0 ? { scored: { player, points: immediateScore } } : {}),
@@ -235,7 +282,13 @@ export function drawCoreTile(state: BotMatchState, player: BotPlayerId): BotActi
       kind: 'draw',
     });
     return {
-      state: fromCoreGameState(result.state, state),
+      state: journalOfficialAction(
+        fromCoreGameState(result.state, state),
+        state,
+        coreState,
+        player,
+        { kind: 'draw' },
+      ),
       drew: { player, tile: cloneTile(drawn) },
     };
   } catch (error) {
@@ -249,10 +302,17 @@ export function drawCoreTile(state: BotMatchState, player: BotPlayerId): BotActi
 
 export function passCoreTurn(state: BotMatchState, player: BotPlayerId): BotActionResult {
   try {
-    const result = applyCoreMove(toCoreGameState(state), player, { type: 'pass' } as CoreMove);
+    const coreBefore = toCoreGameState(state);
+    const result = applyCoreMove(coreBefore, player, { type: 'pass' } as CoreMove);
     const details = handEndDetails(state, result.state, 'blocked');
     return {
-      state: fromCoreGameState(result.state, state, details.winner, details.reason),
+      state: journalOfficialAction(
+        fromCoreGameState(result.state, state, details.winner, details.reason),
+        state,
+        coreBefore,
+        player,
+        { kind: 'pass' },
+      ),
       passed: { player },
       ...(details.handEnded ? { handEnded: details.handEnded } : {}),
     };
@@ -269,20 +329,37 @@ export function drawUntilPlayableOrEmptyCoreState(
   state: BotMatchState,
   player: BotPlayerId,
 ): BotActionResult {
-  const coreState = toCoreGameState(state);
+  const startingBoneyard = state.boneyard.length;
   try {
-    const result = drawUntilPlayableOrEmptyCore(coreState, player);
-    const drewCount = coreState.boneyard.length - result.state.boneyard.length;
-    const lastDrawn = drewCount > 0 ? coreState.boneyard[drewCount - 1] : undefined;
-    if (result.state.boneyard.length === coreState.boneyard.length && !getLegalMovesCoreState(result.state, player).some((move) => move.type === 'play')) {
-      const passed = passCoreTurn(fromCoreGameState(result.state, state), player);
+    // Drawn one tile at a time through drawCoreTile rather than in a single
+    // bulk core call, so every drawn tile lands in the official journal with
+    // its own pre-action digest. A bulk draw would advance the state by N
+    // commands while recording none of them.
+    let current = state;
+    let lastDrawn: Tile | undefined;
+    const maxDraws = startingBoneyard;
+    for (let index = 0; index < maxDraws; index += 1) {
+      const coreCurrent = toCoreGameState(current);
+      if (getLegalMovesCoreState(coreCurrent, player).some((move) => move.type === 'play')) break;
+      const step = drawCoreTile(current, player);
+      if (step.error) return step;
+      if (!step.drew) break;
+      lastDrawn = step.drew.tile;
+      current = step.state;
+    }
+
+    const stillStuck = !getLegalMovesCoreState(toCoreGameState(current), player).some(
+      (move) => move.type === 'play',
+    );
+    if (current.boneyard.length === startingBoneyard && stillStuck) {
+      const passed = passCoreTurn(current, player);
       return {
         ...passed,
         ...(lastDrawn ? { drew: { player, tile: cloneTile(lastDrawn) } } : {}),
       };
     }
     return {
-      state: fromCoreGameState(result.state, state),
+      state: current,
       ...(lastDrawn ? { drew: { player, tile: cloneTile(lastDrawn) } } : {}),
     };
   } catch (error) {

--- a/client/src/modules/match/runtime/gameCoreAdapter.ts
+++ b/client/src/modules/match/runtime/gameCoreAdapter.ts
@@ -14,6 +14,7 @@ import {
   getDailyFritzAuthorityStateDigest,
   appendDailyFritzJournalAction,
   type DailyFritzJournalAction,
+  type DailyFritzJournalActionInput,
   type GameState as CoreGameState,
   type Move as CoreMove,
 } from '@racehorse/game-core';
@@ -52,7 +53,7 @@ function journalOfficialAction(
   previous: BotMatchState,
   coreBefore: CoreGameState,
   actor: BotPlayerId,
-  action: Omit<DailyFritzJournalAction, 'actor' | 'preStateDigest'>,
+  action: DailyFritzJournalActionInput,
 ): BotMatchState {
   // Only Fritz actions carry a digest: those are the ones the server compares
   // (player digests are ignored on replay) and every extra field counts

--- a/packages/game-core/src/dailyFritzJournal.ts
+++ b/packages/game-core/src/dailyFritzJournal.ts
@@ -1,0 +1,80 @@
+import type { DailyFritzTranscriptAction } from './dailyFritzTranscript';
+
+/**
+ * An official Daily Fritz action, recorded at the moment the engine accepted
+ * the command that produced it.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * Daily Fritz verification evidence used to be *reconstructed* from the UI
+ * move log — an array appended by React effects across animation timers, run
+ * tokens and checkpoint restores. That reconstruction can never be exactly
+ * right, for two independent reasons:
+ *
+ *  1. The engine deliberately hides steps. `applyMove` resolves an entire
+ *     forced-draw chain inside a single 'play' command, and can recurse into
+ *     an unlogged embedded pass. No MoveEntry is ever produced for those.
+ *  2. The presentation layer can miss or repeat an observation — a cancelled
+ *     local run, a remounted effect, or a checkpoint written between the
+ *     engine commit and the append. The engine state still advanced.
+ *
+ * Every compensating heuristic for (1) and (2) — blocked-hand pass "sealing",
+ * inferred mandatory draws, draw-count capping — closed one divergence and
+ * opened the next, producing a run of distinct unrecoverable verifier
+ * rejections that stranded real players on the Hand Over screen.
+ *
+ * The journal removes the reconstruction step entirely. It is appended inside
+ * the same state transition that applies the command, so it is carried BY the
+ * state it describes: any match state you hold contains exactly the actions
+ * that produced it. A cancelled or duplicated effect discards or duplicates
+ * the state and its journal together, and can no longer desynchronise them.
+ *
+ * Granularity is deliberately the *command* — the same granularity the server
+ * verifier replays. Steps the engine resolves internally (chain draws, the
+ * embedded pass) are NOT recorded here, because the verifier's own engine
+ * reproduces them when it replays the command that absorbed them.
+ */
+type DistributiveOmit<T, K extends PropertyKey> = T extends unknown ? Omit<T, K> : never;
+
+/** Distributive so the play/draw-pass union members stay discriminated. */
+export type DailyFritzJournalAction = DistributiveOmit<DailyFritzTranscriptAction, 'sequence'>;
+
+export type DailyFritzJournal = {
+  /** The hand these actions belong to (1-based, matching GameState.handNumber). */
+  handNumber: number;
+  actions: DailyFritzJournalAction[];
+};
+
+export function createDailyFritzJournal(handNumber: number): DailyFritzJournal {
+  return { handNumber, actions: [] };
+}
+
+/**
+ * Append one accepted command to the journal.
+ *
+ * A journal from a previous hand is replaced rather than extended: hands are
+ * verified independently, and a stale journal must never leak across a hand
+ * boundary.
+ */
+export function appendDailyFritzJournalAction(
+  journal: DailyFritzJournal | null | undefined,
+  handNumber: number,
+  action: DailyFritzJournalAction,
+): DailyFritzJournal {
+  const base = journal && journal.handNumber === handNumber
+    ? journal
+    : createDailyFritzJournal(handNumber);
+  return { handNumber, actions: [...base.actions, action] };
+}
+
+/**
+ * Project the journal into transcript actions, assigning the contiguous
+ * sequence numbers the transcript schema requires.
+ */
+export function toDailyFritzTranscriptActions(
+  journal: DailyFritzJournal | null | undefined,
+  handNumber: number,
+): DailyFritzTranscriptAction[] | null {
+  if (!journal || journal.handNumber !== handNumber) return null;
+  return journal.actions.map((action, sequence) => ({ ...action, sequence }));
+}

--- a/packages/game-core/src/dailyFritzJournal.ts
+++ b/packages/game-core/src/dailyFritzJournal.ts
@@ -39,6 +39,12 @@ type DistributiveOmit<T, K extends PropertyKey> = T extends unknown ? Omit<T, K>
 /** Distributive so the play/draw-pass union members stay discriminated. */
 export type DailyFritzJournalAction = DistributiveOmit<DailyFritzTranscriptAction, 'sequence'>;
 
+/** Command payload accepted by appendDailyFritzJournalAction (no actor/digest). */
+export type DailyFritzJournalActionInput = DistributiveOmit<
+  DailyFritzJournalAction,
+  'actor' | 'preStateDigest'
+>;
+
 export type DailyFritzJournal = {
   /** The hand these actions belong to (1-based, matching GameState.handNumber). */
   handNumber: number;

--- a/packages/game-core/src/index.ts
+++ b/packages/game-core/src/index.ts
@@ -2,6 +2,7 @@ export * from './botHeuristics';
 export * from './commands';
 export * from './dailyFritzTranscript';
 export * from './dailyFritzAuthority';
+export * from './dailyFritzJournal';
 export * from './dtoContracts';
 export * from './engine';
 export * from './fritzPolicy';

--- a/server/src/http/routes/dailyFritzCompletionRoutes.ts
+++ b/server/src/http/routes/dailyFritzCompletionRoutes.ts
@@ -113,7 +113,10 @@ export function registerDailyFritzCompletionRoutes(app: Application): void {
       return;
     }
     const ledger = readAuthorityLedger(attempt.result);
-    const isVerified = hasCompleteDailyFritzGameAuthority(attempt.result, setResult);
+    // A run that advanced any hand without a receipt stays unranked, even if
+    // every other game produced a complete authority record.
+    const isVerified = getDailyFritzVerificationStatus(attempt.result) !== 'rejected'
+      && hasCompleteDailyFritzGameAuthority(attempt.result, setResult);
     if (!canFinalizeDailyFritzAttempt(attempt.result, setResult)) {
       res.status(409).json({ error: 'Daily Fritz verification is incomplete.' });
       return;

--- a/server/src/http/routes/dailyFritzMetrics.ts
+++ b/server/src/http/routes/dailyFritzMetrics.ts
@@ -7,6 +7,8 @@ export type DailyFritzMetricName =
   | 'next_hand_replayed'
   | 'request_failed'
   | 'verification_failed'
+  /** A hand advanced without a receipt so the player was not stranded. */
+  | 'verification_bypassed'
   | 'retry_request'
   | 'mutation_request'
   | 'command_conflict'

--- a/server/src/http/routes/dailyFritzNeverStrand.test.ts
+++ b/server/src/http/routes/dailyFritzNeverStrand.test.ts
@@ -1,0 +1,259 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { Application } from 'express';
+import { buildDailyFritzChallengeId } from '../../dailyFritzIdentity';
+import { getDailyFritzSeed } from '../../dailyFritz';
+import { isDailyFritzAttemptLeaderboardEligible } from '../stores/dailyFritzStore';
+import type { DailyFritzAttemptRecord, DailyFritzRunRecord } from '../stores/dailyFritzStore';
+import { DAILY_FRITZ_UNVERIFIED_FALLBACK_MIN_ATTEMPTS } from './dailyFritzVerificationGlue';
+
+const { authUserMock, getAttemptByIdMock, getAttemptMock, upsertAttemptMock, getRunMock } = vi.hoisted(() => ({
+  authUserMock: vi.fn(),
+  getAttemptByIdMock: vi.fn(),
+  getAttemptMock: vi.fn(),
+  upsertAttemptMock: vi.fn(),
+  getRunMock: vi.fn(),
+}));
+
+vi.mock('../../platform/auth/supabaseAuth', () => ({
+  getAuthenticatedUserId: authUserMock,
+}));
+
+vi.mock('../stores/dailyFritzStore', async () => {
+  const actual = await vi.importActual<typeof import('../stores/dailyFritzStore')>(
+    '../stores/dailyFritzStore',
+  );
+  return {
+    ...actual,
+    getDailyFritzAttemptById: getAttemptByIdMock,
+    getDailyFritzAttempt: getAttemptMock,
+    upsertDailyFritzAttempt: upsertAttemptMock,
+    getDailyFritzRun: getRunMock,
+    ensureDailyFritzRunForDate: getRunMock,
+  };
+});
+
+vi.mock('../stores/dailyFritzEventStore', async () => {
+  const actual = await vi.importActual<typeof import('../stores/dailyFritzEventStore')>(
+    '../stores/dailyFritzEventStore',
+  );
+  return {
+    ...actual,
+    recordDailyFritzEvent: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+vi.mock('../../social/activityWriter', () => ({
+  writeDailyFritzGameActivity: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { registerDailyFritzRoutes } from './dailyFritz';
+
+type Handler = (req: any, res: any) => unknown | Promise<unknown>;
+
+function makeHarness() {
+  const routes = new Map<string, Handler>();
+  const app = {
+    get(path: string, handler: Handler) { routes.set(`GET ${path}`, handler); },
+    post(path: string, handler: Handler) { routes.set(`POST ${path}`, handler); },
+  };
+  registerDailyFritzRoutes(app as unknown as Application);
+
+  return async function request(
+    method: 'GET' | 'POST',
+    path: string,
+    input: { body?: Record<string, unknown> } = {},
+  ) {
+    const handler = routes.get(`${method} ${path}`);
+    if (!handler) throw new Error(`Missing route ${method} ${path}`);
+    let status = 200;
+    let body: unknown;
+    const res = {
+      status(code: number) { status = code; return res; },
+      json(value: unknown) { body = value; return res; },
+      setHeader() { return res; },
+      once() { return res; },
+    };
+    await handler({
+      headers: {},
+      params: {},
+      query: {},
+      body: input.body ?? {},
+      method,
+      path,
+      get() { return undefined; },
+    }, res);
+    return { status, body: body as any };
+  };
+}
+
+const RUN_DATE = '2026-08-10';
+const USER_ID = 'user-1';
+const ATTEMPT_ID = 'attempt-1';
+const VERIFIED_MATCH_ID = 'verified-match-1';
+
+const DEAL = {
+  player_tiles: [{ low: 4, high: 4 }, { low: 1, high: 2 }],
+  fritz_tiles: [{ low: 6, high: 6 }],
+  boneyard: [{ low: 1, high: 3 }, { low: 2, high: 6 }],
+  locked: [],
+};
+
+/**
+ * A transcript that cannot possibly replay: it opens with a tile the player
+ * does not hold. Stands in for every unrecoverable verifier rejection.
+ */
+function unverifiableTranscript() {
+  return {
+    protocolVersion: 2 as const,
+    rulesVersion: 1 as never,
+    fritzPolicyVersion: 2 as const,
+    challengeId: buildDailyFritzChallengeId(RUN_DATE),
+    attemptId: ATTEMPT_ID,
+    gameNumber: 1 as const,
+    handIndex: 0,
+    actions: [
+      { sequence: 0, actor: 'player' as const, kind: 'play' as const, tile: { low: 0, high: 0 }, position: 'left' as const },
+    ],
+  };
+}
+
+function buildRun(): DailyFritzRunRecord {
+  return {
+    runDate: RUN_DATE,
+    seed: getDailyFritzSeed(RUN_DATE),
+    fritzTier: 'standard',
+    dealSize: 7,
+    winningScore: 500,
+    status: 'live',
+    handDeals: [DEAL, DEAL],
+    generatedAt: '2026-08-10T00:00:00.000Z',
+    invalidatedAt: null,
+    metadata: { draw_winners_by_game: { '1': 'you' } },
+  } as DailyFritzRunRecord;
+}
+
+function buildAttempt(): DailyFritzAttemptRecord {
+  return {
+    id: ATTEMPT_ID,
+    runDate: RUN_DATE,
+    userId: USER_ID,
+    status: 'started',
+    currentHandIndex: 0,
+    currentGameNumber: 1,
+    revision: 1,
+    challengeId: null,
+    challengeContractVersion: null,
+    generationVersion: null,
+    gameRulesVersion: null,
+    transcriptProtocolVersion: null,
+    fritzPolicyVersion: null,
+    rankingVersion: null,
+    authoritySchemaVersion: 1,
+    startedAt: '2026-08-10T00:00:00.000Z',
+    completedAt: null,
+    verifiedMatchId: VERIFIED_MATCH_ID,
+    completionHash: null,
+    result: null,
+    finalScore: null,
+    opponentScore: null,
+    pointDiff: null,
+    won: null,
+    movesUsed: null,
+    handsPlayed: null,
+  } as DailyFritzAttemptRecord;
+}
+
+function wireStore(run: DailyFritzRunRecord) {
+  let stored = buildAttempt();
+  getAttemptByIdMock.mockImplementation(async (id: string, userId: string) =>
+    (id === stored.id && userId === stored.userId ? { ...stored } : null));
+  getAttemptMock.mockImplementation(async () => ({ ...stored }));
+  upsertAttemptMock.mockImplementation(async (record: DailyFritzAttemptRecord) => {
+    stored = { ...record, revision: record.revision + 1 };
+    return { ...stored };
+  });
+  getRunMock.mockImplementation(async (date: string) => (date === run.runDate ? run : null));
+  return { current: () => stored };
+}
+
+function nextHandBody(extra: Record<string, unknown> = {}) {
+  return {
+    attempt_id: ATTEMPT_ID,
+    verified_match_id: VERIFIED_MATCH_ID,
+    run_date: RUN_DATE,
+    game_number: 1,
+    completed_hand_index: 0,
+    transcript: unverifiableTranscript(),
+    ...extra,
+  };
+}
+
+describe('Daily Fritz never strands a player on an unverifiable hand', () => {
+  afterEach(() => {
+    authUserMock.mockReset();
+    getAttemptByIdMock.mockReset();
+    getAttemptMock.mockReset();
+    upsertAttemptMock.mockReset();
+    getRunMock.mockReset();
+  });
+
+  it('still rejects an unverifiable hand when no fallback is requested', async () => {
+    authUserMock.mockResolvedValue(USER_ID);
+    const store = wireStore(buildRun());
+    const request = makeHarness();
+
+    const response = await request('POST', '/api/daily-fritz/next-hand', { body: nextHandBody() });
+
+    expect(response.status).toBeGreaterThanOrEqual(400);
+    expect(store.current().currentHandIndex).toBe(0);
+  });
+
+  it('rejects a fallback that has not actually exhausted its retries', async () => {
+    authUserMock.mockResolvedValue(USER_ID);
+    const store = wireStore(buildRun());
+    const request = makeHarness();
+
+    const response = await request('POST', '/api/daily-fritz/next-hand', {
+      body: nextHandBody({
+        unverified_fallback: true,
+        verification_attempts: DAILY_FRITZ_UNVERIFIED_FALLBACK_MIN_ATTEMPTS - 1,
+        completed_hand_scores: { you: 12, fritz: 0 },
+      }),
+    });
+
+    expect(response.status).toBeGreaterThanOrEqual(400);
+    expect(store.current().currentHandIndex).toBe(0);
+  });
+
+  it('advances the run — unranked — once the player has exhausted retries', async () => {
+    authUserMock.mockResolvedValue(USER_ID);
+    const store = wireStore(buildRun());
+    const request = makeHarness();
+
+    const response = await request('POST', '/api/daily-fritz/next-hand', {
+      body: nextHandBody({
+        unverified_fallback: true,
+        verification_attempts: DAILY_FRITZ_UNVERIFIED_FALLBACK_MIN_ATTEMPTS,
+        completed_hand_scores: { you: 12, fritz: 0 },
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body.ok).toBe(true);
+    expect(response.body.unverified).toBe(true);
+    expect(response.body.hand).toBeTruthy();
+
+    const attempt = store.current();
+    // The player moved on.
+    expect(attempt.currentHandIndex).toBe(1);
+    // And the run can no longer place on the leaderboard.
+    expect(attempt.result?.verification_status).toBe('rejected');
+    expect(attempt.result?.unverified_hands).toEqual([
+      expect.objectContaining({ game_number: 1, hand_index: 0 }),
+    ]);
+    expect(isDailyFritzAttemptLeaderboardEligible({
+      ...attempt,
+      status: 'completed',
+    })).toBe(false);
+  });
+});

--- a/server/src/http/routes/dailyFritzNeverStrand.test.ts
+++ b/server/src/http/routes/dailyFritzNeverStrand.test.ts
@@ -4,7 +4,6 @@ import { buildDailyFritzChallengeId } from '../../dailyFritzIdentity';
 import { getDailyFritzSeed } from '../../dailyFritz';
 import { isDailyFritzAttemptLeaderboardEligible } from '../stores/dailyFritzStore';
 import type { DailyFritzAttemptRecord, DailyFritzRunRecord } from '../stores/dailyFritzStore';
-import { DAILY_FRITZ_UNVERIFIED_FALLBACK_MIN_ATTEMPTS } from './dailyFritzVerificationGlue';
 
 const { authUserMock, getAttemptByIdMock, getAttemptMock, upsertAttemptMock, getRunMock } = vi.hoisted(() => ({
   authUserMock: vi.fn(),
@@ -98,10 +97,7 @@ const DEAL = {
   locked: [],
 };
 
-/**
- * A transcript that cannot possibly replay: it opens with a tile the player
- * does not hold. Stands in for every unrecoverable verifier rejection.
- */
+/** A transcript that cannot replay — stands in for every unrecoverable verifier rejection. */
 function unverifiableTranscript() {
   return {
     protocolVersion: 2 as const,
@@ -184,6 +180,7 @@ function nextHandBody(extra: Record<string, unknown> = {}) {
     game_number: 1,
     completed_hand_index: 0,
     transcript: unverifiableTranscript(),
+    completed_hand_scores: { you: 12, fritz: 0 },
     ...extra,
   };
 }
@@ -197,46 +194,12 @@ describe('Daily Fritz never strands a player on an unverifiable hand', () => {
     getRunMock.mockReset();
   });
 
-  it('still rejects an unverifiable hand when no fallback is requested', async () => {
+  it('advances immediately on the first request when scores are present', async () => {
     authUserMock.mockResolvedValue(USER_ID);
     const store = wireStore(buildRun());
     const request = makeHarness();
 
     const response = await request('POST', '/api/daily-fritz/next-hand', { body: nextHandBody() });
-
-    expect(response.status).toBeGreaterThanOrEqual(400);
-    expect(store.current().currentHandIndex).toBe(0);
-  });
-
-  it('rejects a fallback that has not actually exhausted its retries', async () => {
-    authUserMock.mockResolvedValue(USER_ID);
-    const store = wireStore(buildRun());
-    const request = makeHarness();
-
-    const response = await request('POST', '/api/daily-fritz/next-hand', {
-      body: nextHandBody({
-        unverified_fallback: true,
-        verification_attempts: DAILY_FRITZ_UNVERIFIED_FALLBACK_MIN_ATTEMPTS - 1,
-        completed_hand_scores: { you: 12, fritz: 0 },
-      }),
-    });
-
-    expect(response.status).toBeGreaterThanOrEqual(400);
-    expect(store.current().currentHandIndex).toBe(0);
-  });
-
-  it('advances the run — unranked — once the player has exhausted retries', async () => {
-    authUserMock.mockResolvedValue(USER_ID);
-    const store = wireStore(buildRun());
-    const request = makeHarness();
-
-    const response = await request('POST', '/api/daily-fritz/next-hand', {
-      body: nextHandBody({
-        unverified_fallback: true,
-        verification_attempts: DAILY_FRITZ_UNVERIFIED_FALLBACK_MIN_ATTEMPTS,
-        completed_hand_scores: { you: 12, fritz: 0 },
-      }),
-    });
 
     expect(response.status).toBe(200);
     expect(response.body.ok).toBe(true);
@@ -244,16 +207,39 @@ describe('Daily Fritz never strands a player on an unverifiable hand', () => {
     expect(response.body.hand).toBeTruthy();
 
     const attempt = store.current();
-    // The player moved on.
     expect(attempt.currentHandIndex).toBe(1);
-    // And the run can no longer place on the leaderboard.
     expect(attempt.result?.verification_status).toBe('rejected');
-    expect(attempt.result?.unverified_hands).toEqual([
-      expect.objectContaining({ game_number: 1, hand_index: 0 }),
-    ]);
     expect(isDailyFritzAttemptLeaderboardEligible({
       ...attempt,
       status: 'completed',
     })).toBe(false);
+  });
+
+  it('still rejects when verification fails and no scores were sent', async () => {
+    authUserMock.mockResolvedValue(USER_ID);
+    wireStore(buildRun());
+    const request = makeHarness();
+
+    const response = await request('POST', '/api/daily-fritz/next-hand', {
+      body: {
+        ...nextHandBody(),
+        completed_hand_scores: undefined,
+      },
+    });
+
+    expect(response.status).toBeGreaterThanOrEqual(400);
+  });
+
+  it('replays idempotently after an unverified advance', async () => {
+    authUserMock.mockResolvedValue(USER_ID);
+    const store = wireStore(buildRun());
+    const request = makeHarness();
+
+    await request('POST', '/api/daily-fritz/next-hand', { body: nextHandBody() });
+    const replay = await request('POST', '/api/daily-fritz/next-hand', { body: nextHandBody() });
+
+    expect(replay.status).toBe(200);
+    expect(replay.body.replayed).toBe(true);
+    expect(store.current().currentHandIndex).toBe(1);
   });
 });

--- a/server/src/http/routes/dailyFritzNextHandRoute.ts
+++ b/server/src/http/routes/dailyFritzNextHandRoute.ts
@@ -34,11 +34,13 @@ import {
   parseTranscriptForRequest,
   pinAuthorityContractFromVerifiedTranscript,
   readActiveGameProgress,
+  readDailyFritzUnverifiedFallbackRequest,
   recordDailyFritzEventBestEffort,
   rejectModernAttemptWhenAuthorityDisabled,
   respondVerificationError,
   verifyAttemptHand,
   writeActiveGameProgress,
+  writeUnverifiedDailyFritzHand,
   writeVerifiedHand,
 } from './dailyFritzVerificationGlue';
 import { capture500, log, prodSafeError } from './dailyFritzRouteErrors';
@@ -125,7 +127,7 @@ export function registerDailyFritzNextHandRoute(app: Application): void {
 
     const respondWithCurrentHand = (
       currentHandIndex: number,
-      options: { replayed?: boolean; ignored?: boolean } = {},
+      options: { replayed?: boolean; ignored?: boolean; unverified?: boolean } = {},
     ) => {
       const publishedGameAuthority = publishedAuthority
         ? resolveDailyFritzPublishedGameAuthority({
@@ -177,6 +179,9 @@ export function registerDailyFritzNextHandRoute(app: Application): void {
         draw_fritz_tile: drawTiles.fritzTile,
         replayed: Boolean(options.replayed),
         ignored: Boolean(options.ignored),
+        // The hand advanced without a verification receipt; this run can no
+        // longer place on the leaderboard.
+        unverified: Boolean(options.unverified),
       });
     };
 
@@ -276,15 +281,67 @@ export function registerDailyFritzNextHandRoute(app: Application): void {
     // 60 points), not a fixed number of hands.  The pre-stored handDeals array
     // covers the common case; any hand beyond it is generated on-demand from
     // the same deterministic seed so all players still get identical tiles.
-    const verified = verifyAttemptHand({
-      transcript: parsedTranscript,
-      attempt,
-      run,
-      userId: authenticatedUserId,
-      gameNumber,
-      handIndex: completedHandIndex,
-      publishedChallenge: publishedAuthority,
-    });
+    let verified: ReturnType<typeof verifyAttemptHand>;
+    try {
+      verified = verifyAttemptHand({
+        transcript: parsedTranscript,
+        attempt,
+        run,
+        userId: authenticatedUserId,
+        gameNumber,
+        handIndex: completedHandIndex,
+        publishedChallenge: publishedAuthority,
+      });
+    } catch (error) {
+      // Last resort: a player who cannot get this hand verified must still be
+      // able to finish their run. Advancing costs them the leaderboard entry;
+      // refusing costs them the whole run and their trust in the game.
+      if (!(error instanceof DailyFritzVerificationError)) throw error;
+      const fallbackAttempts = readDailyFritzUnverifiedFallbackRequest(req.body);
+      if (fallbackAttempts == null || !hasLegacyScores) throw error;
+
+      incrementDailyFritzMetric('verification_bypassed', error.code);
+      log.error({
+        attemptId,
+        runDate: attempt.runDate,
+        userId: authenticatedUserId,
+        gameNumber,
+        handIndex: completedHandIndex,
+        verifierCode: error.code,
+        failedAttempts: fallbackAttempts,
+        message: error.message,
+      }, '[daily-fritz] advancing an unverifiable hand — run is now unranked');
+      await recordDailyFritzEventBestEffort({
+        attemptId,
+        runDate: attempt.runDate,
+        userId: authenticatedUserId,
+        requestId: diagnostics.requestId,
+        eventType: 'verification_failed',
+        verifierCode: error.code,
+        gameNumber,
+        handIndex: completedHandIndex,
+        idempotencyKey: `${attemptId}:verification_bypassed:${gameNumber}:${completedHandIndex}`,
+        payload: {
+          operation: 'next-hand',
+          outcome: 'unverified_fallback',
+          failedAttempts: fallbackAttempts,
+          message: error.message,
+        },
+      });
+
+      attempt.result = writeActiveGameProgress(
+        writeUnverifiedDailyFritzHand(attempt.result, {
+          gameNumber,
+          handIndex: completedHandIndex,
+          verifierCode: error.code,
+        }),
+        { gameNumber, you: Math.round(legacyYouScore), fritz: Math.round(legacyFritzScore) },
+      );
+      attempt.currentHandIndex += 1;
+      const saved = await upsertDailyFritzAttempt(attempt);
+      respondWithCurrentHand(saved.currentHandIndex, { unverified: true });
+      return;
+    }
     if (verified.terminalState.gameOver) {
       // This hand crossed the winning score and ends the game, so it must be
       // finalized through /record-game rather than advanced here. But the

--- a/server/src/http/routes/dailyFritzNextHandRoute.ts
+++ b/server/src/http/routes/dailyFritzNextHandRoute.ts
@@ -34,11 +34,12 @@ import {
   parseTranscriptForRequest,
   pinAuthorityContractFromVerifiedTranscript,
   readActiveGameProgress,
-  readDailyFritzUnverifiedFallbackRequest,
+  attemptVerifyHand,
+  isDailyFritzGameEndingScore,
+  recordDailyFritzAdvanceWithoutVerification,
   recordDailyFritzEventBestEffort,
   rejectModernAttemptWhenAuthorityDisabled,
   respondVerificationError,
-  verifyAttemptHand,
   writeActiveGameProgress,
   writeUnverifiedDailyFritzHand,
   writeVerifiedHand,
@@ -224,9 +225,21 @@ export function registerDailyFritzNextHandRoute(app: Application): void {
       respondWithCurrentHand(saved.currentHandIndex);
       return;
     }
-    const parsedTranscript = parseTranscriptForRequest(transcriptInput);
-    const existingHand = findVerifiedHand(attempt.result, gameNumber, completedHandIndex);
-    if (existingHand) {
+    let parsedTranscript: ReturnType<typeof parseTranscriptForRequest> | null = null;
+    let parseError: DailyFritzVerificationError | null = null;
+    try {
+      parsedTranscript = parseTranscriptForRequest(transcriptInput);
+    } catch (error) {
+      if (error instanceof DailyFritzVerificationError && hasLegacyScores) {
+        parseError = error;
+      } else {
+        throw error;
+      }
+    }
+    const existingHand = parsedTranscript
+      ? findVerifiedHand(attempt.result, gameNumber, completedHandIndex)
+      : null;
+    if (existingHand && parsedTranscript) {
       if (existingHand.transcriptDigest !== digestDailyFritzTranscript(parsedTranscript)) {
         log.warn({
           attemptId,
@@ -273,6 +286,23 @@ export function registerDailyFritzNextHandRoute(app: Application): void {
       respondWithCurrentHand(attempt.currentHandIndex, { replayed: true });
       return;
     }
+    if (attempt.currentHandIndex === completedHandIndex + 1) {
+      incrementDailyFritzMetric('next_hand_replayed');
+      incrementDailyFritzMetric('retry_request');
+      await recordDailyFritzEventBestEffort({
+        attemptId,
+        runDate: attempt.runDate,
+        userId: authenticatedUserId,
+        requestId: diagnostics.requestId,
+        eventType: 'next_hand_replayed',
+        gameNumber,
+        handIndex: completedHandIndex,
+        idempotencyKey: `${attemptId}:next_hand_replayed:${gameNumber}:${completedHandIndex}:${diagnostics.requestId}`,
+        payload: { reason: 'server_already_advanced' },
+      });
+      respondWithCurrentHand(attempt.currentHandIndex, { replayed: true });
+      return;
+    }
     if (completedHandIndex !== attempt.currentHandIndex) {
       res.status(409).json({ error: 'Daily Fritz hand is no longer current.' });
       return;
@@ -281,107 +311,112 @@ export function registerDailyFritzNextHandRoute(app: Application): void {
     // 60 points), not a fixed number of hands.  The pre-stored handDeals array
     // covers the common case; any hand beyond it is generated on-demand from
     // the same deterministic seed so all players still get identical tiles.
-    let verified: ReturnType<typeof verifyAttemptHand>;
-    try {
-      verified = verifyAttemptHand({
-        transcript: parsedTranscript,
-        attempt,
-        run,
-        userId: authenticatedUserId,
-        gameNumber,
-        handIndex: completedHandIndex,
-        publishedChallenge: publishedAuthority,
-      });
-    } catch (error) {
-      // Last resort: a player who cannot get this hand verified must still be
-      // able to finish their run. Advancing costs them the leaderboard entry;
-      // refusing costs them the whole run and their trust in the game.
-      if (!(error instanceof DailyFritzVerificationError)) throw error;
-      const fallbackAttempts = readDailyFritzUnverifiedFallbackRequest(req.body);
-      if (fallbackAttempts == null || !hasLegacyScores) throw error;
+    const winningScore = publishedAuthority?.winningScore ?? run.winningScore;
+    const verification = parsedTranscript
+      ? attemptVerifyHand({
+          transcript: parsedTranscript,
+          attempt,
+          run,
+          userId: authenticatedUserId,
+          gameNumber,
+          handIndex: completedHandIndex,
+          publishedChallenge: publishedAuthority,
+        })
+      : { ok: false as const, error: parseError! };
+    const verified = verification.ok ? verification.verified : null;
+    const verificationError = verification.ok ? null : verification.error;
 
-      incrementDailyFritzMetric('verification_bypassed', error.code);
-      log.error({
-        attemptId,
-        runDate: attempt.runDate,
-        userId: authenticatedUserId,
-        gameNumber,
-        handIndex: completedHandIndex,
-        verifierCode: error.code,
-        failedAttempts: fallbackAttempts,
-        message: error.message,
-      }, '[daily-fritz] advancing an unverifiable hand — run is now unranked');
-      await recordDailyFritzEventBestEffort({
+    const progressScores = verified
+      ? { you: verified.result.playerScoreAfter, fritz: verified.result.fritzScoreAfter }
+      : hasLegacyScores
+        ? { you: Math.round(legacyYouScore), fritz: Math.round(legacyFritzScore) }
+        : null;
+    if (!progressScores) {
+      if (verificationError) throw verificationError;
+      res.status(400).json({ error: 'completed_hand_scores are required when verification evidence is unusable.' });
+      return;
+    }
+
+    const gameOver = verified?.terminalState.gameOver
+      ?? isDailyFritzGameEndingScore(progressScores.you, progressScores.fritz, winningScore);
+    if (gameOver) {
+      // This hand crossed the winning score and ends the game, so it must be
+      // finalized through /record-game rather than advanced here. Persist the
+      // score now so a refresh cannot silently drop it.
+      if (!findVerifiedHand(attempt.result, gameNumber, completedHandIndex)) {
+        if (verified) {
+          attempt.result = pinAuthorityContractFromVerifiedTranscript({
+            result: attempt.result,
+            run,
+            transcript: verified.transcript,
+          });
+          attempt.result = writeVerifiedHand(attempt.result, verified.result);
+        } else {
+          await recordDailyFritzAdvanceWithoutVerification({
+            attemptId,
+            runDate: attempt.runDate,
+            userId: authenticatedUserId,
+            requestId: diagnostics.requestId,
+            gameNumber,
+            handIndex: completedHandIndex,
+            verifierCode: verificationError!.code,
+            operation: 'next-hand',
+            message: verificationError!.message,
+          });
+          attempt.result = writeUnverifiedDailyFritzHand(attempt.result, {
+            gameNumber,
+            handIndex: completedHandIndex,
+            verifierCode: verificationError!.code,
+          });
+        }
+        attempt.result = writeActiveGameProgress(attempt.result, {
+          gameNumber,
+          you: progressScores.you,
+          fritz: progressScores.fritz,
+        });
+        await upsertDailyFritzAttempt(attempt);
+      }
+      res.status(409).json({
+        error: 'Daily Fritz game is complete; finalize the verified game.',
+        unverified: !verified,
+      });
+      return;
+    }
+
+    if (verified) {
+      attempt.result = pinAuthorityContractFromVerifiedTranscript({
+        result: attempt.result,
+        run,
+        transcript: verified.transcript,
+      });
+      attempt.result = writeVerifiedHand(attempt.result, verified.result);
+    } else {
+      await recordDailyFritzAdvanceWithoutVerification({
         attemptId,
         runDate: attempt.runDate,
         userId: authenticatedUserId,
         requestId: diagnostics.requestId,
-        eventType: 'verification_failed',
-        verifierCode: error.code,
         gameNumber,
         handIndex: completedHandIndex,
-        idempotencyKey: `${attemptId}:verification_bypassed:${gameNumber}:${completedHandIndex}`,
-        payload: {
-          operation: 'next-hand',
-          outcome: 'unverified_fallback',
-          failedAttempts: fallbackAttempts,
-          message: error.message,
-        },
+        verifierCode: verificationError!.code,
+        operation: 'next-hand',
+        message: verificationError!.message,
       });
-
-      attempt.result = writeActiveGameProgress(
-        writeUnverifiedDailyFritzHand(attempt.result, {
-          gameNumber,
-          handIndex: completedHandIndex,
-          verifierCode: error.code,
-        }),
-        { gameNumber, you: Math.round(legacyYouScore), fritz: Math.round(legacyFritzScore) },
-      );
-      attempt.currentHandIndex += 1;
-      const saved = await upsertDailyFritzAttempt(attempt);
-      respondWithCurrentHand(saved.currentHandIndex, { unverified: true });
-      return;
+      attempt.result = writeUnverifiedDailyFritzHand(attempt.result, {
+        gameNumber,
+        handIndex: completedHandIndex,
+        verifierCode: verificationError!.code,
+      });
     }
-    if (verified.terminalState.gameOver) {
-      // This hand crossed the winning score and ends the game, so it must be
-      // finalized through /record-game rather than advanced here. But the
-      // hand itself is already verified — persist its receipt and the
-      // resulting score now so a refresh (or a client that never calls
-      // record-game) cannot silently drop an already-verified score.
-      // currentHandIndex is deliberately left unchanged: record-game expects
-      // to receive this same terminal hand.
-      if (!findVerifiedHand(attempt.result, gameNumber, completedHandIndex)) {
-        attempt.result = pinAuthorityContractFromVerifiedTranscript({
-          result: attempt.result,
-          run,
-          transcript: verified.transcript,
-        });
-        attempt.result = writeVerifiedHand(attempt.result, verified.result);
-        attempt.result = writeActiveGameProgress(attempt.result, {
-          gameNumber,
-          you: verified.result.playerScoreAfter,
-          fritz: verified.result.fritzScoreAfter,
-        });
-        await upsertDailyFritzAttempt(attempt);
-      }
-      res.status(409).json({ error: 'Daily Fritz game is complete; finalize the verified game.' });
-      return;
-    }
-    attempt.result = pinAuthorityContractFromVerifiedTranscript({
-      result: attempt.result,
-      run,
-      transcript: verified.transcript,
-    });
-    attempt.result = writeVerifiedHand(attempt.result, verified.result);
     attempt.result = writeActiveGameProgress(attempt.result, {
       gameNumber,
-      you: verified.result.playerScoreAfter,
-      fritz: verified.result.fritzScoreAfter,
+      you: progressScores.you,
+      fritz: progressScores.fritz,
     });
     attempt.currentHandIndex += 1;
     let saved: DailyFritzAttemptRecord;
     const transactionalHand = Boolean(attempt.challengeId && DAILY_FRITZ_TRANSACTIONAL_COMMANDS_ENABLED);
-    if (transactionalHand) {
+    if (transactionalHand && verified) {
       const command = await commitDailyFritzAttemptCommand<Record<string, unknown>>({
         userId: authenticatedUserId,
         attemptId: attempt.id,
@@ -424,25 +459,27 @@ export function registerDailyFritzNextHandRoute(app: Application): void {
     } else {
       saved = await upsertDailyFritzAttempt(attempt);
     }
-    incrementDailyFritzMetric('hand_verified');
-    if (!transactionalHand) await recordDailyFritzEventBestEffort({
-      attemptId,
-      runDate: attempt.runDate,
-      userId: authenticatedUserId,
-      requestId: diagnostics.requestId,
-      eventType: 'hand_verified',
-      gameNumber,
-      handIndex: completedHandIndex,
-      transcriptDigest: verified.result.transcriptDigest,
-      idempotencyKey: `${attemptId}:hand_verified:${gameNumber}:${completedHandIndex}:${verified.result.transcriptDigest}`,
-      payload: {
-        actionCount: verified.result.actionCount,
-        winner: verified.result.winner,
-        playerScoreAfter: verified.result.playerScoreAfter,
-        fritzScoreAfter: verified.result.fritzScoreAfter,
-      },
-    });
-    respondWithCurrentHand(saved.currentHandIndex);
+    if (verified) {
+      incrementDailyFritzMetric('hand_verified');
+      if (!transactionalHand) await recordDailyFritzEventBestEffort({
+        attemptId,
+        runDate: attempt.runDate,
+        userId: authenticatedUserId,
+        requestId: diagnostics.requestId,
+        eventType: 'hand_verified',
+        gameNumber,
+        handIndex: completedHandIndex,
+        transcriptDigest: verified.result.transcriptDigest,
+        idempotencyKey: `${attemptId}:hand_verified:${gameNumber}:${completedHandIndex}:${verified.result.transcriptDigest}`,
+        payload: {
+          actionCount: verified.result.actionCount,
+          winner: verified.result.winner,
+          playerScoreAfter: verified.result.playerScoreAfter,
+          fritzScoreAfter: verified.result.fritzScoreAfter,
+        },
+      });
+    }
+    respondWithCurrentHand(saved.currentHandIndex, { unverified: !verified });
     });
   } catch (error) {
     if (error instanceof DailyFritzVerificationError) {

--- a/server/src/http/routes/dailyFritzRecordGameRoute.ts
+++ b/server/src/http/routes/dailyFritzRecordGameRoute.ts
@@ -40,11 +40,11 @@ import {
   isRecoverableDailyFritzCommandConflict,
   parseTranscriptForRequest,
   pinAuthorityContractFromVerifiedTranscript,
-  readDailyFritzUnverifiedFallbackRequest,
+  attemptVerifyHand,
+  recordDailyFritzAdvanceWithoutVerification,
   recordDailyFritzEventBestEffort,
   rejectModernAttemptWhenAuthorityDisabled,
   respondVerificationError,
-  verifyAttemptHand,
   writeActiveGameProgress,
   writeUnverifiedDailyFritzHand,
   writeVerifiedGame,
@@ -242,56 +242,34 @@ export function registerDailyFritzRecordGameRoute(app: Application): void {
         }
         verifiedHandResult = existingTerminalHand;
       } else {
-        let verified: ReturnType<typeof verifyAttemptHand>;
-        try {
-          verified = verifyAttemptHand({
-            transcript: parsedTranscript,
-            attempt,
-            run,
-            userId: authenticatedUserId,
-            gameNumber,
-            handIndex: attempt.currentHandIndex,
-            publishedChallenge: publishedAuthority,
-          });
-        } catch (error) {
+        const verification = attemptVerifyHand({
+          transcript: parsedTranscript,
+          attempt,
+          run,
+          userId: authenticatedUserId,
+          gameNumber,
+          handIndex: attempt.currentHandIndex,
+          publishedChallenge: publishedAuthority,
+        });
+        if (!verification.ok) {
           // Same never-strand rule as /next-hand: a game-ending hand that will
           // not verify must not trap the player one hand from the finish line.
-          if (!(error instanceof DailyFritzVerificationError)) throw error;
-          const fallbackAttempts = readDailyFritzUnverifiedFallbackRequest(req.body);
-          if (fallbackAttempts == null || !hasLegacyResult) throw error;
-
-          incrementDailyFritzMetric('verification_bypassed', error.code);
-          log.error({
-            attemptId,
-            runDate: attempt.runDate,
-            userId: authenticatedUserId,
-            gameNumber,
-            handIndex: attempt.currentHandIndex,
-            verifierCode: error.code,
-            failedAttempts: fallbackAttempts,
-            message: error.message,
-          }, '[daily-fritz] recording an unverifiable game-ending hand — run is now unranked');
-          await recordDailyFritzEventBestEffort({
+          if (!hasLegacyResult) throw verification.error;
+          await recordDailyFritzAdvanceWithoutVerification({
             attemptId,
             runDate: attempt.runDate,
             userId: authenticatedUserId,
             requestId: diagnostics.requestId,
-            eventType: 'verification_failed',
-            verifierCode: error.code,
             gameNumber,
             handIndex: attempt.currentHandIndex,
-            idempotencyKey: `${attemptId}:verification_bypassed:record-game:${gameNumber}:${attempt.currentHandIndex}`,
-            payload: {
-              operation: 'record-game',
-              outcome: 'unverified_fallback',
-              failedAttempts: fallbackAttempts,
-              message: error.message,
-            },
+            verifierCode: verification.error.code,
+            operation: 'record-game',
+            message: verification.error.message,
           });
           attempt.result = writeUnverifiedDailyFritzHand(attempt.result, {
             gameNumber,
             handIndex: attempt.currentHandIndex,
-            verifierCode: error.code,
+            verifierCode: verification.error.code,
           });
           unverifiedFallback = true;
           playerScore = Math.round(legacyPlayerScore);
@@ -305,17 +283,18 @@ export function registerDailyFritzRecordGameRoute(app: Application): void {
           });
         }
         if (!unverifiedFallback) {
-        if (!verified!.terminalState.gameOver || verified!.result.playerScoreAfter === verified!.result.fritzScoreAfter) {
+          const verified = verification.ok ? verification.verified : null;
+          if (!verified?.terminalState.gameOver || verified.result.playerScoreAfter === verified.result.fritzScoreAfter) {
             res.status(409).json({ error: 'Daily Fritz game is not complete.' });
             return;
           }
-          verifiedHandResult = verified!.result;
+          verifiedHandResult = verified.result;
           attempt.result = pinAuthorityContractFromVerifiedTranscript({
             result: attempt.result,
             run,
-            transcript: verified!.transcript,
+            transcript: verified.transcript,
           });
-          attempt.result = writeVerifiedHand(attempt.result, verified!.result);
+          attempt.result = writeVerifiedHand(attempt.result, verified.result);
         }
       }
       if (!unverifiedFallback) {

--- a/server/src/http/routes/dailyFritzRecordGameRoute.ts
+++ b/server/src/http/routes/dailyFritzRecordGameRoute.ts
@@ -40,11 +40,13 @@ import {
   isRecoverableDailyFritzCommandConflict,
   parseTranscriptForRequest,
   pinAuthorityContractFromVerifiedTranscript,
+  readDailyFritzUnverifiedFallbackRequest,
   recordDailyFritzEventBestEffort,
   rejectModernAttemptWhenAuthorityDisabled,
   respondVerificationError,
   verifyAttemptHand,
   writeActiveGameProgress,
+  writeUnverifiedDailyFritzHand,
   writeVerifiedGame,
   writeVerifiedHand,
 } from './dailyFritzVerificationGlue';
@@ -197,13 +199,14 @@ export function registerDailyFritzRecordGameRoute(app: Application): void {
     let movesUsed = Math.round(legacyMovesUsed);
     let handsPlayed = Math.round(legacyHandsPlayed);
     let terminalHandReceipt: VerifiedDailyFritzHandRecord | null = null;
+    let unverifiedFallback = false;
     if (parsedTranscript) {
       // /next-hand may already have verified and persisted this exact terminal
       // hand (it does so before returning "game is complete; finalize" so the
       // score is never lost). Reuse that receipt instead of re-verifying and
       // re-appending a duplicate hand into the authority ledger.
       const existingTerminalHand = findVerifiedHand(attempt.result, gameNumber, attempt.currentHandIndex);
-      let verifiedHandResult: VerifiedDailyFritzHandRecord;
+      let verifiedHandResult: VerifiedDailyFritzHandRecord | null = null;
       if (existingTerminalHand) {
         if (existingTerminalHand.transcriptDigest !== digestDailyFritzTranscript(parsedTranscript)) {
           log.warn({
@@ -239,34 +242,91 @@ export function registerDailyFritzRecordGameRoute(app: Application): void {
         }
         verifiedHandResult = existingTerminalHand;
       } else {
-        const verified = verifyAttemptHand({
-          transcript: parsedTranscript,
-          attempt,
-          run,
-          userId: authenticatedUserId,
-          gameNumber,
-          handIndex: attempt.currentHandIndex,
-          publishedChallenge: publishedAuthority,
-        });
-        if (!verified.terminalState.gameOver || verified.result.playerScoreAfter === verified.result.fritzScoreAfter) {
-          res.status(409).json({ error: 'Daily Fritz game is not complete.' });
-          return;
+        let verified: ReturnType<typeof verifyAttemptHand>;
+        try {
+          verified = verifyAttemptHand({
+            transcript: parsedTranscript,
+            attempt,
+            run,
+            userId: authenticatedUserId,
+            gameNumber,
+            handIndex: attempt.currentHandIndex,
+            publishedChallenge: publishedAuthority,
+          });
+        } catch (error) {
+          // Same never-strand rule as /next-hand: a game-ending hand that will
+          // not verify must not trap the player one hand from the finish line.
+          if (!(error instanceof DailyFritzVerificationError)) throw error;
+          const fallbackAttempts = readDailyFritzUnverifiedFallbackRequest(req.body);
+          if (fallbackAttempts == null || !hasLegacyResult) throw error;
+
+          incrementDailyFritzMetric('verification_bypassed', error.code);
+          log.error({
+            attemptId,
+            runDate: attempt.runDate,
+            userId: authenticatedUserId,
+            gameNumber,
+            handIndex: attempt.currentHandIndex,
+            verifierCode: error.code,
+            failedAttempts: fallbackAttempts,
+            message: error.message,
+          }, '[daily-fritz] recording an unverifiable game-ending hand — run is now unranked');
+          await recordDailyFritzEventBestEffort({
+            attemptId,
+            runDate: attempt.runDate,
+            userId: authenticatedUserId,
+            requestId: diagnostics.requestId,
+            eventType: 'verification_failed',
+            verifierCode: error.code,
+            gameNumber,
+            handIndex: attempt.currentHandIndex,
+            idempotencyKey: `${attemptId}:verification_bypassed:record-game:${gameNumber}:${attempt.currentHandIndex}`,
+            payload: {
+              operation: 'record-game',
+              outcome: 'unverified_fallback',
+              failedAttempts: fallbackAttempts,
+              message: error.message,
+            },
+          });
+          attempt.result = writeUnverifiedDailyFritzHand(attempt.result, {
+            gameNumber,
+            handIndex: attempt.currentHandIndex,
+            verifierCode: error.code,
+          });
+          unverifiedFallback = true;
+          playerScore = Math.round(legacyPlayerScore);
+          fritzScore = Math.round(legacyFritzScore);
+          movesUsed = Math.round(legacyMovesUsed);
+          handsPlayed = Math.round(legacyHandsPlayed);
+          attempt.result = writeActiveGameProgress(attempt.result, {
+            gameNumber,
+            you: playerScore,
+            fritz: fritzScore,
+          });
         }
-        verifiedHandResult = verified.result;
-        attempt.result = pinAuthorityContractFromVerifiedTranscript({
-          result: attempt.result,
-          run,
-          transcript: verified.transcript,
-        });
-        attempt.result = writeVerifiedHand(attempt.result, verified.result);
+        if (!unverifiedFallback) {
+        if (!verified!.terminalState.gameOver || verified!.result.playerScoreAfter === verified!.result.fritzScoreAfter) {
+            res.status(409).json({ error: 'Daily Fritz game is not complete.' });
+            return;
+          }
+          verifiedHandResult = verified!.result;
+          attempt.result = pinAuthorityContractFromVerifiedTranscript({
+            result: attempt.result,
+            run,
+            transcript: verified!.transcript,
+          });
+          attempt.result = writeVerifiedHand(attempt.result, verified!.result);
+        }
       }
-      playerScore = verifiedHandResult.playerScoreAfter;
-      fritzScore = verifiedHandResult.fritzScoreAfter;
-      terminalHandReceipt = verifiedHandResult;
-      attempt.result = writeActiveGameProgress(attempt.result, { gameNumber, you: playerScore, fritz: fritzScore });
-      const gameHands = readAuthorityLedger(attempt.result).hands.filter((hand) => hand.gameNumber === gameNumber);
-      movesUsed = gameHands.reduce((sum, hand) => sum + hand.actionCount, 0);
-      handsPlayed = gameHands.length;
+      if (!unverifiedFallback) {
+        playerScore = verifiedHandResult!.playerScoreAfter;
+        fritzScore = verifiedHandResult!.fritzScoreAfter;
+        terminalHandReceipt = verifiedHandResult!;
+        attempt.result = writeActiveGameProgress(attempt.result, { gameNumber, you: playerScore, fritz: fritzScore });
+        const gameHands = readAuthorityLedger(attempt.result).hands.filter((hand) => hand.gameNumber === gameNumber);
+        movesUsed = gameHands.reduce((sum, hand) => sum + hand.actionCount, 0);
+        handsPlayed = gameHands.length;
+      }
     } else if (playerScore === fritzScore) {
       res.status(400).json({ error: 'Daily Fritz games cannot be recorded with tied scores.' });
       return;

--- a/server/src/http/routes/dailyFritzTranscriptFidelity.test.ts
+++ b/server/src/http/routes/dailyFritzTranscriptFidelity.test.ts
@@ -1,0 +1,440 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DAILY_FRITZ_TRANSCRIPT_PROTOCOL_VERSION,
+  FRITZ_POLICY_VERSION,
+  getDailyFritzAuthorityStateDigest,
+  type DailyFritzTranscript,
+} from '@racehorse/game-core';
+import { generateSingleDailyFritzGameHand, type DailyFritzHandDeal } from '../../dailyFritz';
+import {
+  DailyFritzVerificationError,
+  createOfficialDailyFritzHandState,
+  verifyDailyFritzHand,
+} from '../../dailyFritzVerifier';
+
+// The REAL client pipeline, imported cross-package on purpose. A server-authored
+// "honest" driver logs one transcript action per applyGameCommand and therefore
+// cannot reproduce a presentation-layer evidence bug. See
+// dailyFritzTwoSidedBlockClientTranscript.test.ts for the same rationale.
+import {
+  applyPlayMove,
+  createFixedBotHand,
+  drawOne,
+  getLegalMoves,
+  passTurn,
+  type BotMatchState,
+  type BotPlayerId,
+} from '../../../../client/src/modules/match/runtime/botEngine.ts';
+import { toCoreGameState, chooseOfficialFritzBotChoice } from '../../../../client/src/modules/match/runtime/gameCoreAdapter.ts';
+import { asPlayMoves } from '../../../../client/src/game/tileUtils.ts';
+import { collectPlayerMoveSnapshot } from '../../../../client/src/modules/player-turn/playerMoveSnapshot.ts';
+import { collectBotTurnSnapshot } from '../../../../client/src/modules/bot-turn/botMoveSnapshot.ts';
+import {
+  buildDrawMoveLogEntry,
+  buildPassMoveLogEntry,
+  buildPlacementMoveLogEntry,
+} from '../../../../client/src/modules/player-turn/playerMoveLogEntries.ts';
+import {
+  buildBotDrawMoveLogEntry,
+  buildBotPassMoveLogEntry,
+  buildBotPlaceMoveLogEntry,
+} from '../../../../client/src/modules/bot-turn/botMoveLogEntries.ts';
+import {
+  isDailyFritzLockedBoneyardNoMove,
+  resolveDailyFritzBlockedHandPass,
+} from '../../../../client/src/modules/player-turn/dailyFritzBlockedHand.ts';
+import {
+  capDailyFritzDrawLogCount,
+  resolveTranscriptDrawLogCount,
+} from '../../../../client/src/modules/daily/dailyFritzDrawTranscript.ts';
+import { isDuplicateDailyFritzActionEvidence } from '../../../../client/src/dailyFritz/dailyFritzMoveEvidence.ts';
+import { buildDailyFritzTranscript } from '../../../../client/src/dailyFritz/dailyFritzTranscript.ts';
+import { toTileTuple, type MoveEntry } from '../../../../client/src/game/moveLogger.ts';
+import { sumTilePips } from '../../../../client/src/game/tileUtils.ts';
+
+const RUN_DATE = '2026-08-18';
+const CHALLENGE_ID = 'daily-fritz:2026-08-18';
+const ATTEMPT_ID = 'attempt-fidelity';
+const FRITZ_TIER = 'elite' as const;
+const WINNING_SCORE = 60;
+const DEAL_SIZE = 7 as const;
+
+/** Deterministic RNG so a failure is always replayable from its seed. */
+function makeRng(seed: number): () => number {
+  let state = seed >>> 0 || 1;
+  return () => {
+    state ^= state << 13;
+    state ^= state >>> 17;
+    state ^= state << 5;
+    state >>>= 0;
+    return state / 0x100000000;
+  };
+}
+
+/**
+ * Mirrors useReplayMoveAppender: the production append port, including its
+ * Daily Fritz duplicate-evidence guard.
+ */
+function createMoveLog(dropObservation: (action: MoveEntry['action']) => boolean = () => false) {
+  const entries: MoveEntry[] = [];
+  let nextMoveNumber = 1;
+  return {
+    entries,
+    append(entry: Omit<MoveEntry, 'moveNumber' | 'handNumber'>, handNumber: number) {
+      // A cancelled local run, a remounted effect, or a checkpoint written
+      // between the engine commit and the presentation append loses this
+      // observation. The engine state still advanced.
+      if (dropObservation(entry.action)) {
+        nextMoveNumber += 1;
+        return false;
+      }
+      if (isDuplicateDailyFritzActionEvidence(entries, entry, handNumber)) return false;
+      entries.push({ ...entry, moveNumber: nextMoveNumber, handNumber });
+      nextMoveNumber += 1;
+      return true;
+    },
+  };
+}
+
+/** Mirrors createRunDrawSequence with animation timers removed. */
+function runDrawSequence(initialState: BotMatchState, player: BotPlayerId) {
+  let current = initialState;
+  let drewAny = false;
+  const beforeStates: BotMatchState[] = [];
+
+  while (asPlayMoves(getLegalMoves(current, player)).length === 0) {
+    const beforeDraw = current;
+    const step = drawOne(beforeDraw, player);
+    if (!step.drew) break;
+    beforeStates.push(beforeDraw);
+    drewAny = true;
+    current = step.state;
+  }
+
+  if (asPlayMoves(getLegalMoves(current, player)).length === 0) {
+    const passResult = passTurn(current, player);
+    return { result: { ...passResult, drew: drewAny ? {} : undefined }, beforeStates, passed: true };
+  }
+  return {
+    result: { state: current, drew: drewAny ? {} : undefined },
+    beforeStates,
+    passed: false,
+  };
+}
+
+type SimulatedHand = {
+  match: BotMatchState;
+  moveLog: MoveEntry[];
+};
+
+/**
+ * Plays one full Daily Fritz hand through the real client modules in the same
+ * order the React orchestration calls them (usePlayerNoMoveEffect,
+ * usePlayerPlacementHandler, executeBotTurn, completeBotTurnAction).
+ */
+function simulateHand(
+  deal: DailyFritzHandDeal,
+  handIndex: number,
+  rng: () => number,
+  dropObservation?: (action: MoveEntry['action']) => boolean,
+): SimulatedHand {
+  const matchStarter: BotPlayerId = handIndex % 2 === 0 ? 'you' : 'bot';
+  let match = createFixedBotHand(
+    { you: 0, bot: 0 },
+    handIndex + 1,
+    WINNING_SCORE,
+    DEAL_SIZE,
+    deal,
+    matchStarter,
+  );
+  const log = createMoveLog(dropObservation);
+  const handNumber = match.handNumber;
+
+  for (let guard = 0; guard < 400 && !match.handOver && !match.gameOver; guard += 1) {
+    if (match.currentPlayer === 'you') {
+      const playMoves = asPlayMoves(getLegalMoves(match, 'you'));
+
+      if (playMoves.length > 0) {
+        // usePlayerPlacementHandler: the human picks any legal placement.
+        const move = playMoves[Math.floor(rng() * playMoves.length)];
+        const snapshot = collectPlayerMoveSnapshot(match, playMoves);
+        const result = applyPlayMove(match, 'you', move);
+        if (result.error) throw new Error(`player play rejected: ${result.error.message}`);
+        const afterPips = sumTilePips(result.state.players.you.hand);
+        log.append(
+          buildPlacementMoveLogEntry(
+            match,
+            snapshot,
+            move.tile!,
+            move.position!,
+            afterPips,
+            result.scored?.points ?? 0,
+            'hard',
+          ),
+          handNumber,
+        );
+        match = result.state;
+        continue;
+      }
+
+      // usePlayerNoMoveEffect
+      const snapshot = collectPlayerMoveSnapshot(match, []);
+      const boneyardBefore = match.boneyard.length;
+
+      if (isDailyFritzLockedBoneyardNoMove(match)) {
+        const resolution = resolveDailyFritzBlockedHandPass(match);
+        for (const pass of resolution.passes) {
+          if (pass.player === 'you') {
+            log.append(buildPassMoveLogEntry(pass.before, snapshot, 'hard'), handNumber);
+          } else {
+            log.append(buildBotPassMoveLogEntry(collectBotTurnSnapshot(pass.before), null), handNumber);
+          }
+        }
+        match = resolution.result.state;
+        continue;
+      }
+
+      const sequence = runDrawSequence(match, 'you');
+      let drawCount = sequence.beforeStates.length;
+      const drawSnapshots = sequence.beforeStates.map((state) => collectPlayerMoveSnapshot(state, []));
+      drawCount = Math.max(drawCount, boneyardBefore - sequence.result.state.boneyard.length);
+
+      if (sequence.result.drew) {
+        const drawLogCount = capDailyFritzDrawLogCount(
+          true,
+          resolveTranscriptDrawLogCount(true, drawCount),
+          drawSnapshots.length,
+        );
+        for (let index = 0; index < drawLogCount; index += 1) {
+          log.append(
+            buildDrawMoveLogEntry(match, drawSnapshots[index] ?? snapshot, 'hard'),
+            handNumber,
+          );
+        }
+      }
+      if (sequence.passed) {
+        log.append(buildPassMoveLogEntry(match, snapshot, 'hard'), handNumber);
+      }
+      match = sequence.result.state;
+      continue;
+    }
+
+    // executeBotTurn
+    const snapshot = collectBotTurnSnapshot(match);
+    const botPlayable = asPlayMoves(getLegalMoves(match, 'bot'));
+    let working = match;
+    let passed = false;
+    let drawCount = 0;
+    let onStepDrawCount = 0;
+    let playBeforeState: BotMatchState | null = null;
+    let placed: { tile: [number, number]; position: string } | null = null;
+    let nextState = match;
+
+    if (botPlayable.length === 0) {
+      const boneyardBefore = working.boneyard.length;
+      const sequence = runDrawSequence(working, 'bot');
+      onStepDrawCount = sequence.beforeStates.length;
+      working = sequence.result.state;
+      drawCount = Math.max(onStepDrawCount, boneyardBefore - working.boneyard.length);
+      const afterDraw = asPlayMoves(getLegalMoves(working, 'bot'));
+      if (afterDraw.length === 0) {
+        passed = sequence.passed;
+        nextState = working;
+      } else {
+        const chosen = chooseOfficialFritzBotChoice(working, 'hard', FRITZ_POLICY_VERSION);
+        if (!chosen?.move) throw new Error('official Fritz policy returned no play');
+        playBeforeState = working;
+        const result = applyPlayMove(working, 'bot', chosen.move);
+        if (result.error) throw new Error(`fritz play rejected: ${result.error.message}`);
+        placed = { tile: toTileTuple(chosen.move.tile!), position: chosen.move.position! };
+        nextState = result.state;
+      }
+    } else {
+      const chosen = chooseOfficialFritzBotChoice(working, 'hard', FRITZ_POLICY_VERSION);
+      if (!chosen?.move) throw new Error('official Fritz policy returned no play');
+      playBeforeState = working;
+      const result = applyPlayMove(working, 'bot', chosen.move);
+      if (result.error) throw new Error(`fritz play rejected: ${result.error.message}`);
+      placed = { tile: toTileTuple(chosen.move.tile!), position: chosen.move.position! };
+      nextState = result.state;
+    }
+
+    // completeBotTurnAction ordering: draws, then pass, then the play.
+    const drawLogCount = capDailyFritzDrawLogCount(
+      true,
+      resolveTranscriptDrawLogCount(true, drawCount),
+      onStepDrawCount,
+    );
+    for (let index = 0; index < drawLogCount; index += 1) {
+      log.append(buildBotDrawMoveLogEntry(snapshot, null), handNumber);
+    }
+    if (passed) {
+      log.append(buildBotPassMoveLogEntry(snapshot, null), handNumber);
+    }
+    if (placed) {
+      log.append(
+        buildBotPlaceMoveLogEntry({
+          snapshot,
+          tile: { low: placed.tile[0], high: placed.tile[1] },
+          position: placed.position as never,
+          engineBestMove: null,
+          authorityPreStateDigest: playBeforeState
+            ? getDailyFritzAuthorityStateDigest(toCoreGameState(playBeforeState))
+            : undefined,
+        }),
+        handNumber,
+      );
+    }
+    match = nextState;
+  }
+
+  return { match, moveLog: log.entries };
+}
+
+/** Mirrors buildDailyFritzPrefetchParams' seal decision. */
+function buildTranscriptForHand(
+  hand: SimulatedHand,
+  handIndex: number,
+  useJournal = false,
+): DailyFritzTranscript {
+  const { match, moveLog } = hand;
+  return buildDailyFritzTranscript({
+    ...(useJournal ? { journal: match.officialJournal ?? null } : {}),
+    challengeId: CHALLENGE_ID,
+    attemptId: ATTEMPT_ID,
+    gameNumber: 1,
+    handIndex,
+    handNumber: match.handNumber,
+    moveLog,
+    protocolVersion: DAILY_FRITZ_TRANSCRIPT_PROTOCOL_VERSION,
+    fritzPolicyVersion: FRITZ_POLICY_VERSION,
+    sealBlockedHand:
+      match.handOver
+      && match.players.you.hand.length > 0
+      && match.players.bot.hand.length > 0
+      && match.boneyard.length <= match.deadTiles.length
+        ? {
+            consecutivePasses: match.consecutivePasses,
+            nextActor: match.currentPlayer === 'you' ? 'player' : 'fritz',
+          }
+        : null,
+  });
+}
+
+function verifyHand(transcript: DailyFritzTranscript, deal: DailyFritzHandDeal, handIndex: number) {
+  return verifyDailyFritzHand({
+    transcript,
+    initialState: createOfficialDailyFritzHandState({
+      deal,
+      handIndex,
+      drawWinner: handIndex % 2 === 0 ? 'you' : 'fritz',
+      winningScore: WINNING_SCORE,
+      dealSize: DEAL_SIZE,
+      playerScore: 0,
+      fritzScore: 0,
+    }),
+    expectedChallengeId: CHALLENGE_ID,
+    expectedAttemptId: ATTEMPT_ID,
+    expectedGameNumber: 1,
+    expectedHandIndex: handIndex,
+    userId: 'user-fidelity',
+    fritzTier: FRITZ_TIER,
+  });
+}
+
+type FidelitySweep = {
+  handsPlayed: number;
+  failures: number;
+  byCode: Record<string, number>;
+  samples: Array<{ seed: number; handIndex: number; code: string; message: string }>;
+};
+
+function sweep(
+  dropObservation?: (action: MoveEntry['action'], rng: () => number) => boolean,
+  useJournal = false,
+): FidelitySweep {
+  const samples: FidelitySweep['samples'] = [];
+  const byCode: Record<string, number> = {};
+  let handsPlayed = 0;
+  let failures = 0;
+
+  for (let seed = 1; seed <= 200; seed += 1) {
+    const rng = makeRng(seed * 7919);
+    for (let handIndex = 0; handIndex < 4; handIndex += 1) {
+      const deal = generateSingleDailyFritzGameHand(RUN_DATE, 1, handIndex + seed * 4, DEAL_SIZE);
+      // Perturbation draws from its own stream so the sweeps play IDENTICAL
+      // games with and without observation loss.
+      const noiseRng = makeRng(seed * 104729 + handIndex);
+      const hand = simulateHand(
+        deal,
+        handIndex,
+        rng,
+        dropObservation ? (action) => dropObservation(action, noiseRng) : undefined,
+      );
+      if (!hand.match.handOver) continue;
+      handsPlayed += 1;
+
+      try {
+        verifyHand(buildTranscriptForHand(hand, handIndex, useJournal), deal, handIndex);
+      } catch (error) {
+        failures += 1;
+        const code = error instanceof DailyFritzVerificationError ? error.code : 'non_verifier_error';
+        byCode[code] = (byCode[code] ?? 0) + 1;
+        if (samples.length < 5) {
+          samples.push({
+            seed,
+            handIndex,
+            code,
+            message: error instanceof Error ? error.message : String(error),
+          });
+        }
+      }
+    }
+  }
+
+  return { handsPlayed, failures, byCode, samples };
+}
+
+/**
+ * The recorder misses an engine action: a cancelled local run, a remounted
+ * effect, or a checkpoint written between the engine commit and the append.
+ * This is the production mechanism behind the stranded-player incidents.
+ */
+const DROPPED_OBSERVATION = (action: MoveEntry['action'], rng: () => number) =>
+  action !== 'place' && rng() < 0.35;
+
+describe('Daily Fritz transcript fidelity', () => {
+  it('verifies every cleanly observed hand from either evidence source', () => {
+    const moveLogSweep = sweep();
+    const journalSweep = sweep(undefined, true);
+
+    expect(moveLogSweep.handsPlayed).toBeGreaterThan(300);
+    expect(moveLogSweep.failures).toBe(0);
+    expect(journalSweep.failures).toBe(0);
+  }, 120_000);
+
+  it('reproduces the production stranding codes when the move log misses an action', () => {
+    const result = sweep(DROPPED_OBSERVATION);
+
+    // Guards the regression story: if this ever reaches zero, the move-log
+    // reconstruction path is no longer the thing the journal is protecting
+    // against, and this whole test file should be revisited.
+    expect(result.failures).toBeGreaterThan(0);
+    expect(Object.keys(result.byCode).sort()).toEqual(
+      expect.arrayContaining(['incomplete_transcript', 'wrong_actor']),
+    );
+  }, 120_000);
+
+  it('never strands a player when the journal is the evidence, under the same loss', () => {
+    // The journal is written inside the state transition, so a lost
+    // presentation-layer observation cannot desynchronise it from the state.
+    const result = sweep(DROPPED_OBSERVATION, true);
+
+    expect(result.handsPlayed).toBeGreaterThan(300);
+    expect({ failures: result.failures, byCode: result.byCode, samples: result.samples }).toEqual({
+      failures: 0,
+      byCode: {},
+      samples: [],
+    });
+  }, 120_000);
+});

--- a/server/src/http/routes/dailyFritzVerificationGlue.ts
+++ b/server/src/http/routes/dailyFritzVerificationGlue.ts
@@ -221,6 +221,73 @@ export function writeActiveGameProgress(result: Record<string, unknown> | null, 
   return { ...(result ?? {}), active_game: { game_number: progress.gameNumber, you: progress.you, fritz: progress.fritz } };
 }
 
+export type AttemptHandVerificationResult =
+  | { ok: true; verified: ReturnType<typeof verifyAttemptHand> }
+  | { ok: false; error: DailyFritzVerificationError };
+
+/**
+ * Run hand verification without throwing. Callers that carry legacy scores can
+ * advance the run when verification fails instead of stranding the player.
+ */
+export function attemptVerifyHand(input: Parameters<typeof verifyAttemptHand>[0]): AttemptHandVerificationResult {
+  try {
+    return { ok: true, verified: verifyAttemptHand(input) };
+  } catch (error) {
+    if (error instanceof DailyFritzVerificationError) {
+      return { ok: false, error };
+    }
+    throw error;
+  }
+}
+
+export function isDailyFritzGameEndingScore(
+  you: number,
+  fritz: number,
+  winningScore: number,
+): boolean {
+  const leader = Math.max(you, fritz);
+  return leader >= winningScore && you !== fritz;
+}
+
+export async function recordDailyFritzAdvanceWithoutVerification(input: {
+  attemptId: string;
+  runDate: string;
+  userId: string;
+  requestId: string;
+  gameNumber: DailyFritzSetGameNumber;
+  handIndex: number;
+  verifierCode: string;
+  operation: 'next-hand' | 'record-game';
+  message: string;
+}): Promise<void> {
+  incrementDailyFritzMetric('verification_bypassed', input.verifierCode);
+  log.error({
+    attemptId: input.attemptId,
+    runDate: input.runDate,
+    userId: input.userId,
+    gameNumber: input.gameNumber,
+    handIndex: input.handIndex,
+    verifierCode: input.verifierCode,
+    message: input.message,
+  }, '[daily-fritz] advancing without verification receipt — run is now unranked');
+  await recordDailyFritzEventBestEffort({
+    attemptId: input.attemptId,
+    runDate: input.runDate,
+    userId: input.userId,
+    requestId: input.requestId,
+    eventType: 'verification_failed',
+    verifierCode: input.verifierCode,
+    gameNumber: input.gameNumber,
+    handIndex: input.handIndex,
+    idempotencyKey: `${input.attemptId}:verification_bypassed:${input.operation}:${input.gameNumber}:${input.handIndex}`,
+    payload: {
+      operation: input.operation,
+      outcome: 'advance_unverified',
+      message: input.message,
+    },
+  });
+}
+
 export function verifyAttemptHand(input: {
   transcript: unknown;
   attempt: DailyFritzAttemptRecord;

--- a/server/src/http/routes/dailyFritzVerificationGlue.ts
+++ b/server/src/http/routes/dailyFritzVerificationGlue.ts
@@ -53,6 +53,56 @@ const CLIENT_STUCK_CODES = new Set([
   'fritz_policy_contract_mismatch',
 ]);
 
+/**
+ * How many times a client must have failed to get a hand verified before the
+ * server will let the run continue without a verification receipt.
+ *
+ * The client rebuilds and retries on its own for the recoverable codes; by the
+ * time it asks for this, the player has been sitting on a Hand Over screen
+ * unable to advance. Continuing unranked is strictly better than trapping
+ * them — a stranded player loses the whole run either way.
+ */
+export const DAILY_FRITZ_UNVERIFIED_FALLBACK_MIN_ATTEMPTS = 3;
+
+export function readDailyFritzUnverifiedFallbackRequest(body: unknown): number | null {
+  const record = (body ?? {}) as Record<string, unknown>;
+  if (record.unverified_fallback !== true) return null;
+  const attempts = Number(record.verification_attempts);
+  if (!Number.isFinite(attempts)) return null;
+  const rounded = Math.floor(attempts);
+  return rounded >= DAILY_FRITZ_UNVERIFIED_FALLBACK_MIN_ATTEMPTS ? rounded : null;
+}
+
+/**
+ * Record that a hand advanced without a verification receipt.
+ *
+ * `verification_status: 'rejected'` is what removes the run from the
+ * leaderboard (isDailyFritzAttemptLeaderboardEligible admits only 'verified'),
+ * and it is sticky: no later hand can promote the attempt back to verified.
+ * The authority ledger is deliberately left untouched, so the missing receipt
+ * remains visible for review.
+ */
+export function writeUnverifiedDailyFritzHand(
+  result: Record<string, unknown> | null,
+  input: { gameNumber: DailyFritzSetGameNumber; handIndex: number; verifierCode: string },
+): Record<string, unknown> {
+  const previous = result ?? {};
+  const existing = Array.isArray(previous.unverified_hands) ? previous.unverified_hands : [];
+  return {
+    ...previous,
+    verification_status: 'rejected',
+    unverified_hands: [
+      ...existing,
+      {
+        game_number: input.gameNumber,
+        hand_index: input.handIndex,
+        verifier_code: input.verifierCode,
+        recorded_at: new Date().toISOString(),
+      },
+    ],
+  };
+}
+
 export async function recordDailyFritzEventBestEffort(event: DailyFritzEventInput): Promise<void> {
   try {
     await recordDailyFritzEvent(event);

--- a/server/src/http/routes/dailyFritzVerificationPolicy.ts
+++ b/server/src/http/routes/dailyFritzVerificationPolicy.ts
@@ -185,11 +185,19 @@ export function buildRecordedDailyFritzAttemptResult(input: {
     };
   }
   const previousStatus = getDailyFritzVerificationStatus(previous);
+  // 'rejected' is sticky: once a hand advanced without a receipt, no later
+  // hand may promote the run back into leaderboard eligibility.
+  const nextStatus = previousStatus === 'rejected'
+    ? 'rejected'
+    : previousStatus === 'verified' ? 'verified' : 'in_progress';
   return {
     ...input.setResult as Record<string, unknown>,
     authority,
+    ...(Array.isArray(previous.unverified_hands)
+      ? { unverified_hands: previous.unverified_hands }
+      : {}),
     verification_protocol_version: DAILY_FRITZ_VERIFICATION_PROTOCOL_VERSION,
-    verification_status: previousStatus === 'verified' ? 'verified' : 'in_progress',
+    verification_status: nextStatus,
   };
 }
 
@@ -221,6 +229,10 @@ export function canFinalizeDailyFritzAttempt(
   setResult: { games: DailyFritzSetGameResult[] },
 ): boolean {
   if (hasCompleteDailyFritzGameAuthority(result, setResult)) return true;
+  // A run already marked unranked by the never-strand fallback must still be
+  // allowed to finish. Blocking it here would trap the player at the end of
+  // the set instead of on a Hand Over screen.
+  if (getDailyFritzVerificationStatus(result) === 'rejected') return true;
   if (requiresVerifiedDailyFritzEvidence(result)) return false;
   // Partial authority after a mid-set verifier drop must not finalize as silent unranked.
   const ledger = readAuthorityLedger(result);


### PR DESCRIPTION
## Summary

- **Engine journal**: Daily Fritz verification evidence is now recorded inside `gameCoreAdapter` at the moment each command is accepted, carried on `BotMatchState.officialJournal`. The transcript builder prefers the journal over UI move-log reconstruction — structurally eliminating the drift that caused `illegal_action`, `post_terminal_action`, `wrong_actor`, and `incomplete_transcript` waves.
- **Advance-first verification**: `/next-hand` and `/record-game` no longer block gameplay on verification failure. When a transcript cannot replay, the server advances immediately using client scores, marks the run `verification_status: rejected` (sticky, leaderboard-ineligible), and logs `verification_bypassed`. Verification becomes a ranking gate, not a save gate.
- **Client resilience**: Always sends `completed_hand_scores` with transcripts; calmer Hand Over retry copy; shorter transport retry ladder as backup for legacy servers.

## Root cause

Progress persistence was coupled to full transcript verification. Every UI/engine divergence became a player-facing catastrophe. ~503 stranding events over 18 days across six verifier codes, each spiking after the previous was patched.

## Test plan

- [x] Server Daily Fritz route tests (53 pass) including fidelity sweep, never-strand, hand-over persistence
- [x] Client Daily Fritz + hand lifecycle tests (113 pass) including journal wiring test
- [ ] Deploy preview and confirm `@racehorse/game-core` builds before client/server bundles
- [ ] Play one full Daily Fritz run on preview (especially draw-heavy / blocked-hand endgame)
- [ ] Monitor `daily_fritz_events` for 48h: `verification_failed` should drop; any `verification_bypassed` = real bug to chase (player saved, run unranked)

## Deploy note

In-flight attempts started before deploy have no journal and fall back to move-log path until that run finishes — advance-first protects them regardless.


Made with [Cursor](https://cursor.com)