### PR TITLE
fix(daily-fritz): ledger-based hand-start scores for verification

### DIFF
--- a/docs/daily-fritz-state-mismatch-investigation.md
+++ b/docs/daily-fritz-state-mismatch-investigation.md
@@ -1,0 +1,265 @@
+# Daily Fritz `fritz_state_mismatch` — Phase 3 Investigation
+
+**Date:** 2026-08-19  
+**Attempt:** `272dd33b-5ef0-4c30-8604-8c82be2ac5b4` (mom, user `889bf1a4-382b-4a18-9cc5-c8fdbe0038b4`)  
+**Run:** `2026-08-19` elite tier, game 1 hand 6 (terminal hand, instant skunk 61–27)  
+**Production error:** `Fritz state diverged before action 4 (client df-state-v1:c7116bcd, server df-state-v1:3a092a3b).`  
+**Status:** Investigation only — no code changes in this pass.
+
+---
+
+## Executive summary
+
+**Root cause:** The client transcript and Fritz state digests were **correct**. The server async verifier rebuilt hand 6 from the **wrong starting scores** (`0–0` instead of `50–23`) because `buildRecordedDailyFritzAttemptResult()` **drops `active_game`** when merging the set-result blob, and `attemptVerifyHand()` reads mid-game progress exclusively from `active_game`.
+
+This is **not** a gameplay cheat, journal timing race, transcript mapping bug, or mandatory-draw reconstruction issue. It is a **deterministic server-side wiring bug** introduced by the advance-first `/record-game` path (PR #18): the HTTP handler saves progress, then immediately overwrites the persisted attempt result in a way that erases that progress before async verification runs.
+
+**Offline reproducibility:** **Yes.** Replaying the recovered transcript with initial scores `50–23` verifies cleanly; replaying with `0–0` reproduces the **exact** production digest pair (`c7116bcd` vs `3a092a3b`).
+
+---
+
+## 1. Evidence pulled
+
+### 1.1 Event chain (Supabase `daily_fritz_events`)
+
+Equivalent to `GET /api/daily-fritz/events/272dd33b-5ef0-4c30-8604-8c82be2ac5b4` (admin route requires `x-admin-secret`; events were pulled directly from Supabase with service role).
+
+| Time (UTC) | Event | Notes |
+|---|---|---|
+| 22:04:16 | `attempt_started` | revision 1 |
+| 22:04:32 | `first_move` | game 1 hand 0 |
+| 22:05:02 – 22:09:29 | `hand_verified` ×6 | hands 0–5, all clean |
+| 22:10:25 | `game_recorded` | hand 6, digest `572a0cd2…`, setWinner player, 61–27 |
+| 22:10:25 | `verification_failed` | **`fritz_state_mismatch`**, operation `record-game`, outcome `advance_unverified` |
+| 22:10:26 | `request_failed` | `/complete` → `daily_fritz_invalid_finalize_transition` (downstream) |
+
+Hands 0–5 verified synchronously via `/next-hand`. Hand 6 failed **async** verification scheduled by `/record-game`.
+
+### 1.2 Checkpoint / journal
+
+| Source | Result |
+|---|---|
+| `daily_fritz_events` `checkpoint_saved` | **None** for this attempt |
+| `attempt.result.active_checkpoint` | **Absent** |
+| Server-persisted `officialJournal` for hand 6 | **Not stored** (transcripts are not persisted; only digests in authority ledger) |
+| `daily_fritz_verified_hands` for hand 6 | **No row** (hand rejected) |
+
+The client-submitted transcript was **not** retained in the database. Recovery required offline digest search (see §2).
+
+### 1.3 Authority ledger at failure time
+
+Verified hands 0–5 receipts (from `attempt.result.authority.hands`):
+
+| Hand | Actions | Score after | Digest (prefix) |
+|---|---|---|---|
+| 0 | 10 | 9–1 | `d9a01357…` |
+| 1 | 18 | 17–6 | `8c8e204a…` |
+| 2 | 14 | 24–18 | `be68c544…` |
+| 3 | 19 | 31–20 | `867da51c…` |
+| 4 | 8 | 43–20 | `03c7d2f7…` |
+| 5 | 23 | **50–23** | `2d54a72a…` |
+
+Hand 6 start scores (authoritative): **player 50, fritz 23**.
+
+Terminal hand transcript digest (from `game_recorded` event):  
+`572a0cd200d642e78959f39011cc071582171b3662d4287ac6ce7993700aa6d0`
+
+---
+
+## 2. Offline replay
+
+### 2.1 Transcript recovery
+
+Because the transcript JSON was not persisted, it was **reconstructed offline** by:
+
+1. Loading the official hand-6 deal from `daily_fritz_runs` for `2026-08-19`.
+2. BFS over legal player moves + official Fritz policy moves from initial state `(50, 23)`.
+3. Keeping paths that terminate at `(61, 27)` domino.
+4. Matching `digestDailyFritzTranscript()` to `572a0cd2…`.
+
+Recovered transcript: **20 actions**, `clientRelease: "unknown"`, protocol v2, fritz policy v2.  
+(Action 4 is Fritz play `3–6` on `left` with `preStateDigest: df-state-v1:c7116bcd`.)
+
+### 2.2 Verifier replay results
+
+| Initial scores | `requireStateDigests: true` | Action-4 server digest |
+|---|---|---|
+| **50–23 (correct)** | **PASS** | `c7116bcd` (matches client) |
+| **0–0 (bug path)** | **FAIL `fritz_state_mismatch`** | **`3a092a3b` (matches production)** |
+| 61–27 (post-overwrite scores) | FAIL | `205673f9` (different message) |
+
+**Conclusion:** Production failed on the **`0–0` initial-state path**, not on the final `61–27` scores written to `active_game` immediately before save.
+
+### 2.3 Earliest divergence (step-by-step)
+
+Player actions do not carry digest checks; Fritz `play` actions do. State diverges from **hand start**:
+
+| Step | Correct (50–23) digest | Wrong (0–0) digest |
+|---|---|---|
+| Initial | `9a998d19` | `a6fde2ef` |
+| After action 0 (player draw) | `d384a456` | `d9bfa350` |
+| After action 1 (player draw) | `3254c9a5` | `f8806dc3` |
+| After action 2 (player play 6–6) | `5edd506f` | `e3e0cdad` |
+| After action 3 (player play 0–6) | **`c7116bcd`** | **`3a092a3b`** |
+| Action 4 check (Fritz play) | would pass | **FAIL detected here** |
+
+**Earliest divergence:** initial state construction (before action 0).  
+**Earliest detection:** Fritz action 4 (first Fritz `play` with a `preStateDigest` check after the divergent player sequence).
+
+---
+
+## 3. Candidate cause classification
+
+| Candidate | Verdict | Evidence |
+|---|---|---|
+| **(a) Journal capture timing race** | **Ruled out** | Recovered transcript verifies offline with honest digests. Client journal matches engine replay when initial state is correct. |
+| **(b) Transcript build / mapping error** | **Ruled out** | `toDailyFritzTranscriptActions(journal)` path is consistent; digest match confirms canonical transcript shape. |
+| **(c) Mandatory-draw reconstruction drift** | **Ruled out** | Before action 4 on the correct path, `canDraw(fritz) === false`. Mismatch is not from `applyOmittedMandatoryDraws`. |
+| **(d) Something else** | **Confirmed** | **`active_game` progress wiped before async verify** → verifier starts hand 6 at `0–0`. |
+
+### 3.1 Mechanism (code path)
+
+**`/record-game` advance-first handler** (`dailyFritzRecordGameRoute.ts`):
+
+1. Reads progress: `readActiveGameProgress()` → `{ you: 50, fritz: 23 }` (correct).
+2. Writes final scores: `writeActiveGameProgress({ you: 61, fritz: 27 })`.
+3. Calls `buildRecordedDailyFritzAttemptResult({ previousResult, setResult, verificationPending: true })`.
+4. Persists attempt, then schedules `runDailyFritzRecordGameVerification()`.
+
+**Bug:** `buildRecordedDailyFritzAttemptResult` returns:
+
+```ts
+return {
+  ...input.setResult,   // set-result blob (games, setWinner, …)
+  authority,
+  verification_status: 'pending_verification',
+  // active_game NOT included → dropped
+};
+```
+
+`setResult` does not contain `active_game`. Spreading it **replaces** the result object shape and **drops** `active_game`.
+
+**Async verifier** (`dailyFritzRecordGameAsyncVerification.ts` → `attemptVerifyHand` → `verifyAttemptHand`):
+
+```ts
+const progress = readActiveGameProgress(input.attempt.result, gameNumber);
+// → { you: 0, fritz: 0 } when active_game missing
+
+createOfficialDailyFritzHandState({
+  …,
+  playerScore: progress.you,   // 0
+  fritzScore: progress.fritz,  // 0
+});
+```
+
+**Reproduced locally:**
+
+```text
+before merge active_game { game_number: 1, you: 50, fritz: 23 }
+after merge active_game undefined
+readActiveGameProgress after merge { gameNumber: 1, you: 0, fritz: 0 }
+```
+
+---
+
+## 4. Scope assessment
+
+### 4.1 Is this specific to instant skunk / hand 6?
+
+**No.** Any terminal hand verified via **async `/record-game`** after PR #18 is affected if mid-game progress lived only in `active_game`. Instant skunk is incidental — it forces a clinching `/record-game` on the terminal hand.
+
+Hands 0–5 used **`/next-hand`**, which updates `active_game` **after** verification and does **not** call `buildRecordedDailyFritzAttemptResult`, so they verified correctly.
+
+### 4.2 Systemic vs rare edge case
+
+| Dimension | Assessment |
+|---|---|
+| Bug class | **Systemic** on advance-first `/record-game` async verification |
+| Gameplay legitimacy | Mom's hand was **legitimate**; transcript is valid |
+| Client anti-cheat evidence | **Not broken** for this incident |
+| Production frequency | **Low traffic** — only one `fritz_state_mismatch` on `record-game` ever (this attempt) |
+| `/next-hand` mismatches | Separate historical cluster (Aug 1, attempt `542c08d6…`, action **0**, 5 retries) — likely resume/checkpoint class, **not** this bug |
+
+### 4.3 Historical `fritz_state_mismatch` (all time)
+
+**6 total** in `daily_fritz_events`:
+
+- **5×** `542c08d6…` / `next-hand` / action 0 (2026-08-01)
+- **1×** mom's attempt / `record-game` / action 4 (2026-08-19)
+
+**262** total `verification_failed` with `operation: record-game` (mostly other codes: `wrong_actor`, `illegal_action`, etc.) — the wiped-progress bug would only surface as state/policy mismatch codes when the transcript is otherwise valid; mom's case is the only `fritz_state_mismatch` on that path.
+
+Under **pre–PR #18 blocking behavior**, a rejected terminal hand would have blocked `/record-game` entirely; the mismatch would not have triggered the `/complete` finalize trap. PR #18 **surfaced** the async-verify bug by advancing first.
+
+---
+
+## 5. Recommended fix approach (NOT implemented)
+
+**Do not patch verifier digest logic or loosen `fritz_state_mismatch`.** The verifier correctly detected inconsistent initial state.
+
+### Option A (minimal, recommended): Preserve progress through record-game merge
+
+In `buildRecordedDailyFritzAttemptResult`, carry forward `active_game` from `previousResult` (and any other non–set-result fields that async verification depends on).
+
+Add an integration test:
+
+1. Attempt with `active_game: { you: 50, fritz: 23 }` and authority hands 0–5.
+2. `/record-game` with valid terminal transcript + `verificationPending`.
+3. Assert persisted attempt still has usable hand-start progress **or** async verifier receives explicit start scores.
+4. Assert async path verifies (or mock `runDailyFritzRecordGameVerification` inputs).
+
+### Option B (more robust): Stop relying on `active_game` for verification
+
+In `runDailyFritzRecordGameVerification`, derive hand-start scores from:
+
+- Last verified hand in authority ledger: `hands[handIndex - 1].playerScoreAfter / fritzScoreAfter`, or
+- Explicit `handStartScores` captured in `asyncVerificationInput` **before** `writeActiveGameProgress` overwrites to terminal totals.
+
+This decouples verification from UI progress bookkeeping.
+
+### Option C (defensive): Fail closed instead of mis-verifying
+
+If `readActiveGameProgress` returns `0–0` but authority ledger shows prior hands with non-zero scores, **do not run digest verification** — log `missing_hand_start_progress` and treat as infrastructure error. Prevents false `fritz_state_mismatch` accusations against honest clients.
+
+### Priority
+
+1. Option A + test (smallest fix for the proven bug).  
+2. Option B (harder to regress).  
+3. Option C as belt-and-suspenders.
+
+---
+
+## 6. What this incident was NOT
+
+- Not evidence of client-side cheating or Fritz policy divergence on mom's device.
+- Not caused by instant-skunk scoring rules.
+- Not fixed by PR #20 (`legacy_unverified` finalize) — that addresses the **downstream `/complete` trap**, not verification rejection.
+- Not reproducible by replaying the journal with correct hand-start scores — verification **passes**.
+
+---
+
+## 7. Artifacts & commands used
+
+- Supabase prod read: `daily_fritz_events`, `daily_fritz_attempts`, `daily_fritz_runs`
+- Offline scripts: BFS transcript recovery + verifier replay (`npx tsx` one-offs in `server/`, not committed)
+- Key files reviewed:
+  - `server/src/http/routes/dailyFritzRecordGameRoute.ts`
+  - `server/src/http/routes/dailyFritzRecordGameAsyncVerification.ts`
+  - `server/src/http/routes/dailyFritzVerificationGlue.ts` (`readActiveGameProgress`, `attemptVerifyHand`)
+  - `server/src/http/routes/dailyFritzVerificationPolicy.ts` (`buildRecordedDailyFritzAttemptResult`)
+  - `server/src/dailyFritzVerifier.ts` (mismatch throw site)
+  - `client/src/modules/match/runtime/gameCoreAdapter.ts` (journal capture — exonerated)
+  - `packages/game-core/src/dailyFritzJournal.ts`
+
+---
+
+## 8. Sign-off checklist
+
+| Question | Answer |
+|---|---|
+| Root cause identified with evidence? | **Yes** — `active_game` dropped → verifier used `0–0` start |
+| Reproducible offline? | **Yes** — exact production digests on `0–0` path |
+| Client transcript valid? | **Yes** — verifies with `50–23` start |
+| Earliest divergence? | Initial state (detected at Fritz action 4) |
+| Scope | Systemic on async `/record-game`; low observed rate |
+| Fix implemented? | **No** (investigation-only per request) |

--- a/server/src/http/routes/dailyFritzHandStartScoresVerification.test.ts
+++ b/server/src/http/routes/dailyFritzHandStartScoresVerification.test.ts
@@ -7,8 +7,8 @@ import { verifyDailyFritzHand, createOfficialDailyFritzHandState } from '../../d
 import { buildHonestDailyFritzHandTranscript } from '../../testing/dailyFritzTranscriptDriver';
 import type { DailyFritzAttemptRecord, DailyFritzRunRecord } from '../stores/dailyFritzStore';
 import { buildRecordedDailyFritzAttemptResult } from './dailyFritzVerificationPolicy';
+import type { VerifiedDailyFritzHandRecord } from '../../dailyFritzVerifier';
 import {
-  assertHandStartScoresAvailableForVerification,
   attemptVerifyHand,
   readActiveGameProgress,
   recordDailyFritzAdvanceWithoutVerification,
@@ -67,6 +67,38 @@ function buildAttempt(result: Record<string, unknown>): DailyFritzAttemptRecord 
     startedAt: '2026-08-19T22:04:16.000Z',
     updatedAt: '2026-08-19T22:10:25.000Z',
   };
+}
+
+function stubVerifiedHand(handIndex: number, playerAfter: number, fritzAfter: number): VerifiedDailyFritzHandRecord {
+  return {
+    verificationVersion: 2,
+    transcriptDigest: `${handIndex}`.repeat(64).slice(0, 64),
+    challengeId: CHALLENGE_ID,
+    attemptId: ATTEMPT_ID,
+    userId: USER_ID,
+    gameNumber: 1,
+    handIndex,
+    winner: 'player',
+    reason: 'domino',
+    pointsAwarded: 5,
+    playerScoreBefore: Math.max(0, playerAfter - 5),
+    fritzScoreBefore: Math.max(0, fritzAfter - 1),
+    playerScoreAfter: playerAfter,
+    fritzScoreAfter: fritzAfter,
+    actionCount: 10,
+    fritzPolicyVersion: 2,
+    fritzPolicyContract: 'fritz-policy-v2-deterministic-canonical-ties',
+    lastAuthorityStateDigest: null,
+    verifiedAt: '2026-08-01T00:00:00.000Z',
+  };
+}
+
+function ledgerWithHands(hands: VerifiedDailyFritzHandRecord[]): Record<string, unknown> {
+  let result: Record<string, unknown> = { authority: { version: 1, hands: [], games: [] } };
+  for (const hand of hands) {
+    result = writeVerifiedHand(result, hand);
+  }
+  return result;
 }
 
 describe('Daily Fritz hand-start scores for verification', () => {
@@ -208,7 +240,7 @@ describe('Daily Fritz hand-start scores for verification', () => {
     expect(verification.verified.result.playerScoreAfter).toBeGreaterThan(0);
   });
 
-  it('fails closed when hand-start would be 0-0 but prior verified hands exist', () => {
+  it('fails closed when the immediate prior hand receipt is missing from the ledger', () => {
     const runDate = '2026-08-01';
     const deal0 = generateSingleDailyFritzGameHand(runDate, 1, 0, 7);
     const drawWinner = getDailyFritzDrawWinner(runDate, 1);
@@ -246,19 +278,17 @@ describe('Daily Fritz hand-start scores for verification', () => {
     });
     const result = writeVerifiedHand(null, hand0Verified.result);
 
-    expect(() => assertHandStartScoresAvailableForVerification({
+    expect(() => resolveHandStartScoresForVerification({
       result,
       gameNumber: 1,
       handIndex: 2,
-      startScores: { gameNumber: 1, you: 0, fritz: 0 },
     })).toThrow(/hand-start scores/i);
 
     try {
-      assertHandStartScoresAvailableForVerification({
+      resolveHandStartScoresForVerification({
         result,
         gameNumber: 1,
         handIndex: 2,
-        startScores: { gameNumber: 1, you: 0, fritz: 0 },
       });
     } catch (error) {
       expect((error as { code: string }).code).toBe('missing_hand_start_progress');
@@ -273,6 +303,58 @@ describe('Daily Fritz hand-start scores for verification', () => {
         }),
       }),
     );
+  });
+
+  it('fails closed on a ledger gap instead of falling back to an earlier hand', () => {
+    // Ledger has hands 1, 2, skips 3, has 4 (1-based) → indices 0, 1, skip 2, has 3.
+    // Verifying hand 5 (index 4) must fail because hand 3 (index 2) is missing.
+    const result = ledgerWithHands([
+      stubVerifiedHand(0, 10, 5),
+      stubVerifiedHand(1, 20, 8),
+      stubVerifiedHand(3, 35, 12),
+    ]);
+
+    expect(() => resolveHandStartScoresForVerification({
+      result,
+      gameNumber: 1,
+      handIndex: 4,
+    })).toThrow(/hand-start scores/i);
+
+    const runDate = '2026-08-01';
+    const deal4 = generateSingleDailyFritzGameHand(runDate, 1, 4, 7);
+    const drawWinner = getDailyFritzDrawWinner(runDate, 1);
+    const hand4 = buildHonestDailyFritzHandTranscript({
+      challengeId: CHALLENGE_ID,
+      attemptId: ATTEMPT_ID,
+      gameNumber: 1,
+      handIndex: 4,
+      deal: deal4,
+      drawWinner,
+      winningScore: 60,
+      dealSize: 7,
+      playerScore: 35,
+      fritzScore: 12,
+      fritzTier: 'elite',
+      fritzPolicyVersion: FRITZ_POLICY_VERSION,
+    });
+    const run = {
+      ...buildRun(),
+      handDeals: [deal4],
+    };
+
+    const verification = attemptVerifyHand({
+      transcript: hand4.transcript,
+      attempt: buildAttempt(result),
+      run,
+      userId: USER_ID,
+      gameNumber: 1,
+      handIndex: 4,
+      publishedChallenge: null,
+    });
+
+    expect(verification.ok).toBe(false);
+    if (verification.ok) throw new Error('Expected gap ledger to fail closed.');
+    expect(verification.error.code).toBe('missing_hand_start_progress');
   });
 
   it('does not emit cheat-style bypass alerts for infrastructure verifier codes', async () => {

--- a/server/src/http/routes/dailyFritzHandStartScoresVerification.test.ts
+++ b/server/src/http/routes/dailyFritzHandStartScoresVerification.test.ts
@@ -1,0 +1,296 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import * as Sentry from '@sentry/node';
+import { FRITZ_POLICY_VERSION } from '@racehorse/game-core';
+import { generateSingleDailyFritzGameHand, getDailyFritzDrawWinner, getDailyFritzSeed } from '../../dailyFritz';
+import { buildDailyFritzChallengeId } from '../../dailyFritzIdentity';
+import { verifyDailyFritzHand, createOfficialDailyFritzHandState } from '../../dailyFritzVerifier';
+import { buildHonestDailyFritzHandTranscript } from '../../testing/dailyFritzTranscriptDriver';
+import type { DailyFritzAttemptRecord, DailyFritzRunRecord } from '../stores/dailyFritzStore';
+import { buildRecordedDailyFritzAttemptResult } from './dailyFritzVerificationPolicy';
+import {
+  assertHandStartScoresAvailableForVerification,
+  attemptVerifyHand,
+  readActiveGameProgress,
+  recordDailyFritzAdvanceWithoutVerification,
+  resolveHandStartScoresForVerification,
+  writeActiveGameProgress,
+  writeVerifiedHand,
+} from './dailyFritzVerificationGlue';
+
+vi.mock('@sentry/node', () => ({
+  captureMessage: vi.fn(),
+  captureException: vi.fn(),
+  startSpan: vi.fn((_opts: unknown, cb: () => unknown) => cb()),
+}));
+
+vi.mock('../stores/dailyFritzEventStore', () => ({
+  recordDailyFritzEvent: vi.fn().mockResolvedValue(undefined),
+}));
+
+const RUN_DATE = '2026-08-01';
+const CHALLENGE_ID = buildDailyFritzChallengeId(RUN_DATE);
+const USER_ID = 'user-hand-start-ledger';
+const ATTEMPT_ID = 'attempt-hand-start-ledger';
+
+function buildRun(): DailyFritzRunRecord {
+  return {
+    runDate: RUN_DATE,
+    seed: getDailyFritzSeed(RUN_DATE),
+    fritzTier: 'elite',
+    dealSize: 7,
+    winningScore: 60,
+    status: 'live',
+    handDeals: [],
+    metadata: { draw_winners_by_game: { 1: 'you' } },
+  };
+}
+
+function buildAttempt(result: Record<string, unknown>): DailyFritzAttemptRecord {
+  return {
+    id: ATTEMPT_ID,
+    userId: USER_ID,
+    runDate: RUN_DATE,
+    status: 'started',
+    revision: 7,
+    currentGameNumber: 1,
+    currentHandIndex: 6,
+    verifiedMatchId: 'verified-match-hand-start',
+    challengeId: CHALLENGE_ID,
+    challengeContractVersion: 1,
+    generationVersion: 1,
+    gameRulesVersion: 1,
+    transcriptProtocolVersion: 2,
+    fritzPolicyVersion: 2,
+    rankingVersion: 1,
+    authoritySchemaVersion: 1,
+    result,
+    startedAt: '2026-08-19T22:04:16.000Z',
+    updatedAt: '2026-08-19T22:10:25.000Z',
+  };
+}
+
+describe('Daily Fritz hand-start scores for verification', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('resolves hand-start scores from the authority ledger, not active_game', () => {
+    const runDate = '2026-08-01';
+    const deal0 = generateSingleDailyFritzGameHand(runDate, 1, 0, 7);
+    const drawWinner = getDailyFritzDrawWinner(runDate, 1);
+    const hand0 = buildHonestDailyFritzHandTranscript({
+      challengeId: buildDailyFritzChallengeId(runDate),
+      attemptId: ATTEMPT_ID,
+      gameNumber: 1,
+      handIndex: 0,
+      deal: deal0,
+      drawWinner,
+      winningScore: 60,
+      dealSize: 7,
+      playerScore: 0,
+      fritzScore: 0,
+      fritzTier: 'elite',
+      fritzPolicyVersion: FRITZ_POLICY_VERSION,
+    });
+    const hand0Initial = createOfficialDailyFritzHandState({
+      deal: deal0,
+      handIndex: 0,
+      drawWinner,
+      winningScore: 60,
+      dealSize: 7,
+      playerScore: 0,
+      fritzScore: 0,
+    });
+    const hand0Verified = verifyDailyFritzHand({
+      transcript: hand0.transcript,
+      initialState: hand0Initial,
+      expectedChallengeId: buildDailyFritzChallengeId(runDate),
+      expectedAttemptId: ATTEMPT_ID,
+      expectedGameNumber: 1,
+      expectedHandIndex: 0,
+      userId: USER_ID,
+      fritzTier: 'elite',
+    });
+
+    let result = writeVerifiedHand(null, hand0Verified.result);
+    result = writeActiveGameProgress(result, {
+      gameNumber: 1,
+      you: hand0Verified.result.playerScoreAfter,
+      fritz: hand0Verified.result.fritzScoreAfter,
+    });
+
+    const deal1 = generateSingleDailyFritzGameHand(runDate, 1, 1, 7);
+    const hand1 = buildHonestDailyFritzHandTranscript({
+      challengeId: buildDailyFritzChallengeId(runDate),
+      attemptId: ATTEMPT_ID,
+      gameNumber: 1,
+      handIndex: 1,
+      deal: deal1,
+      drawWinner,
+      winningScore: 60,
+      dealSize: 7,
+      playerScore: hand0Verified.result.playerScoreAfter,
+      fritzScore: hand0Verified.result.fritzScoreAfter,
+      fritzTier: 'elite',
+      fritzPolicyVersion: FRITZ_POLICY_VERSION,
+    });
+
+    const hand1Verified = verifyDailyFritzHand({
+      transcript: hand1.transcript,
+      initialState: createOfficialDailyFritzHandState({
+        deal: deal1,
+        handIndex: 1,
+        drawWinner,
+        winningScore: 60,
+        dealSize: 7,
+        playerScore: hand0Verified.result.playerScoreAfter,
+        fritzScore: hand0Verified.result.fritzScoreAfter,
+      }),
+      expectedChallengeId: buildDailyFritzChallengeId(runDate),
+      expectedAttemptId: ATTEMPT_ID,
+      expectedGameNumber: 1,
+      expectedHandIndex: 1,
+      userId: USER_ID,
+      fritzTier: 'elite',
+    });
+
+    // Reproduce the record-game merge that wiped active_game in production.
+    result = buildRecordedDailyFritzAttemptResult({
+      previousResult: result,
+      setResult: {
+        version: 2,
+        format: 'best_of_3',
+        playerGamesWon: 1,
+        fritzGamesWon: 0,
+        totalPointDiff: 10,
+        setWinner: 'player',
+        games: [{
+          gameNumber: 1,
+          playerScore: hand1Verified.result.playerScoreAfter,
+          fritzScore: hand1Verified.result.fritzScoreAfter,
+        }],
+      },
+      hasTranscript: true,
+      verificationPending: true,
+    });
+
+    expect(readActiveGameProgress(result, 1)).toEqual({ gameNumber: 1, you: 0, fritz: 0 });
+    expect(resolveHandStartScoresForVerification({
+      result,
+      gameNumber: 1,
+      handIndex: 1,
+    })).toEqual({
+      gameNumber: 1,
+      you: hand0Verified.result.playerScoreAfter,
+      fritz: hand0Verified.result.fritzScoreAfter,
+    });
+
+    const run = {
+      ...buildRun(),
+      runDate,
+      seed: getDailyFritzSeed(runDate),
+      handDeals: [deal0, deal1],
+    };
+    const verification = attemptVerifyHand({
+      transcript: hand1.transcript,
+      attempt: buildAttempt(result),
+      run,
+      userId: USER_ID,
+      gameNumber: 1,
+      handIndex: 1,
+      publishedChallenge: null,
+    });
+
+    expect(verification.ok).toBe(true);
+    if (!verification.ok) {
+      throw new Error(`${verification.error.code}: ${verification.error.message}`);
+    }
+    expect(verification.verified.result.playerScoreAfter).toBeGreaterThan(0);
+  });
+
+  it('fails closed when hand-start would be 0-0 but prior verified hands exist', () => {
+    const runDate = '2026-08-01';
+    const deal0 = generateSingleDailyFritzGameHand(runDate, 1, 0, 7);
+    const drawWinner = getDailyFritzDrawWinner(runDate, 1);
+    const hand0 = buildHonestDailyFritzHandTranscript({
+      challengeId: buildDailyFritzChallengeId(runDate),
+      attemptId: ATTEMPT_ID,
+      gameNumber: 1,
+      handIndex: 0,
+      deal: deal0,
+      drawWinner,
+      winningScore: 60,
+      dealSize: 7,
+      playerScore: 0,
+      fritzScore: 0,
+      fritzTier: 'elite',
+      fritzPolicyVersion: FRITZ_POLICY_VERSION,
+    });
+    const hand0Verified = verifyDailyFritzHand({
+      transcript: hand0.transcript,
+      initialState: createOfficialDailyFritzHandState({
+        deal: deal0,
+        handIndex: 0,
+        drawWinner,
+        winningScore: 60,
+        dealSize: 7,
+        playerScore: 0,
+        fritzScore: 0,
+      }),
+      expectedChallengeId: buildDailyFritzChallengeId(runDate),
+      expectedAttemptId: ATTEMPT_ID,
+      expectedGameNumber: 1,
+      expectedHandIndex: 0,
+      userId: USER_ID,
+      fritzTier: 'elite',
+    });
+    const result = writeVerifiedHand(null, hand0Verified.result);
+
+    expect(() => assertHandStartScoresAvailableForVerification({
+      result,
+      gameNumber: 1,
+      handIndex: 2,
+      startScores: { gameNumber: 1, you: 0, fritz: 0 },
+    })).toThrow(/hand-start scores/i);
+
+    try {
+      assertHandStartScoresAvailableForVerification({
+        result,
+        gameNumber: 1,
+        handIndex: 2,
+        startScores: { gameNumber: 1, you: 0, fritz: 0 },
+      });
+    } catch (error) {
+      expect((error as { code: string }).code).toBe('missing_hand_start_progress');
+    }
+
+    expect(Sentry.captureMessage).toHaveBeenCalledWith(
+      expect.stringContaining('infrastructure failure'),
+      expect.objectContaining({
+        tags: expect.objectContaining({
+          daily_fritz_alert: 'verification_infrastructure_error',
+          verifier_code: 'missing_hand_start_progress',
+        }),
+      }),
+    );
+  });
+
+  it('does not emit cheat-style bypass alerts for infrastructure verifier codes', async () => {
+    await recordDailyFritzAdvanceWithoutVerification({
+      attemptId: ATTEMPT_ID,
+      runDate: RUN_DATE,
+      userId: USER_ID,
+      requestId: 'req-infra',
+      gameNumber: 1,
+      handIndex: 6,
+      verifierCode: 'missing_hand_start_progress',
+      operation: 'record-game',
+      message: 'Daily Fritz hand verification is missing authoritative hand-start scores while prior verified hands exist.',
+    });
+
+    expect(Sentry.captureMessage).not.toHaveBeenCalledWith(
+      expect.stringContaining('verification bypassed'),
+      expect.anything(),
+    );
+  });
+});

--- a/server/src/http/routes/dailyFritzVerificationGlue.ts
+++ b/server/src/http/routes/dailyFritzVerificationGlue.ts
@@ -218,6 +218,84 @@ export function readActiveGameProgress(result: Record<string, unknown> | null, g
     : { gameNumber, you: 0, fritz: 0 };
 }
 
+/** Verifier codes that indicate server-side wiring/data loss — not client cheat rejection. */
+export const DAILY_FRITZ_INFRASTRUCTURE_VERIFIER_CODES = new Set([
+  'missing_hand_start_progress',
+]);
+
+/**
+ * Hand-start scores for transcript replay. The authority ledger is the durable
+ * source of truth; `active_game` is UI/progress bookkeeping and can be wiped
+ * (e.g. by `buildRecordedDailyFritzAttemptResult`).
+ */
+export function resolveHandStartScoresForVerification(input: {
+  result: Record<string, unknown> | null;
+  gameNumber: DailyFritzSetGameNumber;
+  handIndex: number;
+}): DailyFritzActiveGameProgress {
+  const { result, gameNumber, handIndex } = input;
+  if (handIndex <= 0) {
+    return { gameNumber, you: 0, fritz: 0 };
+  }
+
+  const immediatePrior = findVerifiedHand(result, gameNumber, handIndex - 1);
+  if (immediatePrior) {
+    return {
+      gameNumber,
+      you: immediatePrior.playerScoreAfter,
+      fritz: immediatePrior.fritzScoreAfter,
+    };
+  }
+
+  const ledger = readAuthorityLedger(result);
+  const latestPrior = ledger.hands
+    .filter((hand) => hand.gameNumber === gameNumber && hand.handIndex < handIndex)
+    .sort((left, right) => right.handIndex - left.handIndex)[0];
+  if (latestPrior) {
+    return {
+      gameNumber,
+      you: latestPrior.playerScoreAfter,
+      fritz: latestPrior.fritzScoreAfter,
+    };
+  }
+
+  return { gameNumber, you: 0, fritz: 0 };
+}
+
+export function assertHandStartScoresAvailableForVerification(input: {
+  result: Record<string, unknown> | null;
+  gameNumber: DailyFritzSetGameNumber;
+  handIndex: number;
+  startScores: DailyFritzActiveGameProgress;
+}): void {
+  if (input.handIndex <= 0) return;
+  if (input.startScores.you !== 0 || input.startScores.fritz !== 0) return;
+
+  const hasPriorVerifiedHands = readAuthorityLedger(input.result).hands.some(
+    (hand) => hand.gameNumber === input.gameNumber && hand.handIndex < input.handIndex,
+  );
+  if (!hasPriorVerifiedHands) return;
+
+  Sentry.captureMessage(
+    '[daily-fritz] verification infrastructure failure — hand-start progress unavailable',
+    {
+      level: 'error',
+      tags: {
+        daily_fritz_alert: 'verification_infrastructure_error',
+        verifier_code: 'missing_hand_start_progress',
+      },
+      extra: {
+        gameNumber: input.gameNumber,
+        handIndex: input.handIndex,
+      },
+    },
+  );
+  throw new DailyFritzVerificationError(
+    'Daily Fritz hand verification is missing authoritative hand-start scores while prior verified hands exist.',
+    'missing_hand_start_progress',
+  );
+}
+
 export function writeActiveGameProgress(result: Record<string, unknown> | null, progress: DailyFritzActiveGameProgress): Record<string, unknown> {
   return { ...(result ?? {}), active_game: { game_number: progress.gameNumber, you: progress.you, fritz: progress.fritz } };
 }
@@ -287,24 +365,28 @@ export async function recordDailyFritzAdvanceWithoutVerification(input: {
       message: input.message,
     },
   });
+  const infrastructureFailure = DAILY_FRITZ_INFRASTRUCTURE_VERIFIER_CODES.has(input.verifierCode);
   // Player was not stranded, but verification failed — alert ops so we can
-  // chase the bug without waiting for a player report.
-  Sentry.captureMessage('[daily-fritz] verification bypassed — run advanced unranked', {
-    level: 'warning',
-    tags: {
-      daily_fritz_alert: 'verification_bypassed',
-      verifier_code: input.verifierCode,
-      operation: input.operation,
-    },
-    extra: {
-      attemptId: input.attemptId,
-      runDate: input.runDate,
-      userId: input.userId,
-      gameNumber: input.gameNumber,
-      handIndex: input.handIndex,
-      message: input.message,
-    },
-  });
+  // chase the bug without waiting for a player report. Infrastructure failures
+  // use a distinct alert tag so they are never confused with cheat rejection.
+  if (!infrastructureFailure) {
+    Sentry.captureMessage('[daily-fritz] verification bypassed — run advanced unranked', {
+      level: 'warning',
+      tags: {
+        daily_fritz_alert: 'verification_bypassed',
+        verifier_code: input.verifierCode,
+        operation: input.operation,
+      },
+      extra: {
+        attemptId: input.attemptId,
+        runDate: input.runDate,
+        userId: input.userId,
+        gameNumber: input.gameNumber,
+        handIndex: input.handIndex,
+        message: input.message,
+      },
+    });
+  }
 }
 
 export function verifyAttemptHand(input: {
@@ -323,7 +405,17 @@ export function verifyAttemptHand(input: {
   if (buildDailyFritzChallengeId(input.run.runDate) !== buildDailyFritzChallengeId(input.attempt.runDate)) {
     throw new DailyFritzVerificationError('Daily Fritz challenge identity is invalid.', 'challenge_mismatch');
   }
-  const progress = readActiveGameProgress(input.attempt.result, input.gameNumber);
+  const startScores = resolveHandStartScoresForVerification({
+    result: input.attempt.result,
+    gameNumber: input.gameNumber,
+    handIndex: input.handIndex,
+  });
+  assertHandStartScoresAvailableForVerification({
+    result: input.attempt.result,
+    gameNumber: input.gameNumber,
+    handIndex: input.handIndex,
+    startScores,
+  });
   const authorityContract = readDailyFritzAuthorityContract(input.attempt.result);
   const publishedAuthority = input.publishedChallenge
     ? resolveDailyFritzPublishedGameAuthority({
@@ -353,8 +445,8 @@ export function verifyAttemptHand(input: {
       drawWinner,
       winningScore,
       dealSize,
-      playerScore: progress.you,
-      fritzScore: progress.fritz,
+      playerScore: startScores.you,
+      fritzScore: startScores.fritz,
     }),
     expectedChallengeId: challengeId,
     expectedAttemptId: input.attempt.id,

--- a/server/src/http/routes/dailyFritzVerificationGlue.ts
+++ b/server/src/http/routes/dailyFritzVerificationGlue.ts
@@ -227,6 +227,9 @@ export const DAILY_FRITZ_INFRASTRUCTURE_VERIFIER_CODES = new Set([
  * Hand-start scores for transcript replay. The authority ledger is the durable
  * source of truth; `active_game` is UI/progress bookkeeping and can be wiped
  * (e.g. by `buildRecordedDailyFritzAttemptResult`).
+ *
+ * Requires a contiguous verified chain for this game: hands 0..N-1 must all
+ * be present before hand N can replay. No fallback to an earlier hand.
  */
 export function resolveHandStartScoresForVerification(input: {
   result: Record<string, unknown> | null;
@@ -238,44 +241,29 @@ export function resolveHandStartScoresForVerification(input: {
     return { gameNumber, you: 0, fritz: 0 };
   }
 
-  const immediatePrior = findVerifiedHand(result, gameNumber, handIndex - 1);
-  if (immediatePrior) {
-    return {
-      gameNumber,
-      you: immediatePrior.playerScoreAfter,
-      fritz: immediatePrior.fritzScoreAfter,
-    };
+  for (let priorIndex = 0; priorIndex < handIndex; priorIndex += 1) {
+    if (!findVerifiedHand(result, gameNumber, priorIndex)) {
+      throwMissingHandStartProgress({
+        gameNumber,
+        handIndex,
+        missingPriorHandIndex: priorIndex,
+      });
+    }
   }
 
-  const ledger = readAuthorityLedger(result);
-  const latestPrior = ledger.hands
-    .filter((hand) => hand.gameNumber === gameNumber && hand.handIndex < handIndex)
-    .sort((left, right) => right.handIndex - left.handIndex)[0];
-  if (latestPrior) {
-    return {
-      gameNumber,
-      you: latestPrior.playerScoreAfter,
-      fritz: latestPrior.fritzScoreAfter,
-    };
-  }
-
-  return { gameNumber, you: 0, fritz: 0 };
+  const immediatePrior = findVerifiedHand(result, gameNumber, handIndex - 1)!;
+  return {
+    gameNumber,
+    you: immediatePrior.playerScoreAfter,
+    fritz: immediatePrior.fritzScoreAfter,
+  };
 }
 
-export function assertHandStartScoresAvailableForVerification(input: {
-  result: Record<string, unknown> | null;
+function throwMissingHandStartProgress(input: {
   gameNumber: DailyFritzSetGameNumber;
   handIndex: number;
-  startScores: DailyFritzActiveGameProgress;
-}): void {
-  if (input.handIndex <= 0) return;
-  if (input.startScores.you !== 0 || input.startScores.fritz !== 0) return;
-
-  const hasPriorVerifiedHands = readAuthorityLedger(input.result).hands.some(
-    (hand) => hand.gameNumber === input.gameNumber && hand.handIndex < input.handIndex,
-  );
-  if (!hasPriorVerifiedHands) return;
-
+  missingPriorHandIndex: number;
+}): never {
   Sentry.captureMessage(
     '[daily-fritz] verification infrastructure failure — hand-start progress unavailable',
     {
@@ -287,6 +275,7 @@ export function assertHandStartScoresAvailableForVerification(input: {
       extra: {
         gameNumber: input.gameNumber,
         handIndex: input.handIndex,
+        missingPriorHandIndex: input.missingPriorHandIndex,
       },
     },
   );
@@ -409,12 +398,6 @@ export function verifyAttemptHand(input: {
     result: input.attempt.result,
     gameNumber: input.gameNumber,
     handIndex: input.handIndex,
-  });
-  assertHandStartScoresAvailableForVerification({
-    result: input.attempt.result,
-    gameNumber: input.gameNumber,
-    handIndex: input.handIndex,
-    startScores,
   });
   const authorityContract = readDailyFritzAuthorityContract(input.attempt.result);
   const publishedAuthority = input.publishedChallenge


### PR DESCRIPTION
## Summary

- **Root cause fix (Option 2):** `verifyAttemptHand()` now derives hand-start scores from the **authority ledger** (prior verified hand’s `playerScoreAfter` / `fritzScoreAfter`), not `active_game`. This fixes the Aug 19 production `fritz_state_mismatch` where `buildRecordedDailyFritzAttemptResult()` wiped `active_game` before async `/record-game` verification ran.
- **Safety net (Option 3):** If hand-start resolves to `0–0` while the ledger contains prior verified hands for the same game, verification fails closed with `missing_hand_start_progress` and Sentry tag `verification_infrastructure_error` (not `verification_bypassed` / cheat-style alerts).
- **Investigation doc:** `docs/daily-fritz-state-mismatch-investigation.md` (Phase 3 write-up).
- **Regression tests:** record-game merge scenario (active_game wiped, verify still passes) + infrastructure safety-net Sentry behavior.

## Call-site audit: `readActiveGameProgress()`

| Location | Purpose | Vulnerable to wiped `active_game`? |
|---|---|---|
| `verifyAttemptHand()` | **Hand transcript replay initial scores** | **Was yes — fixed in this PR** |
| `dailyFritzNextHandRoute` `respondWithCurrentHand` | Return current scores to client UI | No — display only, not verification |
| `dailyFritzNextHandRoute` post-verify | Persist scores after successful verify | No — writes progress, does not read for replay |
| `dailyFritzRecordGameRoute` | Resolve clinching scores before record | No — uses legacy body scores or pre-merge progress for HTTP gatekeeping, not transcript replay |
| `dailyFritzStartRoute` | Draw package / hub display | No — UI only |

**Verification entry points:** both `/next-hand` and async `/record-game` call `attemptVerifyHand()` → `verifyAttemptHand()`. This PR fixes the single verification read path shared by both.

## Follow-up (out of scope)

- **Aug 1 `next-hand` action-0 cluster** (`542c08d6…`, 5× `fritz_state_mismatch` at action 0): separate investigation — not touched in this pass.

## Test plan

- [x] `server`: 174 tests passed (`npm test --prefix server`)
- [x] `client`: 1161 tests passed (`npm test --prefix client`)
- [x] `npm run build --prefix server` OK
- [x] `npm run build --prefix client` OK
- [x] New: `dailyFritzHandStartScoresVerification.test.ts` (ledger replay + safety net)


Made with [Cursor](https://cursor.com)