### PR TITLE
fix(nav): desktop nav click interception (grid layout)

### DIFF
--- a/client/e2e/helpers/navOverlap.ts
+++ b/client/e2e/helpers/navOverlap.ts
@@ -1,0 +1,58 @@
+import { expect, type Page } from '@playwright/test';
+
+type Rect = { left: number; right: number; top: number; bottom: number };
+
+function overlaps(a: Rect, b: Rect, tolerancePx = 2): boolean {
+  return (
+    a.left < b.right - tolerancePx
+    && b.left < a.right - tolerancePx
+    && a.top < b.bottom
+    && b.top < a.bottom
+  );
+}
+
+export async function assertDesktopNavRegionsDoNotOverlap(page: Page) {
+  const result = await page.evaluate(() => {
+    const read = (selector: string) => {
+      const node = document.querySelector(selector);
+      if (!node) return null;
+      const rect = node.getBoundingClientRect();
+      return {
+        left: rect.left,
+        right: rect.right,
+        top: rect.top,
+        bottom: rect.bottom,
+      };
+    };
+
+    const brand = read('.rh-nav-brand');
+    const center = read('.rh-nav-center-desktop');
+    const stats = read('.rh-nav-stats');
+    if (!brand || !center || !stats) {
+      return { ok: false, reason: 'missing nav region', brand, center, stats };
+    }
+
+    return {
+      ok: true,
+      brand,
+      center,
+      stats,
+    };
+  });
+
+  expect(result.ok, result.reason ?? 'nav regions should exist').toBe(true);
+  if (!result.ok || !result.brand || !result.center || !result.stats) return;
+
+  expect(
+    overlaps(result.brand, result.center),
+    `brand (${result.brand.right}px) must not overlap center tabs (${result.center.left}px)`,
+  ).toBe(false);
+  expect(
+    overlaps(result.center, result.stats),
+    `center tabs (${result.center.right}px) must not overlap stats (${result.stats.left}px)`,
+  ).toBe(false);
+  expect(
+    overlaps(result.brand, result.stats),
+    `brand (${result.brand.right}px) must not overlap stats (${result.stats.left}px)`,
+  ).toBe(false);
+}

--- a/client/e2e/routing.spec.ts
+++ b/client/e2e/routing.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { assertDesktopNavRegionsDoNotOverlap } from './helpers/navOverlap';
 
 test.describe('browser routing', () => {
   test.beforeEach(async ({ page }) => {
@@ -78,6 +79,23 @@ test.describe('browser routing', () => {
     await expect(page.getByRole('button', { name: 'Global', exact: true })).toBeVisible();
     await expect(page.getByRole('button', { name: 'By Mode', exact: true })).toBeVisible();
     await expect(page).toHaveURL(/\/social$/);
+  });
+
+  test('desktop nav regions keep separate hit targets at common widths', async ({ page }) => {
+    for (const width of [769, 1024, 1280, 1440]) {
+      await page.setViewportSize({ width, height: 720 });
+      await page.goto('/solo', { waitUntil: 'domcontentloaded' });
+      await expect(page.getByRole('heading', { name: 'Single Player' })).toBeVisible({ timeout: 15_000 });
+      await assertDesktopNavRegionsDoNotOverlap(page);
+
+      await page.getByRole('button', { name: 'Learn', exact: true }).click();
+      await expect(page).toHaveURL(/\/learn$/);
+      await expect(page.getByRole('heading', { name: 'Learn' })).toBeVisible({ timeout: 15_000 });
+      await assertDesktopNavRegionsDoNotOverlap(page);
+
+      await page.getByRole('button', { name: 'Racehorse home' }).click();
+      await expect(page).toHaveURL(/\/$/);
+    }
   });
 
   for (const path of [

--- a/client/src/components/GlobalNav.tsx
+++ b/client/src/components/GlobalNav.tsx
@@ -190,12 +190,12 @@ export function GlobalNav({
           background: 'linear-gradient(180deg, rgba(2, 4, 10, 0.22) 0%, rgba(2, 4, 10, 0.08) 48%, rgba(2, 4, 10, 0) 100%)',
         }}
       />
-      <div className={`rh-nav-inner relative flex h-full min-w-0 items-center justify-between gap-2 max-w-[1440px] mx-auto w-full px-3 ${compactChrome ? 'desk:px-7' : 'desk:px-9'}`}>
+      <div className={`rh-nav-inner relative flex h-full min-w-0 items-center justify-between gap-2 max-w-[1440px] mx-auto w-full px-3 desk:grid desk:grid-cols-[auto_minmax(0,1fr)_auto] desk:items-center ${compactChrome ? 'desk:px-7 desk:gap-4' : 'desk:px-9 desk:gap-6'}`}>
         {/* Left: Brand & Identity */}
         <button
           type="button"
           aria-label="Racehorse home"
-          className="rh-nav-brand flex min-w-0 shrink cursor-pointer items-center border-0 bg-transparent p-0 text-inherit"
+          className="rh-nav-brand flex min-w-0 shrink cursor-pointer items-center border-0 bg-transparent p-0 text-inherit desk:justify-self-start"
           onClick={() => onNavigate?.('home')}
         >
           <BrandLogo
@@ -221,7 +221,7 @@ export function GlobalNav({
         </button>
 
         {/* Center Content Logic (The Switch) */}
-        <div className={`rh-nav-center-desktop absolute left-1/2 top-1/2 hidden -translate-x-1/2 -translate-y-1/2 items-center desk:flex ${compactChrome ? 'gap-6' : 'gap-8'}`}>
+        <div className={`rh-nav-center-desktop hidden min-w-0 items-center justify-center justify-self-center desk:flex desk:w-full ${compactChrome ? 'gap-6' : 'gap-8'}`}>
           {isHome ? (
             <div 
               className="uppercase"
@@ -270,7 +270,7 @@ export function GlobalNav({
         </div>
 
         {/* Right Side: Player Statistics */}
-        <div className="rh-nav-stats flex min-w-0 shrink-0 items-center justify-end">
+        <div className="rh-nav-stats flex min-w-0 shrink-0 items-center justify-end desk:justify-self-end">
           {/* Rating */}
           <div className="rh-nav-stat-block flex items-center gap-3 px-5 py-2.5">
             <svg className="rh-nav-stat-icon" width="20" height="20" viewBox="0 0 24 24" fill={activeColor ?? 'var(--tier-elite)'} xmlns="http://www.w3.org/2000/svg">

--- a/client/src/styles/rh-mobile-chrome.css
+++ b/client/src/styles/rh-mobile-chrome.css
@@ -211,6 +211,37 @@
     min-height: 42px;
   }
 
+  /*
+   * Desktop nav uses a 3-column grid (brand | tabs | stats). The old absolute
+   * center stack sat on top of siblings while `.rh-nav-brand { flex: 1 1 auto }`
+   * expanded the logo hit target across the full row — intercepting tab clicks
+   * (and vice versa depending on paint order).
+   */
+  .rh-nav-brand {
+    flex: 0 0 auto;
+    width: auto;
+    max-width: 100%;
+  }
+
+  .rh-nav-center-desktop {
+    min-width: 0;
+    max-width: 100%;
+  }
+
+  .rh-nav-center-desktop > div {
+    min-width: 0;
+    max-width: 100%;
+    flex-wrap: nowrap;
+  }
+
+  .rh-nav-center-desktop button {
+    white-space: nowrap;
+  }
+
+  .rh-nav-stats {
+    min-width: 0;
+  }
+
   .home-mode-tabs {
     display: block;
   }


### PR DESCRIPTION
## Summary
- Fixes a production UI bug where desktop GlobalNav regions overlapped: the brand button’s expanded flex hit target and the absolutely centered tab strip intercepted each other’s clicks (logo, Multiplayer, Learn, etc.).
- Replaces absolute center positioning with a three-column CSS grid (`brand | tabs | stats`) so each region stays in its own column with constrained hit targets.
- Adds a Playwright regression (`assertDesktopNavRegionsDoNotOverlap`) covering widths 769–1440px plus Learn/logo navigation clicks.

## Root cause
On desktop, `.rh-nav-center-desktop` used `absolute left-1/2 -translate-x-1/2` (out of document flow) while `.rh-nav-brand` had `flex: 1 1 auto`, growing the logo button’s invisible click area across the row. Depending on paint order, either the logo or a center tab blocked the intended target — failing routing, solo-hub, and multiplayer-chaos e2e tests.

## Test plan
- [x] `npx playwright test e2e/routing.spec.ts e2e/solo-hub-no-circuit.spec.ts e2e/multiplayer-chaos.spec.ts --project=chromium` — **28/28 pass**
- [x] `npx playwright test e2e/mobile-390.spec.ts --project=chromium-mobile` — **9/9 pass** (mobile unchanged)
- [x] `npm run typecheck --prefix client`
- [x] `npm run build --prefix client`
- [ ] Manually click logo + center tabs at 769px, 1024px, 1280px, 1440px on Vercel preview before merge

## Out of scope (logged separately)
- `journey-premium-open-end-discipline` domino keyboard interaction failures
- MP Private Authority Soak turn-order flake


Made with [Cursor](https://cursor.com)