### PR TITLE
Restore Daily Fritz between-games overlay on refresh

### DIFF
--- a/client/src/dailyFritz/dailyFritzScreenHelpers.test.ts
+++ b/client/src/dailyFritz/dailyFritzScreenHelpers.test.ts
@@ -13,6 +13,7 @@ import {
   normalizeSetResult,
   getNextGameNumberFromSetResult,
   resolveTodayNextAction,
+  resolveBetweenGamesOverlayFromStart,
 } from './dailyFritzScreenHelpers';
 
 describe('formatDateLabel', () => {
@@ -167,5 +168,67 @@ describe('resolveTodayNextAction', () => {
       rank: null,
       leaderboard_preview: [],
     })).toBe('view_results');
+  });
+});
+
+describe('resolveBetweenGamesOverlayFromStart', () => {
+  const game1 = {
+    gameNumber: 1 as const,
+    seed: 'g1',
+    playerWon: true,
+    playerScore: 60,
+    fritzScore: 40,
+    pointDiff: 20,
+    completedAt: '2026-08-19T10:00:00.000Z',
+  };
+
+  const startBase = {
+    ok: true as const,
+    attempt_id: 'attempt-1',
+    verified_match_id: 'verified-1',
+    run_date: '2026-08-19',
+    current_hand_index: 0,
+    current_game_number: 2 as const,
+    needs_completion: false,
+    set_result: {
+      version: 2 as const,
+      format: 'best_of_3' as const,
+      playerGamesWon: 1,
+      fritzGamesWon: 0,
+      totalPointDiff: 20,
+      games: [game1],
+    },
+    fritz_tier: 'elite' as const,
+    deal_size: 7 as const,
+    winning_score: 60,
+    first_hand: {
+      player_tiles: [{ low: 0, high: 0 }],
+      fritz_tiles: [{ low: 1, high: 1 }],
+      boneyard: [],
+      locked: [],
+    },
+    draw_winner: 'you' as const,
+    draw_player_tile: { low: 0, high: 1 },
+    draw_fritz_tile: { low: 0, high: 2 },
+  };
+
+  it('reconstructs the last completed game and next game slot from a between_games /start payload', () => {
+    expect(resolveBetweenGamesOverlayFromStart({
+      ...startBase,
+      next_action: 'between_games',
+    })).toEqual({
+      completedGame: game1,
+      setResult: startBase.set_result,
+      nextGameNumber: 2,
+    });
+  });
+
+  it('does not reconstruct an overlay for a mid-hand play_hand resume', () => {
+    expect(resolveBetweenGamesOverlayFromStart({
+      ...startBase,
+      next_action: 'play_hand',
+      current_hand_index: 2,
+      current_game_number: 2,
+    })).toBeNull();
   });
 });

--- a/client/src/dailyFritz/dailyFritzScreenHelpers.ts
+++ b/client/src/dailyFritz/dailyFritzScreenHelpers.ts
@@ -321,6 +321,25 @@ export function normalizeStartResponse(
   return normalized;
 }
 
+/**
+ * Reconstruct the live between-games overlay from a /start resume payload.
+ * `/start` already includes next_action, set_result (completed games), and the next game slot.
+ */
+export function resolveBetweenGamesOverlayFromStart(started: DailyFritzStartResponse): {
+  completedGame: DailyFritzSetGameResult;
+  setResult: DailyFritzSetResult;
+  nextGameNumber: DailyFritzSetGameNumber;
+} | null {
+  if (resolveStartNextAction(started) !== 'between_games') return null;
+  const setResult = normalizeSetResult(started.set_result);
+  if (!setResult || setResult.setWinner || setResult.games.length === 0) return null;
+  const completedGame = setResult.games[setResult.games.length - 1];
+  if (!completedGame) return null;
+  const nextGameNumber = resolveDailyFritzCurrentGameNumber(setResult, started.current_game_number);
+  if (nextGameNumber === completedGame.gameNumber) return null;
+  return { completedGame, setResult, nextGameNumber };
+}
+
 export function formatMargin(value: number): string {
   if (!Number.isFinite(value)) return '—';
   return `${value >= 0 ? '+' : ''}${value}`;

--- a/client/src/dailyFritz/useDailyFritzRunController.test.tsx
+++ b/client/src/dailyFritz/useDailyFritzRunController.test.tsx
@@ -152,6 +152,59 @@ describe('Daily Fritz authoritative resume fallthroughs', () => {
     });
   });
 
+  it('shows the between-games overlay on /start resume instead of dropping into the next game', async () => {
+    const betweenSet = {
+      ...setResult,
+      playerGamesWon: 1,
+      fritzGamesWon: 0,
+      setWinner: undefined,
+      games: [setResult.games[0]!],
+    };
+    const betweenStart = started({
+      next_action: 'between_games',
+      current_game_number: 2,
+      current_hand_index: 0,
+      needs_completion: false,
+      set_result: betweenSet,
+    });
+    apiMocks.startDailyFritz.mockResolvedValue(betweenStart);
+    const { result } = renderHook(() => useDailyFritzRunController({
+      today: today({
+        current_game_number: 2,
+        needs_completion: false,
+        next_action: 'between_games',
+        set_result: betweenSet,
+      }),
+      hubError: null,
+      setHubError: vi.fn(),
+      refreshToday: vi.fn().mockResolvedValue(undefined),
+    }));
+
+    await act(async () => {
+      await result.current.continueSet();
+    });
+
+    expect(result.current.hasEmbeddedMatch).toBe(true);
+    expect(result.current.setOverlay).toMatchObject({
+      kind: 'between',
+      nextGameNumber: 2,
+      completedGame: { gameNumber: 1, playerScore: 60, fritzScore: 40 },
+      setResult: { playerGamesWon: 1, fritzGamesWon: 0 },
+    });
+
+    await act(async () => {
+      await result.current.continueSet();
+    });
+
+    expect(apiMocks.startDailyFritz).toHaveBeenCalledTimes(2);
+    expect(result.current.setOverlay).toBeNull();
+    expect(result.current.hasEmbeddedMatch).toBe(true);
+    expect(result.current.dailyFritzPackageForMatch).toMatchObject({
+      current_game_number: 2,
+      current_hand_index: 0,
+    });
+  });
+
   it('does not replay /start or /complete after /complete committed and /today is already completed', async () => {
     renderHook(() => useDailyFritzRunController({
       today: today({ attempt_status: 'completed', needs_completion: false }),

--- a/client/src/dailyFritz/useDailyFritzRunController.ts
+++ b/client/src/dailyFritz/useDailyFritzRunController.ts
@@ -24,6 +24,7 @@ import {
   resolveTodayNextAction,
   normalizeStartResponse,
   resolveDailyFritzCurrentGameNumber,
+  resolveBetweenGamesOverlayFromStart,
 } from './dailyFritzScreenHelpers';
 import type {
   DailyFritzGameCompletionPayload,
@@ -272,7 +273,16 @@ export function useDailyFritzRunController({
       }
       return;
     }
+    const betweenGames = resolveBetweenGamesOverlayFromStart(normalized);
     openEmbeddedRun(normalized);
+    if (betweenGames) {
+      setSetOverlay({
+        kind: 'between',
+        completedGame: betweenGames.completedGame,
+        setResult: betweenGames.setResult,
+        nextGameNumber: betweenGames.nextGameNumber,
+      });
+    }
   }, [buildCompletedGame, openEmbeddedRun, submitSetCompletion]);
 
   const beginRun = useCallback(async () => {
@@ -324,7 +334,14 @@ export function useDailyFritzRunController({
     }
     try {
       const started = await startDailyFritz({ timeoutMs: DAILY_FRITZ_INIT_TIMEOUT_MS });
+      const advancingFromBetweenOverlay = setOverlay?.kind === 'between';
       setSetOverlay(null);
+      if (advancingFromBetweenOverlay) {
+        // /start still reports between_games until the next hand is played.
+        // The player already saw the interstitial; open the next game.
+        openEmbeddedRun(normalizeStartResponse(started, fallbackSetResult));
+        return;
+      }
       await handleStartResponse(started, fallbackSetResult);
     } catch (err) {
       setHubError(friendlyDailyFritzInitError(err));
@@ -332,7 +349,7 @@ export function useDailyFritzRunController({
       startActionInFlightRef.current = false;
       setStartActionPending(false);
     }
-  }, [handleStartResponse, setOverlay, setHubError, today]);
+  }, [handleStartResponse, openEmbeddedRun, setOverlay, setHubError, today]);
 
   useEffect(() => {
     if (resolveTodayNextAction(today) !== 'finalize_set' || activeRun) return;


### PR DESCRIPTION
## Summary
- Hard refresh while `next_action === 'between_games'` now reconstructs the existing between-games interstitial from `/start` (`set_result` + next game slot) instead of dropping into the next live game.
- Continue from that overlay still starts the next game: `/start` keeps reporting `between_games` until a hand is played, so Continue skips overlay reconstruction and opens the package.
- No server or session-reducer changes. Overlay state is the same `kind: 'between'` payload used after a live record-game.

## Test plan
- [ ] Win Game 1, stay on the between-games overlay, hard refresh, Resume → overlay shows Game 1 result (`60–40`, set `1-0`) not a live hand
- [ ] Tap Start Game 2 from the reconstructed overlay → Game 2 starts (same as live Continue)
- [ ] Mid-hand Resume (`play_hand`) still skips the overlay
- [ ] Return to Hub from overlay still lands on hub (no auto-reopen)


Made with [Cursor](https://cursor.com)