### PR TITLE
Server-driven Daily Fritz next_action (Phase 2.2)

### DIFF
--- a/client/src/dailyFritz/DailyFritzScreen.tsx
+++ b/client/src/dailyFritz/DailyFritzScreen.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useDeferredAsset } from '../ui/useDeferredAsset';
 import '../screens/RacehorseHomeArt.css';
 
-import { normalizeSetResult } from './dailyFritzScreenHelpers';
+import { normalizeSetResult, resolveTodayNextAction } from './dailyFritzScreenHelpers';
 import type { DailyFritzScreenProps } from './dailyFritzScreenTypes';
 import { DailyFritzLoadingScreen } from './DailyFritzLoadingScreen';
 import { useDailyFritzInit } from './useDailyFritzInit';
@@ -87,14 +87,21 @@ export default function DailyFritzScreen({
   }, [onNavigate]);
 
   const handleSetAction = useCallback(() => {
-    if (today?.attempt_status === 'completed') { openLeaderboard(); return; }
-    const isStarted = today?.attempt_status === 'started';
-    if (isStarted) {
+    const nextAction = resolveTodayNextAction(today);
+    if (nextAction === 'view_results') {
+      openLeaderboard();
+      return;
+    }
+    if (nextAction === 'locked') {
+      setHubError('Today’s Daily Fritz run is locked.');
+      return;
+    }
+    if (today?.attempt_status === 'started') {
       void continueSet();
       return;
     }
     void beginRun();
-  }, [beginRun, continueSet, openLeaderboard, today?.attempt_status]);
+  }, [beginRun, continueSet, openLeaderboard, setHubError, today]);
 
   const setOverlayConfig = useMemo(() => {
     if (!setOverlay) return null;

--- a/client/src/dailyFritz/api.ts
+++ b/client/src/dailyFritz/api.ts
@@ -291,12 +291,15 @@ export interface DailyFritzLeaderboardRow {
 export type DailyFritzVerificationStatus = 'in_progress' | 'pending_verification' | 'verified' | 'rejected' | 'legacy_unverified';
 
 export type DailyFritzClientNextAction =
-  | 'start_set'
-  | 'resume_hand'
+  | 'play_hand'
   | 'between_games'
   | 'finalize_set'
   | 'view_results'
   | 'locked';
+export type DailyFritzServerNextAction =
+  | DailyFritzClientNextAction
+  | 'start_set'
+  | 'resume_hand';
 export type DailyFritzHistoryEntry = { challenge_date: string; player_score: number; fritz_score: number; won: boolean; completed_at: string | null; verification_status: DailyFritzVerificationStatus };
 export async function getDailyFritzHistory(limit = 5): Promise<DailyFritzHistoryEntry[]> {
   const result = await apiGet<{ ok: true; results: DailyFritzHistoryEntry[] }>(`/api/daily-fritz/history?limit=${Math.max(1,Math.min(10,Math.floor(limit)))}`);
@@ -334,7 +337,7 @@ export interface DailyFritzTodayResponse {
   winning_score: number;
   attempt_status: 'none' | 'started' | 'completed' | 'abandoned';
   authority_revision?: number | null;
-  next_action?: DailyFritzClientNextAction;
+  next_action?: DailyFritzServerNextAction;
   current_game_number: DailyFritzSetGameNumber | null;
   needs_completion?: boolean;
   streak: number;
@@ -373,7 +376,7 @@ export interface DailyFritzStartResponse {
   verifier_version?: number;
   time_zone?: 'America/Los_Angeles';
   verification_status?: DailyFritzVerificationStatus;
-  next_action?: DailyFritzClientNextAction;
+  next_action?: DailyFritzServerNextAction;
   current_hand_index: number;
   current_game_scores?: { you: number; fritz: number };
   current_game_number?: DailyFritzSetGameNumber | null;

--- a/client/src/dailyFritz/dailyFritzHubViewModel.test.ts
+++ b/client/src/dailyFritz/dailyFritzHubViewModel.test.ts
@@ -3,7 +3,10 @@ import { describe, expect, it } from 'vitest';
 import { buildDailyFritzHubGameCards, buildDailyFritzHubViewModel } from './dailyFritzHubViewModel';
 import type { DailyFritzSetResult, DailyFritzTodayResponse } from './api';
 
-function makeToday(attemptStatus: DailyFritzTodayResponse['attempt_status']): DailyFritzTodayResponse {
+function makeToday(
+  attemptStatus: DailyFritzTodayResponse['attempt_status'],
+  nextAction: DailyFritzTodayResponse['next_action'] = 'play_hand',
+): DailyFritzTodayResponse {
   return {
     ok: true,
     run_date: '2026-07-05',
@@ -11,6 +14,7 @@ function makeToday(attemptStatus: DailyFritzTodayResponse['attempt_status']): Da
     deal_size: 7,
     winning_score: 60,
     attempt_status: attemptStatus,
+    next_action: nextAction,
     current_game_number: null,
     streak: attemptStatus === 'none' ? 3 : 1,
     result: null,
@@ -71,23 +75,34 @@ describe('buildDailyFritzHubGameCards', () => {
 });
 
 describe('buildDailyFritzHubViewModel', () => {
-  it('returns play CTA when attempt not started', () => {
-    const vm = buildDailyFritzHubViewModel(makeToday('none'), null, 0, false, true);
+  it('maps play_hand to play CTA for a fresh start', () => {
+    const vm = buildDailyFritzHubViewModel(makeToday('none', 'play_hand'), null, 0, false, true);
     expect(vm.primaryCtaLabel).toBe("Play Today's Set");
     expect(vm.isComplete).toBe(false);
     expect(vm.isStarted).toBe(false);
   });
 
-  it('returns resume CTA when attempt started', () => {
-    const vm = buildDailyFritzHubViewModel(makeToday('started'), emptySetResult, 0, false, true);
+  it('maps between_games to resume CTA', () => {
+    const vm = buildDailyFritzHubViewModel(makeToday('started', 'between_games'), emptySetResult, 0, false, true);
     expect(vm.primaryCtaLabel).toBe("Resume Today's Set");
     expect(vm.isStarted).toBe(true);
   });
 
-  it('renders the authoritative completed hub after a lost /complete response', () => {
-    const vm = buildDailyFritzHubViewModel(makeToday('completed'), emptySetResult, 0, false, true);
+  it('maps finalize_set to resume CTA', () => {
+    const vm = buildDailyFritzHubViewModel(makeToday('started', 'finalize_set'), emptySetResult, 0, false, true);
+    expect(vm.primaryCtaLabel).toBe("Resume Today's Set");
+  });
+
+  it('maps view_results to completed render', () => {
+    const vm = buildDailyFritzHubViewModel(makeToday('completed', 'view_results'), emptySetResult, 0, false, true);
     expect(vm.primaryCtaLabel).toBe("View Today's Result");
     expect(vm.setStatusLabel).toBe('Complete');
     expect(vm.isComplete).toBe(true);
+  });
+
+  it('maps locked to locked render', () => {
+    const vm = buildDailyFritzHubViewModel(makeToday('abandoned', 'locked'), emptySetResult, 0, false, true);
+    expect(vm.primaryCtaLabel).toBe('Locked');
+    expect(vm.setStatusLabel).toBe('Locked');
   });
 });

--- a/client/src/dailyFritz/dailyFritzHubViewModel.ts
+++ b/client/src/dailyFritz/dailyFritzHubViewModel.ts
@@ -3,6 +3,7 @@ import { formatOrdinalPlace } from './format';
 import {
   formatCountdownHms,
   formatDateLabel,
+  resolveTodayNextAction,
   secondsUntilNextPacificMidnight,
   tierDisplayLabel,
   titleCaseTier,
@@ -129,14 +130,17 @@ export function buildDailyFritzHubViewModel(
   const streakLabel = today ? `${today.streak} day${today.streak === 1 ? '' : 's'}` : '0 days';
   const winTarget = today?.winning_score ?? 60;
 
-  const isComplete = today?.attempt_status === 'completed';
+  const nextAction = resolveTodayNextAction(today);
+  const isComplete = nextAction === 'view_results';
   const isStarted = today?.attempt_status === 'started';
 
-  const primaryCtaLabel = isComplete
+  const primaryCtaLabel = nextAction === 'view_results'
     ? "View Today's Result"
-    : isStarted
-      ? "Resume Today's Set"
-      : "Play Today's Set";
+    : nextAction === 'locked'
+      ? 'Locked'
+      : isStarted
+        ? "Resume Today's Set"
+        : "Play Today's Set";
 
   const games = buildDailyFritzHubGameCards(todaySetResult, {
     isComplete,
@@ -157,7 +161,11 @@ export function buildDailyFritzHubViewModel(
       : today?.competitive_verification_available === false
         ? 'Competitive verification temporarily unavailable'
         : 'Play today to appear on the leaderboard';
-  const setStatusLabel = isComplete ? 'Complete' : isStarted ? 'In Progress' : 'Ready';
+  const setStatusLabel = nextAction === 'locked'
+    ? 'Locked'
+    : isComplete
+      ? 'Complete'
+      : isStarted ? 'In Progress' : 'Ready';
   const setStakesLabel = isComplete
     ? 'Return tomorrow for a new set'
     : today?.competitive_verification_available === false

--- a/client/src/dailyFritz/dailyFritzScreenHelpers.test.ts
+++ b/client/src/dailyFritz/dailyFritzScreenHelpers.test.ts
@@ -12,6 +12,7 @@ import {
   friendlyDailyFritzInitError,
   normalizeSetResult,
   getNextGameNumberFromSetResult,
+  resolveTodayNextAction,
 } from './dailyFritzScreenHelpers';
 
 describe('formatDateLabel', () => {
@@ -129,5 +130,42 @@ describe('normalizeSetResult', () => {
 describe('getNextGameNumberFromSetResult', () => {
   it('returns 1 when set result is null', () => {
     expect(getNextGameNumberFromSetResult(null)).toBe(1);
+  });
+});
+
+describe('resolveTodayNextAction', () => {
+  it('uses server next_action when present', () => {
+    expect(resolveTodayNextAction({
+      ok: true,
+      run_date: '2026-08-19',
+      fritz_tier: 'elite',
+      deal_size: 7,
+      winning_score: 60,
+      attempt_status: 'started',
+      next_action: 'between_games',
+      current_game_number: 2,
+      streak: 1,
+      result: null,
+      set_result: null,
+      rank: null,
+      leaderboard_preview: [],
+    })).toBe('between_games');
+  });
+
+  it('falls back gracefully when next_action is missing', () => {
+    expect(resolveTodayNextAction({
+      ok: true,
+      run_date: '2026-08-19',
+      fritz_tier: 'elite',
+      deal_size: 7,
+      winning_score: 60,
+      attempt_status: 'completed',
+      current_game_number: null,
+      streak: 1,
+      result: null,
+      set_result: null,
+      rank: null,
+      leaderboard_preview: [],
+    })).toBe('view_results');
   });
 });

--- a/client/src/dailyFritz/dailyFritzScreenHelpers.ts
+++ b/client/src/dailyFritz/dailyFritzScreenHelpers.ts
@@ -1,4 +1,6 @@
 import type {
+  DailyFritzClientNextAction,
+  DailyFritzServerNextAction,
   DailyFritzSetGameNumber,
   DailyFritzSetGameResult,
   DailyFritzSetResult,
@@ -38,6 +40,47 @@ export function shouldClearStaleClientState(
   if (cached.attempt_status === 'started' && server.attempt_status !== 'started') return true;
   if (cached.attempt_status === 'completed' && server.attempt_status === 'none') return true;
   return false;
+}
+
+function inferFallbackNextActionFromToday(today: DailyFritzTodayResponse | null): DailyFritzClientNextAction {
+  if (!today) return 'play_hand';
+  if (today.attempt_status === 'completed') return 'view_results';
+  if (today.attempt_status === 'abandoned') return 'locked';
+  if (today.attempt_status === 'started' && (today.needs_completion || today.set_result?.setWinner)) {
+    return 'finalize_set';
+  }
+  return 'play_hand';
+}
+
+function inferFallbackNextActionFromStart(started: DailyFritzStartResponse): DailyFritzClientNextAction {
+  if (started.needs_completion || started.set_result?.setWinner) return 'finalize_set';
+  return 'play_hand';
+}
+
+export function normalizeDailyFritzNextAction(
+  nextAction: DailyFritzServerNextAction | null | undefined,
+  fallback: DailyFritzClientNextAction,
+): DailyFritzClientNextAction {
+  if (nextAction === 'play_hand'
+    || nextAction === 'between_games'
+    || nextAction === 'finalize_set'
+    || nextAction === 'view_results'
+    || nextAction === 'locked') {
+    return nextAction;
+  }
+  // Backward-compatibility with older cached API payloads.
+  if (nextAction === 'start_set' || nextAction === 'resume_hand') {
+    return 'play_hand';
+  }
+  return fallback;
+}
+
+export function resolveTodayNextAction(today: DailyFritzTodayResponse | null): DailyFritzClientNextAction {
+  return normalizeDailyFritzNextAction(today?.next_action, inferFallbackNextActionFromToday(today));
+}
+
+export function resolveStartNextAction(started: DailyFritzStartResponse): DailyFritzClientNextAction {
+  return normalizeDailyFritzNextAction(started.next_action, inferFallbackNextActionFromStart(started));
 }
 
 export function friendlyDailyFritzInitError(error: unknown): string {

--- a/client/src/dailyFritz/useDailyFritzRunController.ts
+++ b/client/src/dailyFritz/useDailyFritzRunController.ts
@@ -20,6 +20,8 @@ import {
   getNextGameNumberFromSetResult,
   normalizeGameNumber,
   normalizeSetResult,
+  resolveStartNextAction,
+  resolveTodayNextAction,
   normalizeStartResponse,
   resolveDailyFritzCurrentGameNumber,
 } from './dailyFritzScreenHelpers';
@@ -244,7 +246,7 @@ export function useDailyFritzRunController({
     fallbackSetResult: DailyFritzSetResult | null,
   ) => {
     const normalized = normalizeStartResponse(started, fallbackSetResult);
-    if (normalized.needs_completion && normalized.set_result?.setWinner) {
+    if (resolveStartNextAction(normalized) === 'finalize_set' && normalized.set_result?.setWinner) {
       const completedGame =
         normalized.set_result.games[normalized.set_result.games.length - 1] ??
         buildCompletedGame(normalized, {
@@ -333,12 +335,8 @@ export function useDailyFritzRunController({
   }, [handleStartResponse, setOverlay, setHubError, today]);
 
   useEffect(() => {
-    if (
-      today?.attempt_status !== 'started'
-      || !today.needs_completion
-      || !normalizeSetResult(today.set_result ?? today.result)?.setWinner
-      || activeRun
-    ) return;
+    if (resolveTodayNextAction(today) !== 'finalize_set' || activeRun) return;
+    if (!normalizeSetResult(today?.set_result ?? today?.result)?.setWinner) return;
     void continueSet();
   }, [activeRun, continueSet, today]);
 

--- a/server/src/http/routes/dailyFritzClientPhase.test.ts
+++ b/server/src/http/routes/dailyFritzClientPhase.test.ts
@@ -2,22 +2,22 @@ import { describe, expect, it } from 'vitest';
 import { resolveDailyFritzClientNextAction } from './dailyFritzClientPhase';
 
 describe('resolveDailyFritzClientNextAction', () => {
-  it('returns start_set for a fresh attempt', () => {
+  it('returns play_hand for a fresh attempt', () => {
     expect(resolveDailyFritzClientNextAction({
       attemptStatus: 'started',
       setResult: null,
       currentHandIndex: 0,
       hasResumeCheckpoint: false,
-    })).toBe('start_set');
+    })).toBe('play_hand');
   });
 
-  it('returns resume_hand when a checkpoint exists mid-hand', () => {
+  it('returns play_hand when a checkpoint exists mid-hand', () => {
     expect(resolveDailyFritzClientNextAction({
       attemptStatus: 'started',
       setResult: { version: 2, format: 'best_of_3', playerGamesWon: 0, fritzGamesWon: 0, totalPointDiff: 0, games: [] },
       currentHandIndex: 2,
       hasResumeCheckpoint: true,
-    })).toBe('resume_hand');
+    })).toBe('play_hand');
   });
 
   it('returns between_games after a game is recorded but the set continues', () => {
@@ -71,5 +71,14 @@ describe('resolveDailyFritzClientNextAction', () => {
       currentHandIndex: 0,
       hasResumeCheckpoint: false,
     })).toBe('view_results');
+  });
+
+  it('returns locked for abandoned attempts', () => {
+    expect(resolveDailyFritzClientNextAction({
+      attemptStatus: 'abandoned',
+      setResult: null,
+      currentHandIndex: 0,
+      hasResumeCheckpoint: false,
+    })).toBe('locked');
   });
 });

--- a/server/src/http/routes/dailyFritzClientPhase.ts
+++ b/server/src/http/routes/dailyFritzClientPhase.ts
@@ -1,8 +1,7 @@
 import type { DailyFritzSetResult } from '../../dailyFritz';
 
 export type DailyFritzClientNextAction =
-  | 'start_set'
-  | 'resume_hand'
+  | 'play_hand'
   | 'between_games'
   | 'finalize_set'
   | 'view_results'
@@ -15,11 +14,14 @@ export function resolveDailyFritzClientNextAction(input: {
   currentHandIndex: number;
   hasResumeCheckpoint: boolean;
 }): DailyFritzClientNextAction {
-  if (input.attemptStatus === 'completed' || input.attemptStatus === 'abandoned') {
+  if (input.attemptStatus === 'completed') {
     return 'view_results';
   }
+  if (input.attemptStatus === 'abandoned') {
+    return 'locked';
+  }
   if (input.attemptStatus !== 'started') {
-    return 'start_set';
+    return 'play_hand';
   }
   if (input.needsCompletion || input.setResult?.setWinner) {
     return 'finalize_set';
@@ -28,8 +30,5 @@ export function resolveDailyFritzClientNextAction(input: {
   if (gamesRecorded > 0 && input.currentHandIndex === 0) {
     return 'between_games';
   }
-  if (input.hasResumeCheckpoint || input.currentHandIndex > 0) {
-    return 'resume_hand';
-  }
-  return 'start_set';
+  return 'play_hand';
 }


### PR DESCRIPTION
## Summary
- Collapse server `next_action` to Phase 2.2 enum (`play_hand`, `between_games`, `finalize_set`, `view_results`, `locked`) with legacy `start_set`/`resume_hand` normalization on the client.
- Wire hub CTA, set action routing, and auto-finalize resume to explicit `next_action` from `/today` and `/start`, with fallback when the field is missing.
- Add/extend tests for server phase resolution and client normalization.

## Scope
- `/start` and `/today` response handling + hub/overlay routing only.
- Does **not** include advance-first record-game (merged separately in #18).

## Test plan
- [x] `dailyFritzClientPhase.test.ts`
- [x] `dailyFritzHubViewModel.test.ts`
- [x] `dailyFritzScreenHelpers.test.ts`
- [x] Client build
- [x] Server build


Made with [Cursor](https://cursor.com)