### PR TITLE
fix(daily-fritz): legacy_unverified finalize after rejected terminal hand

### DIFF
--- a/client/src/dailyFritz/DailyFritzScreen.tsx
+++ b/client/src/dailyFritz/DailyFritzScreen.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useDeferredAsset } from '../ui/useDeferredAsset';
 import '../screens/RacehorseHomeArt.css';
 
-import { normalizeSetResult } from './dailyFritzScreenHelpers';
+import { normalizeSetResult, resolveTodayNextAction } from './dailyFritzScreenHelpers';
 import type { DailyFritzScreenProps } from './dailyFritzScreenTypes';
 import { DailyFritzLoadingScreen } from './DailyFritzLoadingScreen';
 import { useDailyFritzInit } from './useDailyFritzInit';
@@ -87,14 +87,21 @@ export default function DailyFritzScreen({
   }, [onNavigate]);
 
   const handleSetAction = useCallback(() => {
-    if (today?.attempt_status === 'completed') { openLeaderboard(); return; }
-    const isStarted = today?.attempt_status === 'started';
-    if (isStarted) {
+    const nextAction = resolveTodayNextAction(today);
+    if (nextAction === 'view_results') {
+      openLeaderboard();
+      return;
+    }
+    if (nextAction === 'locked') {
+      setHubError('Today’s Daily Fritz run is locked.');
+      return;
+    }
+    if (today?.attempt_status === 'started') {
       void continueSet();
       return;
     }
     void beginRun();
-  }, [beginRun, continueSet, openLeaderboard, today?.attempt_status]);
+  }, [beginRun, continueSet, openLeaderboard, setHubError, today]);
 
   const setOverlayConfig = useMemo(() => {
     if (!setOverlay) return null;

--- a/client/src/dailyFritz/api.ts
+++ b/client/src/dailyFritz/api.ts
@@ -291,12 +291,15 @@ export interface DailyFritzLeaderboardRow {
 export type DailyFritzVerificationStatus = 'in_progress' | 'pending_verification' | 'verified' | 'rejected' | 'legacy_unverified';
 
 export type DailyFritzClientNextAction =
-  | 'start_set'
-  | 'resume_hand'
+  | 'play_hand'
   | 'between_games'
   | 'finalize_set'
   | 'view_results'
   | 'locked';
+export type DailyFritzServerNextAction =
+  | DailyFritzClientNextAction
+  | 'start_set'
+  | 'resume_hand';
 export type DailyFritzHistoryEntry = { challenge_date: string; player_score: number; fritz_score: number; won: boolean; completed_at: string | null; verification_status: DailyFritzVerificationStatus };
 export async function getDailyFritzHistory(limit = 5): Promise<DailyFritzHistoryEntry[]> {
   const result = await apiGet<{ ok: true; results: DailyFritzHistoryEntry[] }>(`/api/daily-fritz/history?limit=${Math.max(1,Math.min(10,Math.floor(limit)))}`);
@@ -334,7 +337,7 @@ export interface DailyFritzTodayResponse {
   winning_score: number;
   attempt_status: 'none' | 'started' | 'completed' | 'abandoned';
   authority_revision?: number | null;
-  next_action?: DailyFritzClientNextAction;
+  next_action?: DailyFritzServerNextAction;
   current_game_number: DailyFritzSetGameNumber | null;
   needs_completion?: boolean;
   streak: number;
@@ -373,7 +376,7 @@ export interface DailyFritzStartResponse {
   verifier_version?: number;
   time_zone?: 'America/Los_Angeles';
   verification_status?: DailyFritzVerificationStatus;
-  next_action?: DailyFritzClientNextAction;
+  next_action?: DailyFritzServerNextAction;
   current_hand_index: number;
   current_game_scores?: { you: number; fritz: number };
   current_game_number?: DailyFritzSetGameNumber | null;

--- a/client/src/dailyFritz/dailyFritzHubViewModel.test.ts
+++ b/client/src/dailyFritz/dailyFritzHubViewModel.test.ts
@@ -3,7 +3,10 @@ import { describe, expect, it } from 'vitest';
 import { buildDailyFritzHubGameCards, buildDailyFritzHubViewModel } from './dailyFritzHubViewModel';
 import type { DailyFritzSetResult, DailyFritzTodayResponse } from './api';
 
-function makeToday(attemptStatus: DailyFritzTodayResponse['attempt_status']): DailyFritzTodayResponse {
+function makeToday(
+  attemptStatus: DailyFritzTodayResponse['attempt_status'],
+  nextAction: DailyFritzTodayResponse['next_action'] = 'play_hand',
+): DailyFritzTodayResponse {
   return {
     ok: true,
     run_date: '2026-07-05',
@@ -11,6 +14,7 @@ function makeToday(attemptStatus: DailyFritzTodayResponse['attempt_status']): Da
     deal_size: 7,
     winning_score: 60,
     attempt_status: attemptStatus,
+    next_action: nextAction,
     current_game_number: null,
     streak: attemptStatus === 'none' ? 3 : 1,
     result: null,
@@ -71,23 +75,34 @@ describe('buildDailyFritzHubGameCards', () => {
 });
 
 describe('buildDailyFritzHubViewModel', () => {
-  it('returns play CTA when attempt not started', () => {
-    const vm = buildDailyFritzHubViewModel(makeToday('none'), null, 0, false, true);
+  it('maps play_hand to play CTA for a fresh start', () => {
+    const vm = buildDailyFritzHubViewModel(makeToday('none', 'play_hand'), null, 0, false, true);
     expect(vm.primaryCtaLabel).toBe("Play Today's Set");
     expect(vm.isComplete).toBe(false);
     expect(vm.isStarted).toBe(false);
   });
 
-  it('returns resume CTA when attempt started', () => {
-    const vm = buildDailyFritzHubViewModel(makeToday('started'), emptySetResult, 0, false, true);
+  it('maps between_games to resume CTA', () => {
+    const vm = buildDailyFritzHubViewModel(makeToday('started', 'between_games'), emptySetResult, 0, false, true);
     expect(vm.primaryCtaLabel).toBe("Resume Today's Set");
     expect(vm.isStarted).toBe(true);
   });
 
-  it('renders the authoritative completed hub after a lost /complete response', () => {
-    const vm = buildDailyFritzHubViewModel(makeToday('completed'), emptySetResult, 0, false, true);
+  it('maps finalize_set to resume CTA', () => {
+    const vm = buildDailyFritzHubViewModel(makeToday('started', 'finalize_set'), emptySetResult, 0, false, true);
+    expect(vm.primaryCtaLabel).toBe("Resume Today's Set");
+  });
+
+  it('maps view_results to completed render', () => {
+    const vm = buildDailyFritzHubViewModel(makeToday('completed', 'view_results'), emptySetResult, 0, false, true);
     expect(vm.primaryCtaLabel).toBe("View Today's Result");
     expect(vm.setStatusLabel).toBe('Complete');
     expect(vm.isComplete).toBe(true);
+  });
+
+  it('maps locked to locked render', () => {
+    const vm = buildDailyFritzHubViewModel(makeToday('abandoned', 'locked'), emptySetResult, 0, false, true);
+    expect(vm.primaryCtaLabel).toBe('Locked');
+    expect(vm.setStatusLabel).toBe('Locked');
   });
 });

--- a/client/src/dailyFritz/dailyFritzHubViewModel.ts
+++ b/client/src/dailyFritz/dailyFritzHubViewModel.ts
@@ -3,6 +3,7 @@ import { formatOrdinalPlace } from './format';
 import {
   formatCountdownHms,
   formatDateLabel,
+  resolveTodayNextAction,
   secondsUntilNextPacificMidnight,
   tierDisplayLabel,
   titleCaseTier,
@@ -129,14 +130,17 @@ export function buildDailyFritzHubViewModel(
   const streakLabel = today ? `${today.streak} day${today.streak === 1 ? '' : 's'}` : '0 days';
   const winTarget = today?.winning_score ?? 60;
 
-  const isComplete = today?.attempt_status === 'completed';
+  const nextAction = resolveTodayNextAction(today);
+  const isComplete = nextAction === 'view_results';
   const isStarted = today?.attempt_status === 'started';
 
-  const primaryCtaLabel = isComplete
+  const primaryCtaLabel = nextAction === 'view_results'
     ? "View Today's Result"
-    : isStarted
-      ? "Resume Today's Set"
-      : "Play Today's Set";
+    : nextAction === 'locked'
+      ? 'Locked'
+      : isStarted
+        ? "Resume Today's Set"
+        : "Play Today's Set";
 
   const games = buildDailyFritzHubGameCards(todaySetResult, {
     isComplete,
@@ -157,7 +161,11 @@ export function buildDailyFritzHubViewModel(
       : today?.competitive_verification_available === false
         ? 'Competitive verification temporarily unavailable'
         : 'Play today to appear on the leaderboard';
-  const setStatusLabel = isComplete ? 'Complete' : isStarted ? 'In Progress' : 'Ready';
+  const setStatusLabel = nextAction === 'locked'
+    ? 'Locked'
+    : isComplete
+      ? 'Complete'
+      : isStarted ? 'In Progress' : 'Ready';
   const setStakesLabel = isComplete
     ? 'Return tomorrow for a new set'
     : today?.competitive_verification_available === false

--- a/client/src/dailyFritz/dailyFritzObservability.ts
+++ b/client/src/dailyFritz/dailyFritzObservability.ts
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/react';
 export type DailyFritzOperationalAlert =
   | 'saving_timeout'
   | 'record_game_failed'
+  | 'complete_failed'
   | 'cursor_divergence'
   | 'recovery_started'
   | 'recovery_failed'
@@ -14,7 +15,9 @@ export function reportDailyFritzOperationalAlert(
   context: Record<string, unknown> = {},
 ): void {
   Sentry.captureMessage(message, {
-    level: alert === 'record_game_failed' || alert === 'recovery_failed' ? 'error' : 'warning',
+    level: alert === 'record_game_failed' || alert === 'complete_failed' || alert === 'recovery_failed'
+      ? 'error'
+      : 'warning',
     tags: {
       daily_fritz_alert: alert,
     },

--- a/client/src/dailyFritz/dailyFritzScreenHelpers.test.ts
+++ b/client/src/dailyFritz/dailyFritzScreenHelpers.test.ts
@@ -12,6 +12,7 @@ import {
   friendlyDailyFritzInitError,
   normalizeSetResult,
   getNextGameNumberFromSetResult,
+  resolveTodayNextAction,
 } from './dailyFritzScreenHelpers';
 
 describe('formatDateLabel', () => {
@@ -129,5 +130,42 @@ describe('normalizeSetResult', () => {
 describe('getNextGameNumberFromSetResult', () => {
   it('returns 1 when set result is null', () => {
     expect(getNextGameNumberFromSetResult(null)).toBe(1);
+  });
+});
+
+describe('resolveTodayNextAction', () => {
+  it('uses server next_action when present', () => {
+    expect(resolveTodayNextAction({
+      ok: true,
+      run_date: '2026-08-19',
+      fritz_tier: 'elite',
+      deal_size: 7,
+      winning_score: 60,
+      attempt_status: 'started',
+      next_action: 'between_games',
+      current_game_number: 2,
+      streak: 1,
+      result: null,
+      set_result: null,
+      rank: null,
+      leaderboard_preview: [],
+    })).toBe('between_games');
+  });
+
+  it('falls back gracefully when next_action is missing', () => {
+    expect(resolveTodayNextAction({
+      ok: true,
+      run_date: '2026-08-19',
+      fritz_tier: 'elite',
+      deal_size: 7,
+      winning_score: 60,
+      attempt_status: 'completed',
+      current_game_number: null,
+      streak: 1,
+      result: null,
+      set_result: null,
+      rank: null,
+      leaderboard_preview: [],
+    })).toBe('view_results');
   });
 });

--- a/client/src/dailyFritz/dailyFritzScreenHelpers.ts
+++ b/client/src/dailyFritz/dailyFritzScreenHelpers.ts
@@ -1,4 +1,6 @@
 import type {
+  DailyFritzClientNextAction,
+  DailyFritzServerNextAction,
   DailyFritzSetGameNumber,
   DailyFritzSetGameResult,
   DailyFritzSetResult,
@@ -38,6 +40,47 @@ export function shouldClearStaleClientState(
   if (cached.attempt_status === 'started' && server.attempt_status !== 'started') return true;
   if (cached.attempt_status === 'completed' && server.attempt_status === 'none') return true;
   return false;
+}
+
+function inferFallbackNextActionFromToday(today: DailyFritzTodayResponse | null): DailyFritzClientNextAction {
+  if (!today) return 'play_hand';
+  if (today.attempt_status === 'completed') return 'view_results';
+  if (today.attempt_status === 'abandoned') return 'locked';
+  if (today.attempt_status === 'started' && (today.needs_completion || today.set_result?.setWinner)) {
+    return 'finalize_set';
+  }
+  return 'play_hand';
+}
+
+function inferFallbackNextActionFromStart(started: DailyFritzStartResponse): DailyFritzClientNextAction {
+  if (started.needs_completion || started.set_result?.setWinner) return 'finalize_set';
+  return 'play_hand';
+}
+
+export function normalizeDailyFritzNextAction(
+  nextAction: DailyFritzServerNextAction | null | undefined,
+  fallback: DailyFritzClientNextAction,
+): DailyFritzClientNextAction {
+  if (nextAction === 'play_hand'
+    || nextAction === 'between_games'
+    || nextAction === 'finalize_set'
+    || nextAction === 'view_results'
+    || nextAction === 'locked') {
+    return nextAction;
+  }
+  // Backward-compatibility with older cached API payloads.
+  if (nextAction === 'start_set' || nextAction === 'resume_hand') {
+    return 'play_hand';
+  }
+  return fallback;
+}
+
+export function resolveTodayNextAction(today: DailyFritzTodayResponse | null): DailyFritzClientNextAction {
+  return normalizeDailyFritzNextAction(today?.next_action, inferFallbackNextActionFromToday(today));
+}
+
+export function resolveStartNextAction(started: DailyFritzStartResponse): DailyFritzClientNextAction {
+  return normalizeDailyFritzNextAction(started.next_action, inferFallbackNextActionFromStart(started));
 }
 
 export function friendlyDailyFritzInitError(error: unknown): string {

--- a/client/src/dailyFritz/useDailyFritzRunController.ts
+++ b/client/src/dailyFritz/useDailyFritzRunController.ts
@@ -428,13 +428,29 @@ export function useDailyFritzRunController({
               }
             : current,
         );
-        await submitSetCompletion({
-          run: recordedRun,
-          setResult,
-          completedGame,
-          currentHandIndex: game.currentHandIndex,
-          boardContext: true,
-        });
+        try {
+          await submitSetCompletion({
+            run: recordedRun,
+            setResult,
+            completedGame,
+            currentHandIndex: game.currentHandIndex,
+            boardContext: true,
+          });
+        } catch (completeErr) {
+          const completeMessage = completeErr instanceof Error
+            ? completeErr.message
+            : 'Failed to complete Daily Fritz attempt.';
+          reportDailyFritzOperationalAlert(
+            'complete_failed',
+            'Daily Fritz complete failed',
+            {
+              attemptId: run.attempt_id,
+              gameNumber,
+              error: completeMessage,
+            },
+          );
+          return;
+        }
         return;
       }
 

--- a/client/src/dailyFritz/useDailyFritzRunController.ts
+++ b/client/src/dailyFritz/useDailyFritzRunController.ts
@@ -20,6 +20,8 @@ import {
   getNextGameNumberFromSetResult,
   normalizeGameNumber,
   normalizeSetResult,
+  resolveStartNextAction,
+  resolveTodayNextAction,
   normalizeStartResponse,
   resolveDailyFritzCurrentGameNumber,
 } from './dailyFritzScreenHelpers';
@@ -244,7 +246,7 @@ export function useDailyFritzRunController({
     fallbackSetResult: DailyFritzSetResult | null,
   ) => {
     const normalized = normalizeStartResponse(started, fallbackSetResult);
-    if (normalized.needs_completion && normalized.set_result?.setWinner) {
+    if (resolveStartNextAction(normalized) === 'finalize_set' && normalized.set_result?.setWinner) {
       const completedGame =
         normalized.set_result.games[normalized.set_result.games.length - 1] ??
         buildCompletedGame(normalized, {
@@ -333,12 +335,8 @@ export function useDailyFritzRunController({
   }, [handleStartResponse, setOverlay, setHubError, today]);
 
   useEffect(() => {
-    if (
-      today?.attempt_status !== 'started'
-      || !today.needs_completion
-      || !normalizeSetResult(today.set_result ?? today.result)?.setWinner
-      || activeRun
-    ) return;
+    if (resolveTodayNextAction(today) !== 'finalize_set' || activeRun) return;
+    if (!normalizeSetResult(today?.set_result ?? today?.result)?.setWinner) return;
     void continueSet();
   }, [activeRun, continueSet, today]);
 

--- a/server/src/dbIdempotencySchema.test.ts
+++ b/server/src/dbIdempotencySchema.test.ts
@@ -245,6 +245,16 @@ describe('DB idempotency schema guardrails', () => {
     expect(sql).not.toContain("jsonb_array_length(p_new_result->'games') not in (2, 3)");
   });
 
+  it('allows legacy_unverified set finalize without verified_games receipts', () => {
+    const sql = compactSql(readRepoFile(
+      'supabase/migrations/2026-08-19_daily_fritz_finalize_legacy_unverified.sql',
+    ));
+    expect(sql).toContain("finalize_verification_status := coalesce(p_new_result->>'verification_status', '')");
+    expect(sql).toContain("finalize_verification_status = 'legacy_unverified'");
+    expect(sql).toContain('unranked advance-first path: setwinner + persisted games is enough');
+    expect(sql).toContain("finalize_verification_status = 'verified'");
+  });
+
   it('repairs Daily Fritz outbox idempotency to be player-attempt scoped', () => {
     const sql = compactSql(readRepoFile(
       'supabase/migrations/2026-08-02_daily_fritz_outbox_attempt_scope.sql',

--- a/server/src/http/routes/dailyFritzClientPhase.test.ts
+++ b/server/src/http/routes/dailyFritzClientPhase.test.ts
@@ -2,22 +2,22 @@ import { describe, expect, it } from 'vitest';
 import { resolveDailyFritzClientNextAction } from './dailyFritzClientPhase';
 
 describe('resolveDailyFritzClientNextAction', () => {
-  it('returns start_set for a fresh attempt', () => {
+  it('returns play_hand for a fresh attempt', () => {
     expect(resolveDailyFritzClientNextAction({
       attemptStatus: 'started',
       setResult: null,
       currentHandIndex: 0,
       hasResumeCheckpoint: false,
-    })).toBe('start_set');
+    })).toBe('play_hand');
   });
 
-  it('returns resume_hand when a checkpoint exists mid-hand', () => {
+  it('returns play_hand when a checkpoint exists mid-hand', () => {
     expect(resolveDailyFritzClientNextAction({
       attemptStatus: 'started',
       setResult: { version: 2, format: 'best_of_3', playerGamesWon: 0, fritzGamesWon: 0, totalPointDiff: 0, games: [] },
       currentHandIndex: 2,
       hasResumeCheckpoint: true,
-    })).toBe('resume_hand');
+    })).toBe('play_hand');
   });
 
   it('returns between_games after a game is recorded but the set continues', () => {
@@ -71,5 +71,14 @@ describe('resolveDailyFritzClientNextAction', () => {
       currentHandIndex: 0,
       hasResumeCheckpoint: false,
     })).toBe('view_results');
+  });
+
+  it('returns locked for abandoned attempts', () => {
+    expect(resolveDailyFritzClientNextAction({
+      attemptStatus: 'abandoned',
+      setResult: null,
+      currentHandIndex: 0,
+      hasResumeCheckpoint: false,
+    })).toBe('locked');
   });
 });

--- a/server/src/http/routes/dailyFritzClientPhase.ts
+++ b/server/src/http/routes/dailyFritzClientPhase.ts
@@ -1,8 +1,7 @@
 import type { DailyFritzSetResult } from '../../dailyFritz';
 
 export type DailyFritzClientNextAction =
-  | 'start_set'
-  | 'resume_hand'
+  | 'play_hand'
   | 'between_games'
   | 'finalize_set'
   | 'view_results'
@@ -15,11 +14,14 @@ export function resolveDailyFritzClientNextAction(input: {
   currentHandIndex: number;
   hasResumeCheckpoint: boolean;
 }): DailyFritzClientNextAction {
-  if (input.attemptStatus === 'completed' || input.attemptStatus === 'abandoned') {
+  if (input.attemptStatus === 'completed') {
     return 'view_results';
   }
+  if (input.attemptStatus === 'abandoned') {
+    return 'locked';
+  }
   if (input.attemptStatus !== 'started') {
-    return 'start_set';
+    return 'play_hand';
   }
   if (input.needsCompletion || input.setResult?.setWinner) {
     return 'finalize_set';
@@ -28,8 +30,5 @@ export function resolveDailyFritzClientNextAction(input: {
   if (gamesRecorded > 0 && input.currentHandIndex === 0) {
     return 'between_games';
   }
-  if (input.hasResumeCheckpoint || input.currentHandIndex > 0) {
-    return 'resume_hand';
-  }
-  return 'start_set';
+  return 'play_hand';
 }

--- a/server/src/http/routes/dailyFritzLegacyUnverifiedFinalize.test.ts
+++ b/server/src/http/routes/dailyFritzLegacyUnverifiedFinalize.test.ts
@@ -1,0 +1,274 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Application } from 'express';
+import { buildDailyFritzChallengeId } from '../../dailyFritzIdentity';
+import { getDailyFritzSeed } from '../../dailyFritz';
+import { isDailyFritzAttemptLeaderboardEligible } from '../stores/dailyFritzStore';
+import type { DailyFritzAttemptRecord, DailyFritzRunRecord } from '../stores/dailyFritzStore';
+
+const {
+  authUserMock,
+  getAttemptByIdMock,
+  getAttemptMock,
+  upsertAttemptMock,
+  getRunMock,
+  commitCommandMock,
+} = vi.hoisted(() => {
+  process.env.DAILY_FRITZ_TRANSACTIONAL_COMMANDS = 'true';
+  return {
+  authUserMock: vi.fn(),
+  getAttemptByIdMock: vi.fn(),
+  getAttemptMock: vi.fn(),
+  upsertAttemptMock: vi.fn(),
+  getRunMock: vi.fn(),
+  commitCommandMock: vi.fn(),
+  };
+});
+
+vi.mock('../../platform/auth/supabaseAuth', () => ({
+  getAuthenticatedUserId: authUserMock,
+}));
+
+vi.mock('../stores/dailyFritzStore', async () => {
+  const actual = await vi.importActual<typeof import('../stores/dailyFritzStore')>(
+    '../stores/dailyFritzStore',
+  );
+  return {
+    ...actual,
+    getDailyFritzAttemptById: getAttemptByIdMock,
+    getDailyFritzAttempt: getAttemptMock,
+    upsertDailyFritzAttempt: upsertAttemptMock,
+    getDailyFritzRun: getRunMock,
+    ensureDailyFritzRunForDate: getRunMock,
+    buildDailyFritzLeaderboard: vi.fn().mockResolvedValue([]),
+  };
+});
+
+vi.mock('../stores/dailyFritzEventStore', async () => {
+  const actual = await vi.importActual<typeof import('../stores/dailyFritzEventStore')>(
+    '../stores/dailyFritzEventStore',
+  );
+  return {
+    ...actual,
+    recordDailyFritzEvent: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+vi.mock('../stores/dailyFritzCommandStore', async () => {
+  const actual = await vi.importActual<typeof import('../stores/dailyFritzCommandStore')>(
+    '../stores/dailyFritzCommandStore',
+  );
+  return {
+    ...actual,
+    commitDailyFritzAttemptCommand: commitCommandMock,
+  };
+});
+
+vi.mock('../../shared/verifiedSinglePlayerMatch', () => ({
+  getVerifiedSinglePlayerMatch: vi.fn().mockResolvedValue(null),
+  persistVerifiedSinglePlayerMatch: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { registerDailyFritzRoutes } from './dailyFritz';
+import { resetDailyFritzMetricsForTests } from './dailyFritzMetrics';
+
+type Handler = (req: unknown, res: unknown) => unknown | Promise<unknown>;
+
+function makeHarness() {
+  const routes = new Map<string, Handler>();
+  const app = {
+    get(path: string, handler: Handler) { routes.set(`GET ${path}`, handler); },
+    post(path: string, handler: Handler) { routes.set(`POST ${path}`, handler); },
+  };
+  registerDailyFritzRoutes(app as unknown as Application);
+  return async function request(method: 'GET' | 'POST', path: string, input: { body?: Record<string, unknown> } = {}) {
+    const handler = routes.get(`${method} ${path}`);
+    if (!handler) throw new Error(`Missing route ${method} ${path}`);
+    let status = 200;
+    let body: unknown;
+    const res = {
+      status(code: number) { status = code; return res; },
+      json(value: unknown) { body = value; return res; },
+      setHeader() { return res; },
+      once() { return res; },
+    };
+    await handler({
+      headers: {},
+      params: {},
+      query: {},
+      body: input.body ?? {},
+      method,
+      path,
+      get() { return undefined; },
+    }, res);
+    return { status, body: body as Record<string, unknown> };
+  };
+}
+
+const RUN_DATE = '2026-08-19';
+const USER_ID = 'user-legacy-unverified';
+const ATTEMPT_ID = 'attempt-legacy-unverified';
+const VERIFIED_MATCH_ID = 'verified-match-legacy-unverified';
+const CHALLENGE_ID = buildDailyFritzChallengeId(RUN_DATE);
+
+function buildRun(): DailyFritzRunRecord {
+  return {
+    runDate: RUN_DATE,
+    seed: getDailyFritzSeed(RUN_DATE),
+    fritzTier: 'standard',
+    dealSize: 7,
+    winningScore: 60,
+    status: 'live',
+    handDeals: [],
+    generatedAt: '2026-08-19T00:00:00.000Z',
+    invalidatedAt: null,
+    metadata: null,
+  };
+}
+
+function buildRejectedInstantSkunkAttempt(): DailyFritzAttemptRecord {
+  const handDigest = 'a'.repeat(64);
+  return {
+    id: ATTEMPT_ID,
+    runDate: RUN_DATE,
+    userId: USER_ID,
+    status: 'started',
+    currentHandIndex: 6,
+    currentGameNumber: 1,
+    revision: 7,
+    challengeId: CHALLENGE_ID,
+    challengeContractVersion: 1,
+    generationVersion: 1,
+    gameRulesVersion: 1,
+    transcriptProtocolVersion: 2,
+    fritzPolicyVersion: 2,
+    rankingVersion: 1,
+    authoritySchemaVersion: 1,
+    startedAt: '2026-08-19T22:00:00.000Z',
+    completedAt: null,
+    verifiedMatchId: VERIFIED_MATCH_ID,
+    completionHash: null,
+    finalScore: null,
+    opponentScore: null,
+    pointDiff: null,
+    won: null,
+    movesUsed: null,
+    handsPlayed: null,
+    result: {
+      version: 2,
+      format: 'best_of_3',
+      playerGamesWon: 2,
+      fritzGamesWon: 0,
+      totalPointDiff: 34,
+      setWinner: 'player',
+      instantSkunk: true,
+      skunkGameNumber: 1,
+      verification_status: 'rejected',
+      verification_protocol_version: 2,
+      unverified_hands: [{
+        game_number: 1,
+        hand_index: 6,
+        verifier_code: 'fritz_state_mismatch',
+      }],
+      games: [{
+        gameNumber: 1,
+        seed: `daily-fritz-${RUN_DATE}:game:1`,
+        playerScore: 61,
+        fritzScore: 27,
+        playerWon: true,
+        pointDiff: 34,
+        movesUsed: 53,
+        handsPlayed: 7,
+        skunk: true,
+        skunkBy: 'player',
+        completedAt: '2026-08-19T22:10:24.923Z',
+      }],
+      authority: {
+        version: 1,
+        hands: [{
+          gameNumber: 1,
+          handIndex: 0,
+          transcriptDigest: handDigest,
+          actionCount: 10,
+          playerScoreAfter: 9,
+          fritzScoreAfter: 1,
+          winner: 'player',
+          verificationVersion: 2,
+        }],
+        games: [],
+      },
+    },
+  };
+}
+
+function wireStore(initialAttempt: DailyFritzAttemptRecord, run: DailyFritzRunRecord) {
+  let stored = initialAttempt;
+  getAttemptByIdMock.mockImplementation(async (id: string, userId: string) =>
+    (id === stored.id && userId === stored.userId ? { ...stored } : null));
+  getAttemptMock.mockImplementation(async (runDate: string, userId: string) =>
+    (runDate === stored.runDate && userId === stored.userId ? { ...stored } : null));
+  upsertAttemptMock.mockImplementation(async (record: DailyFritzAttemptRecord) => {
+    stored = { ...record };
+    return { ...stored };
+  });
+  getRunMock.mockImplementation(async (date: string) => (date === run.runDate ? run : null));
+  commitCommandMock.mockImplementation(async (input) => {
+    expect(input.commandType).toBe('finalize_verified_attempt');
+    expect(input.next.result?.verification_status).toBe('legacy_unverified');
+    stored = {
+      ...stored,
+      status: 'completed',
+      revision: stored.revision + 1,
+      completedAt: '2026-08-19T22:20:00.000Z',
+      finalScore: 2,
+      opponentScore: 0,
+      won: true,
+      result: input.next.result,
+    };
+    return {
+      outcome: 'committed',
+      errorCode: null,
+      replayed: false,
+      committedRevision: stored.revision,
+      response: { attempt_id: stored.id, revision: stored.revision, status: 'completed' },
+    };
+  });
+  return { current: () => stored };
+}
+
+describe('Daily Fritz legacy_unverified finalize after rejected terminal hand', () => {
+  beforeEach(() => {
+    authUserMock.mockResolvedValue(USER_ID);
+    resetDailyFritzMetricsForTests();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('completes unranked when setWinner is present, verification rejected, and no verified_games row exists', async () => {
+    const attempt = buildRejectedInstantSkunkAttempt();
+    const store = wireStore(attempt, buildRun());
+    const request = makeHarness();
+
+    const response = await request('POST', '/api/daily-fritz/complete', {
+      body: {
+        attempt_id: ATTEMPT_ID,
+        verified_match_id: VERIFIED_MATCH_ID,
+        run_date: RUN_DATE,
+        completion_hash: 'client-hash-not-used',
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body.ok).toBe(true);
+    expect(response.body.rank).toBeNull();
+    expect(commitCommandMock).toHaveBeenCalledTimes(1);
+    const finalizeInput = commitCommandMock.mock.calls[0]?.[0];
+    expect(finalizeInput?.next?.result?.verification_status).toBe('legacy_unverified');
+    expect(finalizeInput?.next?.status).toBe('completed');
+
+    const saved = store.current();
+    expect(saved.status).toBe('completed');
+    expect(isDailyFritzAttemptLeaderboardEligible(saved)).toBe(false);
+  });
+});

--- a/supabase/migrations/2026-08-19_daily_fritz_finalize_legacy_unverified.sql
+++ b/supabase/migrations/2026-08-19_daily_fritz_finalize_legacy_unverified.sql
@@ -1,0 +1,288 @@
+-- Fix: allow advance-first rejected/unverified sets to finalize as legacy_unverified.
+-- Regression: finalize_verified_attempt required verification_status = 'verified' and
+-- verified_games receipts, so record-game could succeed (setWinner present) while
+-- /complete raised daily_fritz_invalid_finalize_transition when the terminal hand
+-- was marked rejected under async verification.
+
+create or replace function public.commit_daily_fritz_attempt_command(
+  p_user_id uuid,
+  p_attempt_id uuid,
+  p_operation_id text,
+  p_command_type text,
+  p_request_digest text,
+  p_expected_revision bigint,
+  p_new_status text,
+  p_new_current_game_number int,
+  p_new_current_hand_index int,
+  p_new_result jsonb,
+  p_final_score int default null,
+  p_opponent_score int default null,
+  p_point_diff int default null,
+  p_won boolean default null,
+  p_moves_used int default null,
+  p_hands_played int default null,
+  p_completion_hash text default null,
+  p_hand_receipt jsonb default null,
+  p_game_receipt jsonb default null,
+  p_outbox_event_type text default null,
+  p_outbox_payload jsonb default '{}'::jsonb
+)
+returns table (
+  outcome text,
+  error_code text,
+  replayed boolean,
+  committed_revision bigint,
+  response jsonb
+)
+language plpgsql
+security definer
+set search_path = public
+as $$
+#variable_conflict use_column
+declare
+  attempt public.daily_fritz_attempts%rowtype;
+  existing_operation public.daily_fritz_attempt_operations%rowtype;
+  command_response jsonb;
+  receipt_game int;
+  receipt_hand int;
+  finalize_verification_status text;
+begin
+  if p_command_type not in (
+    'accept_verified_hand', 'record_verified_game',
+    'finalize_verified_attempt', 'abandon_attempt'
+  ) then
+    return query select 'rejected', 'unsupported_command', false, null::bigint, null::jsonb;
+    return;
+  end if;
+
+  select * into attempt
+    from public.daily_fritz_attempts
+    where id = p_attempt_id and user_id = p_user_id
+    for update;
+  if not found then
+    return query select 'rejected', 'attempt_not_found', false, null::bigint, null::jsonb;
+    return;
+  end if;
+  select * into existing_operation
+    from public.daily_fritz_attempt_operations
+    where attempt_id = p_attempt_id and operation_id = p_operation_id;
+  if found then
+    if existing_operation.command_type <> p_command_type
+      or existing_operation.request_digest <> p_request_digest then
+      return query select 'conflict', 'command_slot_conflict', false,
+        existing_operation.committed_revision, existing_operation.response;
+      return;
+    end if;
+    return query select existing_operation.status, existing_operation.error_code, true,
+      existing_operation.committed_revision, existing_operation.response;
+    return;
+  end if;
+  if attempt.challenge_id is null then
+    return query select 'rejected', 'legacy_attempt_read_only', false,
+      attempt.revision, jsonb_build_object('attempt_id', attempt.id, 'revision', attempt.revision);
+    return;
+  end if;
+  if attempt.revision <> p_expected_revision then
+    command_response := jsonb_build_object(
+      'attempt_id', attempt.id, 'status', attempt.status, 'revision', attempt.revision,
+      'current_game_number', attempt.current_game_number,
+      'current_hand_index', attempt.current_hand_index, 'result', attempt.result
+    );
+    insert into public.daily_fritz_attempt_operations (
+      operation_id, attempt_id, user_id, challenge_id, command_type,
+      request_digest, expected_revision, status, response, error_code
+    ) values (
+      p_operation_id, attempt.id, p_user_id, attempt.challenge_id, p_command_type,
+      p_request_digest, p_expected_revision, 'rejected', command_response, 'stale_revision'
+    );
+    return query select 'rejected', 'stale_revision', false, attempt.revision, command_response;
+    return;
+  end if;
+  if attempt.status <> 'started' then
+    return query select 'rejected', 'attempt_not_active', false, attempt.revision,
+      jsonb_build_object('attempt_id', attempt.id, 'status', attempt.status, 'revision', attempt.revision);
+    return;
+  end if;
+
+  if p_command_type = 'accept_verified_hand' then
+    if p_hand_receipt is null then raise exception 'daily_fritz_hand_receipt_required'; end if;
+    receipt_game := (p_hand_receipt->>'gameNumber')::int;
+    receipt_hand := (p_hand_receipt->>'handIndex')::int;
+    if receipt_game <> attempt.current_game_number
+      or receipt_hand <> attempt.current_hand_index
+      or p_new_status <> 'started'
+      or p_new_current_game_number <> attempt.current_game_number
+      or p_new_current_hand_index <> attempt.current_hand_index + 1 then
+      raise exception 'daily_fritz_invalid_hand_transition';
+    end if;
+    insert into public.daily_fritz_verified_hands (
+      attempt_id, game_number, hand_index, operation_id, transcript_digest,
+      action_count, player_score_after, fritz_score_after, winner,
+      verifier_version, receipt
+    ) values (
+      attempt.id, receipt_game, receipt_hand, p_operation_id,
+      p_hand_receipt->>'transcriptDigest', (p_hand_receipt->>'actionCount')::int,
+      (p_hand_receipt->>'playerScoreAfter')::int, (p_hand_receipt->>'fritzScoreAfter')::int,
+      p_hand_receipt->>'winner', (p_hand_receipt->>'verificationVersion')::int,
+      p_hand_receipt
+    );
+  elsif p_command_type = 'record_verified_game' then
+    if p_game_receipt is null then raise exception 'daily_fritz_game_receipt_required'; end if;
+    if p_hand_receipt is null then raise exception 'daily_fritz_terminal_hand_receipt_required'; end if;
+    receipt_game := (p_game_receipt->>'gameNumber')::int;
+    receipt_hand := (p_hand_receipt->>'handIndex')::int;
+    if receipt_game <> attempt.current_game_number
+      or (p_hand_receipt->>'gameNumber')::int <> receipt_game
+      or receipt_hand <> attempt.current_hand_index
+      or p_new_status <> 'started'
+      or jsonb_typeof(p_new_result->'games') <> 'array'
+      or jsonb_array_length(p_new_result->'games') <> receipt_game
+      or (
+        p_new_result ? 'setWinner'
+        and (
+          p_new_current_game_number <> attempt.current_game_number
+          or p_new_current_hand_index <> attempt.current_hand_index
+        )
+      )
+      or (
+        not (p_new_result ? 'setWinner')
+        and (
+          attempt.current_game_number = 3
+          or p_new_current_game_number <> attempt.current_game_number + 1
+          or p_new_current_hand_index <> 0
+        )
+      ) then
+      raise exception 'daily_fritz_invalid_game_transition';
+    end if;
+    insert into public.daily_fritz_verified_hands (
+      attempt_id, game_number, hand_index, operation_id, transcript_digest,
+      action_count, player_score_after, fritz_score_after, winner,
+      verifier_version, receipt
+    ) values (
+      attempt.id, receipt_game, receipt_hand, p_operation_id,
+      p_hand_receipt->>'transcriptDigest', (p_hand_receipt->>'actionCount')::int,
+      (p_hand_receipt->>'playerScoreAfter')::int, (p_hand_receipt->>'fritzScoreAfter')::int,
+      p_hand_receipt->>'winner', (p_hand_receipt->>'verificationVersion')::int,
+      p_hand_receipt
+    );
+    insert into public.daily_fritz_verified_games (
+      attempt_id, game_number, operation_id, player_score, fritz_score,
+      point_diff, player_won, action_count, hands_played, result_digest, receipt
+    ) values (
+      attempt.id, receipt_game, p_operation_id,
+      (p_game_receipt->>'playerScore')::int, (p_game_receipt->>'fritzScore')::int,
+      (p_game_receipt->>'pointDiff')::int, (p_game_receipt->>'playerWon')::boolean,
+      (p_game_receipt->>'actionCount')::int, (p_game_receipt->>'handsPlayed')::int,
+      p_game_receipt->>'resultDigest', p_game_receipt
+    );
+  elsif p_command_type = 'finalize_verified_attempt' then
+    finalize_verification_status := coalesce(p_new_result->>'verification_status', '');
+    if p_new_status <> 'completed'
+      or not (p_new_result ? 'setWinner')
+      or jsonb_typeof(p_new_result->'games') <> 'array'
+      or jsonb_array_length(p_new_result->'games') < 1 then
+      raise exception 'daily_fritz_invalid_finalize_transition';
+    end if;
+    if finalize_verification_status = 'verified' then
+      -- Ranked path: unchanged verified-game receipt requirements.
+      if not (
+        (
+          jsonb_array_length(p_new_result->'games') in (2, 3)
+          and (select count(*) from public.daily_fritz_verified_games where attempt_id = attempt.id) >= 2
+        )
+        or (
+          coalesce((p_new_result->>'instantSkunk')::boolean, false)
+          and coalesce((p_new_result->>'skunkGameNumber')::int, 0) = 1
+          and jsonb_array_length(p_new_result->'games') = 1
+          and (select count(*) from public.daily_fritz_verified_games where attempt_id = attempt.id) >= 1
+        )
+      ) then
+        raise exception 'daily_fritz_invalid_finalize_transition';
+      end if;
+    elsif finalize_verification_status = 'legacy_unverified' then
+      -- Unranked advance-first path: setWinner + persisted games is enough.
+      null;
+    else
+      raise exception 'daily_fritz_invalid_finalize_transition';
+    end if;
+  elsif p_command_type = 'abandon_attempt' and p_new_status <> 'abandoned' then
+    raise exception 'daily_fritz_invalid_abandon_transition';
+  end if;
+
+  update public.daily_fritz_attempts set
+    status = p_new_status,
+    current_game_number = p_new_current_game_number,
+    current_hand_index = p_new_current_hand_index,
+    result = p_new_result,
+    final_score = p_final_score,
+    opponent_score = p_opponent_score,
+    point_diff = p_point_diff,
+    won = p_won,
+    moves_used = p_moves_used,
+    hands_played = p_hands_played,
+    completion_hash = p_completion_hash,
+    completed_at = case when p_new_status in ('completed', 'abandoned') then now() else completed_at end,
+    revision = revision + 1
+  where id = attempt.id and revision = p_expected_revision
+  returning * into attempt;
+
+  if not found then raise exception 'daily_fritz_revision_changed_during_commit'; end if;
+
+  if p_command_type in ('finalize_verified_attempt', 'abandon_attempt')
+    and attempt.verified_match_id is not null then
+    update public.verified_single_player_matches set
+      status = attempt.status,
+      completed_at = attempt.completed_at,
+      completion_hash = attempt.completion_hash,
+      completion_result = attempt.result
+    where match_id = attempt.verified_match_id and user_id = p_user_id;
+    if not found then raise exception 'daily_fritz_verified_match_missing'; end if;
+  end if;
+
+  command_response := jsonb_build_object(
+    'attempt_id', attempt.id, 'verified_match_id', attempt.verified_match_id,
+    'challenge_id', attempt.challenge_id, 'run_date', attempt.run_date,
+    'status', attempt.status, 'revision', attempt.revision,
+    'current_game_number', attempt.current_game_number,
+    'current_hand_index', attempt.current_hand_index, 'result', attempt.result,
+    'final_score', attempt.final_score, 'opponent_score', attempt.opponent_score,
+    'point_diff', attempt.point_diff, 'won', attempt.won,
+    'moves_used', attempt.moves_used, 'hands_played', attempt.hands_played,
+    'completion_hash', attempt.completion_hash, 'completed_at', attempt.completed_at
+  );
+
+  insert into public.daily_fritz_attempt_operations (
+    operation_id, attempt_id, user_id, challenge_id, command_type,
+    request_digest, expected_revision, committed_revision, status,
+    response, committed_at
+  ) values (
+    p_operation_id, attempt.id, p_user_id, attempt.challenge_id, p_command_type,
+    p_request_digest, p_expected_revision, attempt.revision, 'committed',
+    command_response, now()
+  );
+
+  if p_outbox_event_type is not null then
+    insert into public.daily_fritz_outbox (
+      attempt_id, challenge_id, operation_id, event_type, payload
+    ) values (
+      attempt.id, attempt.challenge_id, p_operation_id, p_outbox_event_type,
+      p_outbox_payload || jsonb_build_object('revision', attempt.revision)
+    ) on conflict (attempt_id, operation_id, event_type) do nothing;
+  end if;
+
+  return query select 'committed', null::text, false, attempt.revision, command_response;
+end;
+$$;
+
+revoke all on function public.commit_daily_fritz_attempt_command(
+  uuid, uuid, text, text, text, bigint, text, int, int, jsonb,
+  int, int, int, boolean, int, int, text, jsonb, jsonb, text, jsonb
+) from public;
+revoke all on function public.commit_daily_fritz_attempt_command(
+  uuid, uuid, text, text, text, bigint, text, int, int, jsonb,
+  int, int, int, boolean, int, int, text, jsonb, jsonb, text, jsonb
+) from authenticated;
+grant execute on function public.commit_daily_fritz_attempt_command(
+  uuid, uuid, text, text, text, bigint, text, int, int, jsonb,
+  int, int, int, boolean, int, int, text, jsonb, jsonb, text, jsonb
+) to service_role;


### PR DESCRIPTION
## Summary

- **SQL (Option C):** `commit_daily_fritz_attempt_command` now accepts two finalize paths — `verified` (unchanged ranked requirements) and `legacy_unverified` (setWinner + persisted games, no `verified_games` row required). Unblocks advance-first sets where async verification rejected the terminal hand.
- **Client:** `/complete` failures inside `submitCompletedGame` no longer surface as `record_game_failed` / record-error overlay. They emit `complete_failed` to Sentry and keep the existing `final-error` overlay from `submitSetCompletion`.
- **Tests:** Route integration test for rejected instant-skunk finalize + schema guardrail for the new migration.

## Manual recovery (already applied)

Attempt `272dd33b-5ef0-4c30-8604-8c82be2ac5b4` was finalized as **Tier A** (`status=completed`, `verification_status=legacy_unverified`, completion_hash computed from DB authority hand digests). Hub should show today complete (unranked) on refresh.

## Deploy notes

**Apply migration before or with deploy:** `supabase/migrations/2026-08-19_daily_fritz_finalize_legacy_unverified.sql`

Without this migration, `/complete` will still 500 for the rejected-terminal-hand class even after client deploy.

## Follow-up (out of scope)

- Phase 2: UX copy for completed-unranked vs ranked wins
- Phase 3: Investigate `fritz_state_mismatch` on hand 6 (root verifier divergence)

## Test plan

- [x] `server`: full vitest suite — 174 passed (36 files)
- [x] `client`: full vitest suite — 1161 passed (160 files)
- [x] `server` + `client` production builds
- [x] `dailyFritzLegacyUnverifiedFinalize.test.ts`
- [ ] After merge: monitor `complete_failed` / `advance_unverified` events for 24h


Made with [Cursor](https://cursor.com)