### PR TITLE
feat(daily-fritz): Phase 1 platform hardening

### DIFF
--- a/client/src/dailyFritz/api.ts
+++ b/client/src/dailyFritz/api.ts
@@ -14,23 +14,34 @@ import type {
   DailyFritzSetResult as SharedDailyFritzSetResult,
 } from '@racehorse/game-core';
 
-export const DAILY_FRITZ_REQUEST_ID_HEADER = 'x-racehorse-request-id';
-
-export function createDailyFritzRequestId(): string {
-  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
-    return crypto.randomUUID();
-  }
-  return `df-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
-}
-
-/** Init/today/start requests — 8–12s window before the UI leaves infinite loading. */
-export const DAILY_FRITZ_INIT_TIMEOUT_MS = 10_000;
-
-/** Next-hand advance (prefetch + reveal auto-advance). Match init — Render cold starts can exceed 4.5s. */
-export const DAILY_FRITZ_NEXT_HAND_TIMEOUT_MS = 10_000;
-/** Record-game must never strand the player on the Saving… overlay. */
-export const DAILY_FRITZ_RECORD_GAME_TIMEOUT_MS = 15_000;
-export const DAILY_FRITZ_COMPLETE_TIMEOUT_MS = 15_000;
+export {
+  createDailyFritzRequestId,
+  DAILY_FRITZ_REQUEST_ID_HEADER,
+} from './dailyFritzRequestIds';
+export {
+  classifyDailyFritzMutationFailure,
+  DAILY_FRITZ_CHECKPOINT_TIMEOUT_MS,
+  DAILY_FRITZ_COMPLETE_TIMEOUT_MS,
+  DAILY_FRITZ_INIT_TIMEOUT_MS,
+  DAILY_FRITZ_NEXT_HAND_TIMEOUT_MS,
+  DAILY_FRITZ_RECORD_GAME_TIMEOUT_MS,
+  timedDailyFritzMutationPost,
+  throwApiResult,
+  type DailyFritzMutationFailureKind,
+} from './dailyFritzMutations';
+import {
+  createDailyFritzRequestId,
+  DAILY_FRITZ_REQUEST_ID_HEADER,
+} from './dailyFritzRequestIds';
+import {
+  DAILY_FRITZ_COMPLETE_TIMEOUT_MS,
+  DAILY_FRITZ_INIT_TIMEOUT_MS,
+  DAILY_FRITZ_NEXT_HAND_TIMEOUT_MS,
+  DAILY_FRITZ_RECORD_GAME_TIMEOUT_MS,
+  DAILY_FRITZ_CHECKPOINT_TIMEOUT_MS,
+  timedDailyFritzMutationPost,
+  throwApiResult,
+} from './dailyFritzMutations';
 
 export const DAILY_FRITZ_TODAY_CACHE_PREFIX = 'racehorse:daily-fritz:today:';
 
@@ -201,51 +212,7 @@ async function timedApiGet<T>(path: string): Promise<ApiResult<T>> {
 }
 
 async function timedApiPost<T>(path: string, body: unknown, timeoutMs?: number): Promise<ApiResult<T>> {
-  const start = performance.now();
-  const controller = typeof AbortController !== 'undefined' && timeoutMs != null ? new AbortController() : null;
-  let timedOut = false;
-  const timeoutId = controller && timeoutMs != null
-    ? window.setTimeout(() => {
-        timedOut = true;
-        controller.abort();
-      }, timeoutMs)
-    : null;
-  try {
-    const result = await apiPost<T>(path, body, {
-      headers: { [DAILY_FRITZ_REQUEST_ID_HEADER]: createDailyFritzRequestId() },
-      signal: controller?.signal,
-    });
-    dfClientDebug('[daily-fritz-client] request', {
-      path,
-      ms: Number((performance.now() - start).toFixed(1)),
-      ok: result.error === null,
-      status: result.status,
-    });
-    if (timedOut && result.error) {
-      return {
-        ...result,
-        error: 'Daily Fritz request timed out. Check your connection and try again.',
-        status: result.status ?? 408,
-      };
-    }
-    return result;
-  } catch (error) {
-    if (timedOut) {
-      return {
-        data: null,
-        error: 'Daily Fritz request timed out. Check your connection and try again.',
-        status: 408,
-      };
-    }
-    throw error;
-  } finally {
-    if (timeoutId != null) window.clearTimeout(timeoutId);
-  }
-}
-
-function throwApiResult<T>(result: ApiResult<T>): T {
-  if (result.error) throw new Error(result.error);
-  return result.data as T;
+  return timedDailyFritzMutationPost<T>(path, body, timeoutMs);
 }
 
 const DAILY_FRITZ_RECOVERABLE_AUTHORITY_CODES = new Set([
@@ -322,6 +289,14 @@ export interface DailyFritzLeaderboardRow {
   is_current_user?: boolean;
 }
 export type DailyFritzVerificationStatus = 'in_progress' | 'pending_verification' | 'verified' | 'rejected' | 'legacy_unverified';
+
+export type DailyFritzClientNextAction =
+  | 'start_set'
+  | 'resume_hand'
+  | 'between_games'
+  | 'finalize_set'
+  | 'view_results'
+  | 'locked';
 export type DailyFritzHistoryEntry = { challenge_date: string; player_score: number; fritz_score: number; won: boolean; completed_at: string | null; verification_status: DailyFritzVerificationStatus };
 export async function getDailyFritzHistory(limit = 5): Promise<DailyFritzHistoryEntry[]> {
   const result = await apiGet<{ ok: true; results: DailyFritzHistoryEntry[] }>(`/api/daily-fritz/history?limit=${Math.max(1,Math.min(10,Math.floor(limit)))}`);
@@ -359,6 +334,7 @@ export interface DailyFritzTodayResponse {
   winning_score: number;
   attempt_status: 'none' | 'started' | 'completed' | 'abandoned';
   authority_revision?: number | null;
+  next_action?: DailyFritzClientNextAction;
   current_game_number: DailyFritzSetGameNumber | null;
   needs_completion?: boolean;
   streak: number;
@@ -397,6 +373,7 @@ export interface DailyFritzStartResponse {
   verifier_version?: number;
   time_zone?: 'America/Los_Angeles';
   verification_status?: DailyFritzVerificationStatus;
+  next_action?: DailyFritzClientNextAction;
   current_hand_index: number;
   current_game_scores?: { you: number; fritz: number };
   current_game_number?: DailyFritzSetGameNumber | null;
@@ -529,7 +506,7 @@ export async function saveDailyFritzCheckpoint(input: {
           verified_match_id: input.verifiedMatchId,
           checkpoint: input.checkpoint,
         }),
-        timeoutMs: input.timeoutMs ?? 8_000,
+        timeoutMs: input.timeoutMs ?? DAILY_FRITZ_CHECKPOINT_TIMEOUT_MS,
       },
     );
   } catch {

--- a/client/src/dailyFritz/dailyFritzMutations.ts
+++ b/client/src/dailyFritz/dailyFritzMutations.ts
@@ -1,0 +1,88 @@
+import { apiPost, type ApiResult } from '../api/client';
+import { createDailyFritzRequestId, DAILY_FRITZ_REQUEST_ID_HEADER } from './dailyFritzRequestIds';
+
+function dfClientDebug(..._args: unknown[]): void {
+  if (import.meta.env.DEV) {
+    // eslint-disable-next-line no-console
+    console.debug(..._args);
+  }
+}
+
+/** Init/today/start requests — 8–12s window before the UI leaves infinite loading. */
+export const DAILY_FRITZ_INIT_TIMEOUT_MS = 10_000;
+
+/** Next-hand advance (prefetch + reveal auto-advance). Match init — Render cold starts can exceed 4.5s. */
+export const DAILY_FRITZ_NEXT_HAND_TIMEOUT_MS = 10_000;
+
+/** Record-game must never strand the player on the Saving… overlay. */
+export const DAILY_FRITZ_RECORD_GAME_TIMEOUT_MS = 15_000;
+
+export const DAILY_FRITZ_COMPLETE_TIMEOUT_MS = 15_000;
+
+export const DAILY_FRITZ_CHECKPOINT_TIMEOUT_MS = 8_000;
+
+export type DailyFritzMutationFailureKind = 'timeout' | 'network' | 'authority' | 'server';
+
+export function classifyDailyFritzMutationFailure(
+  result: ApiResult<unknown>,
+  timedOut: boolean,
+): DailyFritzMutationFailureKind {
+  if (timedOut || result.status === 408) return 'timeout';
+  if (result.status === 401 || result.status === 403) return 'authority';
+  if (result.status != null && result.status >= 500) return 'server';
+  if (result.error?.toLowerCase().includes('timed out')) return 'timeout';
+  return 'network';
+}
+
+export function throwApiResult<T>(result: ApiResult<T>): T {
+  if (result.error) throw new Error(result.error);
+  return result.data as T;
+}
+
+export async function timedDailyFritzMutationPost<T>(
+  path: string,
+  body: unknown,
+  timeoutMs?: number,
+): Promise<ApiResult<T>> {
+  const start = performance.now();
+  const controller = typeof AbortController !== 'undefined' && timeoutMs != null ? new AbortController() : null;
+  let timedOut = false;
+  const timeoutId = controller && timeoutMs != null
+    ? window.setTimeout(() => {
+        timedOut = true;
+        controller.abort();
+      }, timeoutMs)
+    : null;
+  try {
+    const result = await apiPost<T>(path, body, {
+      headers: { [DAILY_FRITZ_REQUEST_ID_HEADER]: createDailyFritzRequestId() },
+      signal: controller?.signal,
+    });
+    dfClientDebug('[daily-fritz-client] mutation', {
+      path,
+      ms: Number((performance.now() - start).toFixed(1)),
+      ok: result.error === null,
+      status: result.status,
+      failureKind: result.error ? classifyDailyFritzMutationFailure(result, timedOut) : null,
+    });
+    if (timedOut && result.error) {
+      return {
+        ...result,
+        error: 'Daily Fritz request timed out. Check your connection and try again.',
+        status: result.status ?? 408,
+      };
+    }
+    return result;
+  } catch (error) {
+    if (timedOut) {
+      return {
+        data: null,
+        error: 'Daily Fritz request timed out. Check your connection and try again.',
+        status: 408,
+      };
+    }
+    throw error;
+  } finally {
+    if (timeoutId != null) window.clearTimeout(timeoutId);
+  }
+}

--- a/client/src/dailyFritz/dailyFritzObservability.ts
+++ b/client/src/dailyFritz/dailyFritzObservability.ts
@@ -1,0 +1,23 @@
+import * as Sentry from '@sentry/react';
+
+export type DailyFritzOperationalAlert =
+  | 'saving_timeout'
+  | 'record_game_failed'
+  | 'cursor_divergence'
+  | 'recovery_started'
+  | 'recovery_failed'
+  | 'transcript_build_failed';
+
+export function reportDailyFritzOperationalAlert(
+  alert: DailyFritzOperationalAlert,
+  message: string,
+  context: Record<string, unknown> = {},
+): void {
+  Sentry.captureMessage(message, {
+    level: alert === 'record_game_failed' || alert === 'recovery_failed' ? 'error' : 'warning',
+    tags: {
+      daily_fritz_alert: alert,
+    },
+    extra: context,
+  });
+}

--- a/client/src/dailyFritz/dailyFritzRequestIds.ts
+++ b/client/src/dailyFritz/dailyFritzRequestIds.ts
@@ -1,0 +1,8 @@
+export const DAILY_FRITZ_REQUEST_ID_HEADER = 'x-racehorse-request-id';
+
+export function createDailyFritzRequestId(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return `df-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}

--- a/client/src/dailyFritz/dailyFritzScreenTypes.ts
+++ b/client/src/dailyFritz/dailyFritzScreenTypes.ts
@@ -94,4 +94,6 @@ export interface DailyFritzGameCompletionPayload {
   handsPlayed: number;
   currentHandIndex: number;
   moveLog: unknown;
+  /** Authoritative engine journal for the terminal hand — required for modern verified attempts. */
+  journal?: import('@racehorse/game-core').DailyFritzJournal | null;
 }

--- a/client/src/dailyFritz/useDailyFritzRunController.ts
+++ b/client/src/dailyFritz/useDailyFritzRunController.ts
@@ -28,6 +28,7 @@ import type {
   DailyFritzOverlayState,
 } from './dailyFritzScreenTypes';
 import { buildDailyFritzTranscript } from './dailyFritzTranscript';
+import { reportDailyFritzOperationalAlert } from './dailyFritzObservability';
 import { createDailyFritzChallengeIdentity } from './dailyFritzChallengeIdentity';
 import type { MoveEntry } from '../game/moveLogger';
 import { dailyFritzTelemetryEventId, getDailyFritzTelemetrySession } from './telemetry';
@@ -369,6 +370,7 @@ export function useDailyFritzRunController({
           handIndex: game.currentHandIndex,
           handNumber: game.handsPlayed,
           moveLog: game.moveLog as MoveEntry[],
+          journal: game.journal ?? null,
           fritzPolicyVersion: run.fritz_policy_version,
         });
       } catch (transcriptError) {
@@ -378,6 +380,17 @@ export function useDailyFritzRunController({
           && run.verification_status !== 'legacy_unverified'
           && Number(run.verification_protocol_version) > 0;
         if (competitive) {
+          reportDailyFritzOperationalAlert(
+            'transcript_build_failed',
+            'Daily Fritz record-game transcript build failed',
+            {
+              attemptId: run.attempt_id,
+              gameNumber,
+              handIndex: game.currentHandIndex,
+              hasJournal: Boolean(game.journal?.actions?.length),
+              error: transcriptError instanceof Error ? transcriptError.message : String(transcriptError),
+            },
+          );
           throw transcriptError instanceof Error
             ? transcriptError
             : new Error('Failed to build Daily Fritz verification transcript.');
@@ -502,6 +515,15 @@ export function useDailyFritzRunController({
         return;
       }
       const message = err instanceof Error ? err.message : 'Failed to save Daily Fritz set progress.';
+      reportDailyFritzOperationalAlert(
+        'record_game_failed',
+        'Daily Fritz record-game failed',
+        {
+          attemptId: run.attempt_id,
+          gameNumber,
+          error: message,
+        },
+      );
       setSetOverlay({
         kind: 'record-error',
         completedGame: fallbackCompletedGame,
@@ -574,6 +596,16 @@ export function useDailyFritzRunController({
         };
       });
       recordGameInFlightRef.current = false;
+      const pendingSnapshot = pendingRecordGameRef.current;
+      const runSnapshot = activeRunRef.current;
+      reportDailyFritzOperationalAlert(
+        'saving_timeout',
+        'Daily Fritz record-game saving overlay timed out',
+        {
+          attemptId: runSnapshot?.attempt_id,
+          gameNumber: pendingSnapshot?.gameNumber,
+        },
+      );
     }, watchdogMs);
     return () => window.clearTimeout(timer);
   }, [setOverlay]);

--- a/client/src/modules/daily/useDailyFritzCompletion.ts
+++ b/client/src/modules/daily/useDailyFritzCompletion.ts
@@ -107,6 +107,7 @@ export function useDailyFritzCompletion({
       handsPlayed: match.handNumber,
       currentHandIndex: dailyFritzHandIndex,
       moveLog: JSON.parse(JSON.stringify(moveLog)) as MoveEntry[],
+      journal: match.officialJournal ?? null,
     };
     void Promise.resolve(onDailyFritzGameComplete(payload))
       .then(() => {
@@ -126,6 +127,7 @@ export function useDailyFritzCompletion({
     enabled,
     match.gameOver,
     match.handNumber,
+    match.officialJournal,
     match.players.bot.score,
     match.players.you.score,
     match.winnerId,

--- a/client/src/modules/daily/useDailyFritzSessionPersistence.ts
+++ b/client/src/modules/daily/useDailyFritzSessionPersistence.ts
@@ -12,6 +12,7 @@ import {
 import { buildDailyFritzTranscript } from '../../dailyFritz/dailyFritzTranscript.ts';
 import { getFritzPolicyContract, isSupportedFritzPolicyVersion } from '@racehorse/game-core';
 import { saveDailyFritzCheckpoint, recordDailyFritzTelemetry } from '../../dailyFritz/api.ts';
+import { reportDailyFritzOperationalAlert } from '../../dailyFritz/dailyFritzObservability.ts';
 import { dailyFritzTelemetryEventId, getDailyFritzTelemetrySession } from '../../dailyFritz/telemetry.ts';
 
 type UseDailyFritzSessionPersistenceArgs = {
@@ -136,6 +137,17 @@ export function useDailyFritzSessionPersistence({
           matchHandNumber: match.handNumber,
           lifecyclePhase: match.gameOver ? 'completed' : match.handOver ? 'hand_transition' : 'active_hand',
         });
+        reportDailyFritzOperationalAlert(
+          'cursor_divergence',
+          'Daily Fritz checkpoint cursor divergence',
+          {
+            attemptId,
+            gameNumber,
+            handIndex: dailyFritzHandIndex,
+            authorityRevision,
+            matchHandNumber: match.handNumber,
+          },
+        );
         const sessionId = getDailyFritzTelemetrySession(runDate);
         void recordDailyFritzTelemetry({
           eventId: dailyFritzTelemetryEventId(attemptId, 'recovery_started', `cursor-divergence:${divergenceKey}`),

--- a/client/src/utils/sound.ts
+++ b/client/src/utils/sound.ts
@@ -221,7 +221,7 @@ export function playTileSound(type: TileSoundType, isMuted: boolean): void {
     try {
       const instance = sample.cloneNode() as HTMLAudioElement;
       instance.volume = type === 'slam' ? 0.78 : type === 'deal' ? 0.42 : 0.64;
-      void instance.play();
+      void instance.play().catch(() => {});
       return;
     } catch {
       // Fall back to synth if sample playback fails.

--- a/server/src/http/routes/dailyFritzCheckpointRoute.ts
+++ b/server/src/http/routes/dailyFritzCheckpointRoute.ts
@@ -1,9 +1,8 @@
 import type { Application } from 'express';
+import { withDailyFritzAttemptLock } from '../../dailyFritzAttemptLock';
 import { getAuthenticatedUserId } from '../../platform/auth/supabaseAuth';
 import {
-  buildDailyFritzRunFingerprint,
   getDailyFritzAttemptById,
-  getDailyFritzRun,
   upsertDailyFritzAttempt,
 } from '../stores/dailyFritzStore';
 import { startDailyFritzRequestDiagnostics } from './dailyFritzRequestDiagnostics';
@@ -33,68 +32,70 @@ export function registerDailyFritzCheckpointRoute(app: Application): void {
     }
 
     try {
-      const authenticatedUserId = await getAuthenticatedUserId(req);
-      if (!authenticatedUserId) {
-        res.status(401).json({ error: 'Unauthorized' });
-        return;
-      }
+      await withDailyFritzAttemptLock(attemptId, async () => {
+        const authenticatedUserId = await getAuthenticatedUserId(req);
+        if (!authenticatedUserId) {
+          res.status(401).json({ error: 'Unauthorized' });
+          return;
+        }
 
-      const checkpoint = parseDailyFritzServerCheckpoint(checkpointInput);
-      if (!checkpoint) {
-        res.status(400).json({ error: 'Invalid Daily Fritz checkpoint payload.', code: 'malformed_checkpoint' });
-        return;
-      }
+        const checkpoint = parseDailyFritzServerCheckpoint(checkpointInput);
+        if (!checkpoint) {
+          res.status(400).json({ error: 'Invalid Daily Fritz checkpoint payload.', code: 'malformed_checkpoint' });
+          return;
+        }
 
-      const attempt = await getDailyFritzAttemptById(attemptId, authenticatedUserId);
-      if (!attempt) {
-        res.status(404).json({ error: 'Daily Fritz attempt not found.' });
-        return;
-      }
+        const attempt = await getDailyFritzAttemptById(attemptId, authenticatedUserId);
+        if (!attempt) {
+          res.status(404).json({ error: 'Daily Fritz attempt not found.' });
+          return;
+        }
 
-      const existing = readDailyFritzActiveCheckpoint(attempt.result);
-      const validation = validateDailyFritzCheckpointWrite(
-        attempt,
-        verifiedMatchId,
-        checkpoint,
-        existing,
-      );
-      if (!validation.ok) {
-        const status = validation.reason === 'stale_checkpoint' ? 409 : 422;
-        res.status(status).json({
-          error: 'Daily Fritz checkpoint rejected.',
-          code: validation.reason,
-          checkpoint_revision: existing?.checkpointRevision ?? null,
+        const existing = readDailyFritzActiveCheckpoint(attempt.result);
+        const validation = validateDailyFritzCheckpointWrite(
+          attempt,
+          verifiedMatchId,
+          checkpoint,
+          existing,
+        );
+        if (!validation.ok) {
+          const status = validation.reason === 'stale_checkpoint' ? 409 : 422;
+          res.status(status).json({
+            error: 'Daily Fritz checkpoint rejected.',
+            code: validation.reason,
+            checkpoint_revision: existing?.checkpointRevision ?? null,
+          });
+          return;
+        }
+
+        attempt.result = writeDailyFritzActiveCheckpoint(attempt.result, checkpoint);
+        const saved = await upsertDailyFritzAttempt(attempt);
+        const stored = readDailyFritzActiveCheckpoint(saved.result);
+        await recordDailyFritzEventBestEffort({
+          attemptId: attempt.id,
+          runDate: attempt.runDate,
+          userId: authenticatedUserId,
+          requestId: diagnostics.requestId,
+          eventType: 'checkpoint_saved',
+          idempotencyKey: `${attempt.id}:checkpoint:${checkpoint.checkpointRevision}`,
+          payload: {
+            gameNumber: checkpoint.gameNumber,
+            handIndex: checkpoint.currentHandIndex,
+            checkpointRevision: checkpoint.checkpointRevision,
+            lifecyclePhase: checkpoint.lifecyclePhase,
+          },
         });
-        return;
-      }
-
-      attempt.result = writeDailyFritzActiveCheckpoint(attempt.result, checkpoint);
-      const saved = await upsertDailyFritzAttempt(attempt);
-      const stored = readDailyFritzActiveCheckpoint(saved.result);
-      await recordDailyFritzEventBestEffort({
-        attemptId: attempt.id,
-        runDate: attempt.runDate,
-        userId: authenticatedUserId,
-        requestId: diagnostics.requestId,
-        eventType: 'checkpoint_saved',
-        idempotencyKey: `${attempt.id}:checkpoint:${checkpoint.checkpointRevision}`,
-        payload: {
-          gameNumber: checkpoint.gameNumber,
-          handIndex: checkpoint.currentHandIndex,
+        incrementDailyFritzMetric('checkpoint_saved');
+        log.info({
+          attemptId,
           checkpointRevision: checkpoint.checkpointRevision,
-          lifecyclePhase: checkpoint.lifecyclePhase,
-        },
-      });
-      incrementDailyFritzMetric('checkpoint_saved');
-      log.info({
-        attemptId,
-        checkpointRevision: checkpoint.checkpointRevision,
-        handIndex: checkpoint.currentHandIndex,
-      }, '[daily-fritz:checkpoint] saved');
-      res.json({
-        ok: true,
-        checkpoint_revision: stored?.checkpointRevision ?? checkpoint.checkpointRevision,
-        authority_revision: saved.revision,
+          handIndex: checkpoint.currentHandIndex,
+        }, '[daily-fritz:checkpoint] saved');
+        res.json({
+          ok: true,
+          checkpoint_revision: stored?.checkpointRevision ?? checkpoint.checkpointRevision,
+          authority_revision: saved.revision,
+        });
       });
     } catch (error) {
       log.error({
@@ -107,9 +108,4 @@ export function registerDailyFritzCheckpointRoute(app: Application): void {
       });
     }
   });
-}
-
-export async function loadDailyFritzRunFingerprint(runDate: string): Promise<string | null> {
-  const run = await getDailyFritzRun(runDate);
-  return run ? buildDailyFritzRunFingerprint(run) : null;
 }

--- a/server/src/http/routes/dailyFritzClientPhase.test.ts
+++ b/server/src/http/routes/dailyFritzClientPhase.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import { resolveDailyFritzClientNextAction } from './dailyFritzClientPhase';
+
+describe('resolveDailyFritzClientNextAction', () => {
+  it('returns start_set for a fresh attempt', () => {
+    expect(resolveDailyFritzClientNextAction({
+      attemptStatus: 'started',
+      setResult: null,
+      currentHandIndex: 0,
+      hasResumeCheckpoint: false,
+    })).toBe('start_set');
+  });
+
+  it('returns resume_hand when a checkpoint exists mid-hand', () => {
+    expect(resolveDailyFritzClientNextAction({
+      attemptStatus: 'started',
+      setResult: { version: 2, format: 'best_of_3', playerGamesWon: 0, fritzGamesWon: 0, totalPointDiff: 0, games: [] },
+      currentHandIndex: 2,
+      hasResumeCheckpoint: true,
+    })).toBe('resume_hand');
+  });
+
+  it('returns between_games after a game is recorded but the set continues', () => {
+    expect(resolveDailyFritzClientNextAction({
+      attemptStatus: 'started',
+      setResult: {
+        version: 2,
+        format: 'best_of_3',
+        playerGamesWon: 1,
+        fritzGamesWon: 0,
+        totalPointDiff: 10,
+        games: [{
+          gameNumber: 1,
+          seed: 'seed',
+          playerWon: true,
+          playerScore: 60,
+          fritzScore: 40,
+          pointDiff: 20,
+          movesUsed: 10,
+          handsPlayed: 3,
+          completedAt: '2026-08-18T00:00:00.000Z',
+        }],
+      },
+      currentHandIndex: 0,
+      hasResumeCheckpoint: false,
+    })).toBe('between_games');
+  });
+
+  it('returns finalize_set when the set winner is decided', () => {
+    expect(resolveDailyFritzClientNextAction({
+      attemptStatus: 'started',
+      setResult: {
+        version: 2,
+        format: 'best_of_3',
+        playerGamesWon: 2,
+        fritzGamesWon: 0,
+        totalPointDiff: 20,
+        setWinner: 'player',
+        games: [],
+      },
+      needsCompletion: true,
+      currentHandIndex: 0,
+      hasResumeCheckpoint: false,
+    })).toBe('finalize_set');
+  });
+
+  it('returns view_results for completed attempts', () => {
+    expect(resolveDailyFritzClientNextAction({
+      attemptStatus: 'completed',
+      setResult: null,
+      currentHandIndex: 0,
+      hasResumeCheckpoint: false,
+    })).toBe('view_results');
+  });
+});

--- a/server/src/http/routes/dailyFritzClientPhase.ts
+++ b/server/src/http/routes/dailyFritzClientPhase.ts
@@ -1,0 +1,35 @@
+import type { DailyFritzSetResult } from '../../dailyFritz';
+
+export type DailyFritzClientNextAction =
+  | 'start_set'
+  | 'resume_hand'
+  | 'between_games'
+  | 'finalize_set'
+  | 'view_results'
+  | 'locked';
+
+export function resolveDailyFritzClientNextAction(input: {
+  attemptStatus: 'started' | 'completed' | 'abandoned' | null;
+  setResult: DailyFritzSetResult | null;
+  needsCompletion?: boolean;
+  currentHandIndex: number;
+  hasResumeCheckpoint: boolean;
+}): DailyFritzClientNextAction {
+  if (input.attemptStatus === 'completed' || input.attemptStatus === 'abandoned') {
+    return 'view_results';
+  }
+  if (input.attemptStatus !== 'started') {
+    return 'start_set';
+  }
+  if (input.needsCompletion || input.setResult?.setWinner) {
+    return 'finalize_set';
+  }
+  const gamesRecorded = input.setResult?.games.length ?? 0;
+  if (gamesRecorded > 0 && input.currentHandIndex === 0) {
+    return 'between_games';
+  }
+  if (input.hasResumeCheckpoint || input.currentHandIndex > 0) {
+    return 'resume_hand';
+  }
+  return 'start_set';
+}

--- a/server/src/http/routes/dailyFritzMetrics.ts
+++ b/server/src/http/routes/dailyFritzMetrics.ts
@@ -37,6 +37,11 @@ export function incrementDailyFritzMetric(
   const target = bucket(name);
   target.total += 1;
   if (code) target.byCode[code] = (target.byCode[code] ?? 0) + 1;
+  if (name === 'request_failed' || name === 'verification_failed') {
+    void import('./dailyFritzMetricsExport').then(({ mirrorDailyFritzMetricIncrementBestEffort }) => {
+      mirrorDailyFritzMetricIncrementBestEffort(name, code);
+    }).catch(() => {});
+  }
 }
 
 export function getDailyFritzMetrics(): Record<DailyFritzMetricName, MetricBucket> {

--- a/server/src/http/routes/dailyFritzMetricsExport.ts
+++ b/server/src/http/routes/dailyFritzMetricsExport.ts
@@ -1,0 +1,26 @@
+import type { DailyFritzMetricName } from './dailyFritzMetrics';
+
+const METRIC_EVENT_MAP: Partial<Record<DailyFritzMetricName, 'request_failed' | 'verification_failed'>> = {
+  request_failed: 'request_failed',
+  verification_failed: 'verification_failed',
+};
+
+/** Best-effort: mirror high-signal in-memory counters into durable events. */
+export function mirrorDailyFritzMetricIncrementBestEffort(
+  name: DailyFritzMetricName,
+  code?: string | null,
+): void {
+  const eventType = METRIC_EVENT_MAP[name];
+  if (!eventType) return;
+  void import('./dailyFritzVerificationGlue').then(({ recordDailyFritzEventBestEffort }) =>
+    recordDailyFritzEventBestEffort({
+      attemptId: null,
+      runDate: null,
+      userId: null,
+      eventType,
+      idempotencyKey: `metric:${name}:${code ?? 'none'}:${Date.now()}`,
+      verifierCode: code ?? null,
+      payload: { metric: name },
+    }),
+  ).catch(() => {});
+}

--- a/server/src/http/routes/dailyFritzRecordGameAdvance.test.ts
+++ b/server/src/http/routes/dailyFritzRecordGameAdvance.test.ts
@@ -1,0 +1,216 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Application } from 'express';
+import {
+  DAILY_FRITZ_TRANSCRIPT_PROTOCOL_VERSION,
+  FRITZ_POLICY_VERSION,
+  GAME_RULES_VERSION,
+  getFritzPolicyContract,
+} from '@racehorse/game-core';
+import { buildDailyFritzChallengeId } from '../../dailyFritzIdentity';
+import { getDailyFritzSeed } from '../../dailyFritz';
+import type { DailyFritzAttemptRecord, DailyFritzRunRecord } from '../stores/dailyFritzStore';
+
+const { authUserMock, getAttemptByIdMock, getAttemptMock, upsertAttemptMock, getRunMock } = vi.hoisted(() => ({
+  authUserMock: vi.fn(),
+  getAttemptByIdMock: vi.fn(),
+  getAttemptMock: vi.fn(),
+  upsertAttemptMock: vi.fn(),
+  getRunMock: vi.fn(),
+}));
+
+vi.mock('../../platform/auth/supabaseAuth', () => ({
+  getAuthenticatedUserId: authUserMock,
+}));
+
+vi.mock('../stores/dailyFritzStore', async () => {
+  const actual = await vi.importActual<typeof import('../stores/dailyFritzStore')>(
+    '../stores/dailyFritzStore',
+  );
+  return {
+    ...actual,
+    getDailyFritzAttemptById: getAttemptByIdMock,
+    getDailyFritzAttempt: getAttemptMock,
+    upsertDailyFritzAttempt: upsertAttemptMock,
+    getDailyFritzRun: getRunMock,
+    ensureDailyFritzRunForDate: getRunMock,
+  };
+});
+
+vi.mock('../stores/dailyFritzEventStore', async () => {
+  const actual = await vi.importActual<typeof import('../stores/dailyFritzEventStore')>(
+    '../stores/dailyFritzEventStore',
+  );
+  return {
+    ...actual,
+    recordDailyFritzEvent: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+vi.mock('../../social/activityWriter', () => ({
+  writeDailyFritzGameActivity: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { registerDailyFritzRoutes } from './dailyFritz';
+import { getDailyFritzMetrics, resetDailyFritzMetricsForTests } from './dailyFritzMetrics';
+
+type Handler = (req: unknown, res: unknown) => unknown | Promise<unknown>;
+
+function makeHarness() {
+  const routes = new Map<string, Handler>();
+  const app = {
+    get(path: string, handler: Handler) { routes.set(`GET ${path}`, handler); },
+    post(path: string, handler: Handler) { routes.set(`POST ${path}`, handler); },
+  };
+  registerDailyFritzRoutes(app as unknown as Application);
+  return async function request(method: 'GET' | 'POST', path: string, input: { body?: Record<string, unknown> } = {}) {
+    const handler = routes.get(`${method} ${path}`);
+    if (!handler) throw new Error(`Missing route ${method} ${path}`);
+    let status = 200;
+    let body: unknown;
+    const res = {
+      status(code: number) { status = code; return res; },
+      json(value: unknown) { body = value; return res; },
+      setHeader() { return res; },
+      once() { return res; },
+    };
+    await handler({ headers: {}, params: {}, query: {}, body: input.body ?? {}, method, path, get() { return undefined; } }, res);
+    return { status, body: body as Record<string, unknown> };
+  };
+}
+
+const RUN_DATE = '2026-08-10';
+const USER_ID = 'user-1';
+const ATTEMPT_ID = 'attempt-1';
+const VERIFIED_MATCH_ID = 'verified-match-1';
+
+function buildAttempt(): DailyFritzAttemptRecord {
+  return {
+    id: ATTEMPT_ID,
+    runDate: RUN_DATE,
+    userId: USER_ID,
+    status: 'started',
+    currentHandIndex: 3,
+    currentGameNumber: 2,
+    revision: 4,
+    challengeId: null,
+    challengeContractVersion: null,
+    generationVersion: null,
+    gameRulesVersion: null,
+    transcriptProtocolVersion: DAILY_FRITZ_TRANSCRIPT_PROTOCOL_VERSION,
+    fritzPolicyVersion: FRITZ_POLICY_VERSION,
+    rankingVersion: null,
+    authoritySchemaVersion: 1,
+    startedAt: '2026-08-10T00:00:00.000Z',
+    completedAt: null,
+    verifiedMatchId: VERIFIED_MATCH_ID,
+    completionHash: null,
+    result: {
+      version: 2,
+      format: 'best_of_3',
+      playerGamesWon: 0,
+      fritzGamesWon: 1,
+      totalPointDiff: -10,
+      games: [{
+        gameNumber: 1,
+        seed: 'seed-1',
+        playerWon: false,
+        playerScore: 40,
+        fritzScore: 60,
+        pointDiff: -20,
+        movesUsed: 12,
+        handsPlayed: 4,
+        completedAt: '2026-08-10T10:00:00.000Z',
+      }],
+      authority_contract: {
+        transcriptProtocolVersion: DAILY_FRITZ_TRANSCRIPT_PROTOCOL_VERSION,
+        gameRulesVersion: GAME_RULES_VERSION,
+        fritzPolicyVersion: FRITZ_POLICY_VERSION,
+        fritzPolicyContract: getFritzPolicyContract(FRITZ_POLICY_VERSION),
+        stateDigestVersion: 1,
+        stateDigestRequired: true,
+        clientRelease: 'test',
+        challengeId: buildDailyFritzChallengeId(RUN_DATE),
+        runFingerprint: 'fp',
+      },
+      verification_status: 'in_progress',
+      active_game: { game_number: 2, you: 60, fritz: 34 },
+    },
+    finalScore: null,
+    opponentScore: null,
+    pointDiff: null,
+    won: null,
+    movesUsed: null,
+    handsPlayed: null,
+  };
+}
+
+function buildRun(): DailyFritzRunRecord {
+  return {
+    runDate: RUN_DATE,
+    seed: getDailyFritzSeed(RUN_DATE),
+    fritzTier: 'standard',
+    dealSize: 7,
+    winningScore: 100,
+    status: 'live',
+    handDeals: [],
+    generatedAt: '2026-08-10T00:00:00.000Z',
+    invalidatedAt: null,
+    metadata: { draw_winners_by_game: { '2': 'you' } },
+  };
+}
+
+describe('record-game advance-first with legacy scores', () => {
+  const request = makeHarness();
+
+  beforeEach(() => {
+    resetDailyFritzMetricsForTests();
+    authUserMock.mockResolvedValue(USER_ID);
+    process.env.DAILY_FRITZ_TEST_FIXTURES_ENABLED = 'true';
+    const attempt = buildAttempt();
+    getAttemptByIdMock.mockImplementation(async () => ({ ...attempt }));
+    getAttemptMock.mockImplementation(async () => ({ ...attempt }));
+    upsertAttemptMock.mockImplementation(async (record: DailyFritzAttemptRecord) => ({ ...record, revision: record.revision + 1 }));
+    getRunMock.mockImplementation(async () => buildRun());
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    delete process.env.DAILY_FRITZ_TEST_FIXTURES_ENABLED;
+  });
+
+  it('records game 2 from legacy scores when transcript verification fails', async () => {
+    const response = await request('POST', '/api/daily-fritz/record-game', {
+      body: {
+        attempt_id: ATTEMPT_ID,
+        verified_match_id: VERIFIED_MATCH_ID,
+        run_date: RUN_DATE,
+        game_number: 2,
+        player_score: 60,
+        fritz_score: 34,
+        moves_used: 18,
+        hands_played: 4,
+        transcript: {
+          protocolVersion: DAILY_FRITZ_TRANSCRIPT_PROTOCOL_VERSION,
+          rulesVersion: GAME_RULES_VERSION,
+          fritzPolicyVersion: FRITZ_POLICY_VERSION,
+          fritzPolicyContract: getFritzPolicyContract(FRITZ_POLICY_VERSION),
+          stateDigestVersion: 1,
+          clientRelease: 'test',
+          challengeId: buildDailyFritzChallengeId(RUN_DATE),
+          attemptId: ATTEMPT_ID,
+          gameNumber: 2,
+          handIndex: 3,
+          actions: [{ sequence: 0, actor: 'player', kind: 'pass' }],
+        },
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body.ok).toBe(true);
+    const games = (response.body.set_result as { games: Array<{ gameNumber: number; playerScore: number; fritzScore: number }> }).games;
+    expect(games).toHaveLength(2);
+    expect(games[1]).toMatchObject({ gameNumber: 2, playerScore: 60, fritzScore: 34 });
+    expect(getDailyFritzMetrics().verification_bypassed.total).toBeGreaterThan(0);
+    expect(response.body.next_game_number).toBe(3);
+  });
+});

--- a/server/src/http/routes/dailyFritzStartRoute.ts
+++ b/server/src/http/routes/dailyFritzStartRoute.ts
@@ -58,6 +58,7 @@ import {
 } from './dailyFritzVerificationGlue';
 import { capture500, log, prodSafeError } from './dailyFritzRouteErrors';
 import { resolveDailyFritzResumeCheckpoint } from './dailyFritzCheckpointPolicy';
+import { resolveDailyFritzClientNextAction } from './dailyFritzClientPhase';
 
 export function registerDailyFritzStartRoute(app: Application): void {
   app.post('/api/daily-fritz/start', async (req, res) => {
@@ -331,6 +332,13 @@ export function registerDailyFritzStartRoute(app: Application): void {
     }, '[daily-fritz:start] draw package');
     const runFingerprint = buildDailyFritzRunFingerprint(run);
     const resumeCheckpoint = resolveDailyFritzResumeCheckpoint(attempt, runFingerprint);
+    const nextAction = resolveDailyFritzClientNextAction({
+      attemptStatus: attempt.status,
+      setResult: currentSetResult,
+      needsCompletion,
+      currentHandIndex: attempt.currentHandIndex,
+      hasResumeCheckpoint: Boolean(resumeCheckpoint),
+    });
     res.json({
       ok: true,
       attempt_id: attempt.id,
@@ -351,6 +359,7 @@ export function registerDailyFritzStartRoute(app: Application): void {
       verifier_version: DAILY_FRITZ_VERIFIER_VERSION,
       time_zone: DAILY_FRITZ_TIME_ZONE,
       verification_status: getDailyFritzVerificationStatus(attempt.result),
+      next_action: nextAction,
       current_hand_index: attempt.currentHandIndex,
       current_game_scores: { you: currentGameScores.you, fritz: currentGameScores.fritz },
       current_game_number: currentGameNumber,

--- a/server/src/http/routes/dailyFritzTodayRoute.ts
+++ b/server/src/http/routes/dailyFritzTodayRoute.ts
@@ -28,6 +28,8 @@ import {
 } from './dailyFritzVerificationPolicy';
 import { DAILY_FRITZ_COMPETITIVE_VERIFICATION_AVAILABLE } from './dailyFritzVerificationGlue';
 import { capture500, log, prodSafeError } from './dailyFritzRouteErrors';
+import { readDailyFritzActiveCheckpoint } from './dailyFritzCheckpointPolicy';
+import { resolveDailyFritzClientNextAction } from './dailyFritzClientPhase';
 
 export function registerDailyFritzTodayRoutes(app: Application): void {
   app.get('/api/daily-fritz/history', async (req, res) => {
@@ -192,6 +194,20 @@ export function registerDailyFritzTodayRoutes(app: Application): void {
     }
 
     const serializeStartedAt = Date.now();
+    const activeCheckpoint = attempt ? readDailyFritzActiveCheckpoint(attempt.result) : null;
+    const hasResumeCheckpoint = Boolean(
+      activeCheckpoint
+      && attempt
+      && activeCheckpoint.currentHandIndex === attempt.currentHandIndex
+      && activeCheckpoint.authorityRevision === attempt.revision,
+    );
+    const nextAction = resolveDailyFritzClientNextAction({
+      attemptStatus: attempt?.status ?? null,
+      setResult: attemptSetResult,
+      needsCompletion,
+      currentHandIndex: attempt?.currentHandIndex ?? 0,
+      hasResumeCheckpoint,
+    });
     const payload = {
       ok: true,
       run_date: run.runDate,
@@ -204,6 +220,7 @@ export function registerDailyFritzTodayRoutes(app: Application): void {
       winning_score: run.winningScore,
       attempt_status: attempt?.status ?? 'none',
       authority_revision: attempt?.revision ?? null,
+      next_action: nextAction,
       verification_protocol_version:
         attemptAuthorityContract?.transcriptProtocolVersion
         ?? DAILY_FRITZ_VERIFICATION_PROTOCOL_VERSION,


### PR DESCRIPTION
## Summary
- **Unified mutation client** — shared timeout/error taxonomy in `dailyFritzMutations.ts`; all record-game/complete/checkpoint POSTs use consistent abort + failure classification.
- **Observability** — Sentry alerts for saving timeout, record-game failure, cursor divergence, and transcript build failure; server mirrors high-signal metrics to durable events.
- **Checkpoint safety** — checkpoint route wrapped in `withDailyFritzAttemptLock` to prevent torn writes.
- **Server phase hints** — `/start` and `/today` now return `next_action` (`resume_hand`, `between_games`, `finalize_set`, etc.) for Phase 2 overlay collapse.
- **Completion evidence source clarified** — `/api/daily-fritz/complete` finalizes from persisted authority ledger + set state; no `officialJournal` field is consumed on the completion path.
- **Advance-first contract test** — record-game accepts legacy scores when transcript verification fails (never strand on Saving…).

## Test plan
- [x] `dailyFritzClientPhase.test.ts` (5 tests)
- [x] `dailyFritzRecordGameAdvance.test.ts` (advance-first legacy scores)
- [x] `dailyFritzCheckpoint.test.ts` (5 tests)
- [x] Client + server builds pass
- [ ] Manual: complete a Daily Fritz game end-to-end; confirm Saving overlay clears within 15s
- [ ] Manual: hard refresh mid-hand; confirm server checkpoint resume works

## Follow-ups (Phase 2)
- Wire client overlays to `next_action` from start/today
- Single resume loader + authority cursor merge


Made with [Cursor](https://cursor.com)