### PR TITLE
feat(daily-fritz): schema 10 checkpoint migration (M7)

### DIFF
--- a/client/src/dailyFritz/resolveDailyFritzSession.test.ts
+++ b/client/src/dailyFritz/resolveDailyFritzSession.test.ts
@@ -5,9 +5,10 @@ import { createDailyFritzChallengeIdentity } from './dailyFritzChallengeIdentity
 import { resolveDailyFritzSession } from './resolveDailyFritzSession';
 import type { DailyFritzStartResponse } from './api';
 import {
+  buildDailyFritzPersistedSnapshot,
+  buildDailyFritzMatchSessionFromLegacyFields,
   buildDailyFritzStorageKey,
   discardDailyFritzSnapshot,
-  DAILY_FRITZ_SESSION_SCHEMA_VERSION,
   persistDailyFritzSnapshot,
   type DailyFritzPersistedSnapshot,
 } from '../modules/daily/dailyFritzSessionStorage';
@@ -21,17 +22,26 @@ function snapshot(overrides: Partial<DailyFritzPersistedSnapshot> = {}): DailyFr
   match.handNumber = 3;
   match.players.you.score = 35;
   match.players.bot.score = 20;
-  return {
-    schemaVersion: DAILY_FRITZ_SESSION_SCHEMA_VERSION,
+  const session = buildDailyFritzMatchSessionFromLegacyFields({
+    gameNumber: overrides.gameNumber ?? 1,
+    currentHandIndex: overrides.currentHandIndex ?? 2,
+    authorityRevision: overrides.authorityRevision ?? AUTHORITY_REVISION,
+    match: overrides.match ?? match,
+  });
+  const {
+    session: _session,
+    gameNumber: _gameNumber,
+    currentHandIndex: _currentHandIndex,
+    authorityRevision: _authorityRevision,
+    match: _match,
+    ...restOverrides
+  } = overrides;
+  return buildDailyFritzPersistedSnapshot(session, {
     challenge: createDailyFritzChallengeIdentity('2026-07-12'),
     classification: 'official',
     attemptId: 'attempt-1',
     runFingerprint: RUN_FP,
-    gameNumber: 1,
-    currentHandIndex: 2,
-    authorityRevision: AUTHORITY_REVISION,
     lifecyclePhase: 'active_hand',
-    match,
     handResult: null,
     movesUsed: 4,
     moveLog: [],
@@ -40,8 +50,8 @@ function snapshot(overrides: Partial<DailyFritzPersistedSnapshot> = {}): DailyFr
     startedAt: '2026-07-12T18:00:00.000Z',
     lastTransitionAt: '2026-07-12T18:01:00.000Z',
     checkpointRevision: 2,
-    ...overrides,
-  };
+    ...restOverrides,
+  });
 }
 
 function makeStartResponse(

--- a/client/src/modules/daily/dailyFritzSessionStorage.test.ts
+++ b/client/src/modules/daily/dailyFritzSessionStorage.test.ts
@@ -2,14 +2,20 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 import { createBotMatch } from '../match/runtime/botEngine.ts';
 import { createDailyFritzChallengeIdentity } from '../../dailyFritz/dailyFritzChallengeIdentity.ts';
+import type { DailyFritzAuthorityCursor } from './dailyFritzMatchSession.ts';
 import {
-  buildDailyFritzStorageKey,
+  buildDailyFritzPersistedSnapshot,
+  buildDailyFritzMatchSessionFromLegacyFields,
+  persistDailyFritzSnapshot,
+  parseDailyFritzPersistedSnapshot,
+  reconcileDailyFritzResume,
+  serializeDailyFritzCheckpointForServer,
+  DAILY_FRITZ_LEGACY_SESSION_SCHEMA_VERSION,
+  DAILY_FRITZ_SERVER_CHECKPOINT_SCHEMA_VERSION,
   DAILY_FRITZ_SESSION_SCHEMA_VERSION,
+  buildDailyFritzStorageKey,
   discardDailyFritzSnapshot,
   discardDailyFritzSnapshotBeforeReload,
-  parseDailyFritzPersistedSnapshot,
-  persistDailyFritzSnapshot,
-  reconcileDailyFritzResume,
   type DailyFritzPersistedSnapshot,
   type DailyFritzResumeRejection,
 } from './dailyFritzSessionStorage.ts';
@@ -18,21 +24,36 @@ const now = new Date('2026-07-12T20:00:00.000Z');
 const RUN_FP = 'abc123fingerprint00000000000000';
 const AUTHORITY_REVISION = 7;
 function snapshot(overrides: Partial<DailyFritzPersistedSnapshot> = {}): DailyFritzPersistedSnapshot {
-  const match = createBotMatch(60, 7);
-  match.handNumber = 3;
-  match.players.you.score = 35;
-  match.players.bot.score = 20;
-  return {
-    schemaVersion: DAILY_FRITZ_SESSION_SCHEMA_VERSION,
+  const baseMatch = createBotMatch(60, 7);
+  const gameNumber = overrides.gameNumber ?? 1;
+  const currentHandIndex = overrides.currentHandIndex ?? 2;
+  const authorityRevision = overrides.authorityRevision ?? AUTHORITY_REVISION;
+  const match = overrides.match ?? baseMatch;
+  if (!overrides.match) {
+    match.handNumber = currentHandIndex + 1;
+    match.players.you.score = 35;
+    match.players.bot.score = 20;
+  }
+  const session = overrides.session ?? buildDailyFritzMatchSessionFromLegacyFields({
+    gameNumber,
+    currentHandIndex,
+    authorityRevision,
+    match,
+  });
+  const {
+    session: _session,
+    gameNumber: _gameNumber,
+    currentHandIndex: _currentHandIndex,
+    authorityRevision: _authorityRevision,
+    match: _match,
+    ...restOverrides
+  } = overrides;
+  return buildDailyFritzPersistedSnapshot(session, {
     challenge: createDailyFritzChallengeIdentity('2026-07-12'),
     classification: 'official',
     attemptId: 'attempt-1',
     runFingerprint: RUN_FP,
-    gameNumber: 1,
-    currentHandIndex: 2,
-    authorityRevision: AUTHORITY_REVISION,
     lifecyclePhase: 'active_hand',
-    match,
     handResult: null,
     movesUsed: 4,
     moveLog: [],
@@ -41,7 +62,16 @@ function snapshot(overrides: Partial<DailyFritzPersistedSnapshot> = {}): DailyFr
     startedAt: '2026-07-12T18:00:00.000Z',
     lastTransitionAt: '2026-07-12T18:01:00.000Z',
     checkpointRevision: 2,
-    ...overrides,
+    ...restOverrides,
+  });
+}
+
+function legacySchema9Wire(overrides: Partial<DailyFritzPersistedSnapshot> = {}): Record<string, unknown> {
+  const normalized = snapshot(overrides);
+  const { session: _session, ...rest } = normalized;
+  return {
+    ...rest,
+    schemaVersion: DAILY_FRITZ_LEGACY_SESSION_SCHEMA_VERSION,
   };
 }
 
@@ -141,7 +171,7 @@ describe('Daily Fritz v3 session persistence', () => {
     expect(parsed?.transcriptProtocolVersion).toBe(2);
   });
 
-  describe.each([
+  it.each([
     {
       name: 'resume before next-hand request is sent',
       local: { gameNumber: 1, currentHandIndex: 2, authorityRevision: 7, matchHandNumber: 3 },
@@ -229,24 +259,75 @@ describe('Daily Fritz v3 session persistence', () => {
       reason: 'revision_mismatch' as DailyFritzResumeRejection,
     },
   ])('$name', ({ local, server, accepted, reason }) => {
-    it('reconciles to one coherent authority cursor', () => {
-      const value = snapshot({
-        gameNumber: local.gameNumber,
-        currentHandIndex: local.currentHandIndex,
-        authorityRevision: local.authorityRevision,
-        match: {
-          ...snapshot().match,
-          handNumber: local.matchHandNumber,
-        },
-      });
-      const result = reconcileDailyFritzResume(value, {
-        attemptId: 'attempt-1',
-        challengeId: createDailyFritzChallengeIdentity('2026-07-12').challengeId,
-        runFingerprint: RUN_FP,
-        cursor: server,
-      });
-      expect(result.accepted).toBe(accepted);
-      if (!accepted && !result.accepted) expect(result.reason).toBe(reason);
+    const value = snapshot({
+      gameNumber: local.gameNumber,
+      currentHandIndex: local.currentHandIndex,
+      authorityRevision: local.authorityRevision,
+      match: {
+        ...snapshot().match,
+        handNumber: local.matchHandNumber,
+      },
+    });
+    const result = reconcileDailyFritzResume(value, {
+      attemptId: 'attempt-1',
+      challengeId: createDailyFritzChallengeIdentity('2026-07-12').challengeId,
+      runFingerprint: RUN_FP,
+      cursor: server as DailyFritzAuthorityCursor,
+    });
+    expect(result.accepted).toBe(accepted);
+    if (!accepted && !result.accepted) expect(result.reason).toBe(reason);
+  });
+
+  describe('schema 10 checkpoint migration', () => {
+    it('round-trips schema 10 through persist and parse with session as canonical blob', () => {
+      const key = buildDailyFritzStorageKey('attempt-1', 1);
+      const original = snapshot({ checkpointRevision: 6 });
+      expect(original.schemaVersion).toBe(DAILY_FRITZ_SESSION_SCHEMA_VERSION);
+      expect(original.session.cursor.handIndex).toBe(2);
+      expect(persistDailyFritzSnapshot(key, original)).toBe(true);
+
+      const parsed = parseDailyFritzPersistedSnapshot(JSON.parse(localStorage.getItem(key)!), now);
+      expect(parsed?.schemaVersion).toBe(DAILY_FRITZ_SESSION_SCHEMA_VERSION);
+      expect(parsed?.session.cursor).toEqual(original.session.cursor);
+      expect(parsed?.session.match.handNumber).toBe(original.session.match.handNumber);
+      expect(parsed?.currentHandIndex).toBe(original.session.cursor.handIndex);
+      expect(parsed?.match.handNumber).toBe(original.session.match.handNumber);
+    });
+
+    it('upgrades legacy schema 9 wire payloads in memory without data loss', () => {
+      const legacyWire = legacySchema9Wire({ checkpointRevision: 8 });
+      expect(legacyWire).not.toHaveProperty('session');
+      expect(legacyWire.schemaVersion).toBe(DAILY_FRITZ_LEGACY_SESSION_SCHEMA_VERSION);
+
+      const parsed = parseDailyFritzPersistedSnapshot(legacyWire, now);
+      expect(parsed?.schemaVersion).toBe(DAILY_FRITZ_SESSION_SCHEMA_VERSION);
+      expect(parsed?.session.cursor.handIndex).toBe(2);
+      expect(parsed?.session.cursor.revision).toBe(AUTHORITY_REVISION);
+      expect(parsed?.session.match.players.you.score).toBe(35);
+      expect(parsed?.currentHandIndex).toBe(2);
+      expect(parsed?.authorityRevision).toBe(AUTHORITY_REVISION);
+    });
+
+    it('serializes schema 10 snapshots to schema 9 server wire without session', () => {
+      const normalized = snapshot();
+      const serverWire = serializeDailyFritzCheckpointForServer(normalized);
+      expect(serverWire.schemaVersion).toBe(DAILY_FRITZ_SERVER_CHECKPOINT_SCHEMA_VERSION);
+      expect(serverWire).not.toHaveProperty('session');
+      expect(serverWire.currentHandIndex).toBe(normalized.session.cursor.handIndex);
+      expect(serverWire.authorityRevision).toBe(normalized.session.cursor.revision);
+    });
+
+    it('rejects corrupt schema 10 checkpoints when session and denormalized cursor diverge', () => {
+      const corrupt = {
+        ...snapshot(),
+        currentHandIndex: 99,
+      };
+      expect(parseDailyFritzPersistedSnapshot(corrupt, now)).toBeNull();
+    });
+
+    it('rejects malformed schema 10 checkpoints missing session', () => {
+      const { session: _session, ...withoutSession } = snapshot();
+      expect(parseDailyFritzPersistedSnapshot(withoutSession, now)).toBeNull();
     });
   });
 

--- a/client/src/modules/daily/dailyFritzSessionStorage.ts
+++ b/client/src/modules/daily/dailyFritzSessionStorage.ts
@@ -5,18 +5,17 @@ import type { DailyFritzStartResponse } from './dailyFritzContracts.ts';
 import { createDailyFritzChallengeIdentity, isDailyFritzChallengeCurrent, type DailyFritzChallengeIdentity } from '../../dailyFritz/dailyFritzChallengeIdentity.ts';
 import type { DailyFritzTranscript } from '@racehorse/game-core';
 import { canonicalizeDailyFritzMoveLog } from '../../dailyFritz/dailyFritzMoveEvidence.ts';
+import type { DailyFritzAuthorityCursor, DailyFritzMatchSession } from './dailyFritzMatchSession.ts';
+import { isCoherentDailyFritzSession } from './dailyFritzMatchSession.ts';
 
-// Bump when the local match state is no longer safe to replay against the
-// server verifier. Version 9 binds every checkpoint to the server authority
-// revision and rejects match/index pairs torn across a hand transition.
-export const DAILY_FRITZ_SESSION_SCHEMA_VERSION = 9;
+/** Canonical client checkpoint schema — stores `session` as the authority blob. */
+export const DAILY_FRITZ_SESSION_SCHEMA_VERSION = 10;
+/** Legacy flat cursor + match layout (still accepted on read; upgraded in memory). */
+export const DAILY_FRITZ_LEGACY_SESSION_SCHEMA_VERSION = 9;
+/** Server checkpoint parser version — unchanged until a dedicated server migration. */
+export const DAILY_FRITZ_SERVER_CHECKPOINT_SCHEMA_VERSION = 9;
+
 export type DailyFritzPersistedPhase = 'active_hand' | 'hand_transition' | 'completed';
-
-export type DailyFritzAuthorityCursor = {
-  gameNumber: number;
-  handIndex: number;
-  revision: number;
-};
 
 export type DailyFritzResumeRejection =
   | 'attempt_mismatch'
@@ -32,19 +31,21 @@ export type DailyFritzResumeReconciliation =
   | { accepted: true; snapshot: DailyFritzPersistedSnapshot }
   | { accepted: false; reason: DailyFritzResumeRejection };
 
+/** Normalized in-memory checkpoint (always schema 10 after parse). */
 export type DailyFritzPersistedSnapshot = {
-  schemaVersion: 9;
+  schemaVersion: typeof DAILY_FRITZ_SESSION_SCHEMA_VERSION;
+  session: DailyFritzMatchSession;
   challenge: DailyFritzChallengeIdentity;
   classification: 'official';
   attemptId: string;
   /** Binds resume to the exact published run (seed/deals/status). */
   runFingerprint: string;
+  /** Denormalized compat fields — derived from `session` on write (one-release bridge). */
   gameNumber: number;
   currentHandIndex: number;
-  /** Server attempt revision from which this hand state was derived. */
   authorityRevision: number;
-  lifecyclePhase: DailyFritzPersistedPhase;
   match: BotMatchState;
+  lifecyclePhase: DailyFritzPersistedPhase;
   handResult: BotHandReveal | null;
   movesUsed: number;
   moveLog: MoveEntry[];
@@ -58,6 +59,16 @@ export type DailyFritzPersistedSnapshot = {
   transcriptProtocolVersion?: 1 | 2;
   fritzPolicyVersion?: 1 | 2;
   fritzPolicyContract?: string;
+};
+
+type ParsedCheckpointEnvelope = Omit<
+  DailyFritzPersistedSnapshot,
+  'schemaVersion' | 'session' | 'gameNumber' | 'currentHandIndex' | 'authorityRevision' | 'match'
+> & {
+  gameNumber: number;
+  currentHandIndex: number;
+  authorityRevision: number;
+  match: BotMatchState;
 };
 
 const object = (value: unknown): value is Record<string, unknown> => Boolean(value) && typeof value === 'object' && !Array.isArray(value);
@@ -90,6 +101,7 @@ function validChallenge(value: unknown): value is DailyFritzChallengeIdentity {
   return object(value) && typeof value.challengeDate === 'string' && typeof value.challengeId === 'string'
     && Number.isInteger(value.rulesVersion) && Number.isInteger(value.seedVersion);
 }
+
 function validHandResult(value: unknown): value is BotHandReveal | null {
   if (value === null) return true;
   return object(value) && (value.winner === 'you' || value.winner === 'bot' || value.winner === null)
@@ -99,32 +111,210 @@ function validHandResult(value: unknown): value is BotHandReveal | null {
     && Array.isArray(value.botRemainingTiles) && value.botRemainingTiles.every(validTile);
 }
 
-export function parseDailyFritzPersistedSnapshot(value: unknown, now = new Date()): DailyFritzPersistedSnapshot | null {
-  if (!object(value) || value.schemaVersion !== DAILY_FRITZ_SESSION_SCHEMA_VERSION || value.classification !== 'official') return null;
+function validSessionCursor(value: unknown): value is DailyFritzAuthorityCursor {
+  if (!object(value)) return false;
+  const gameNumber = Number(value.gameNumber);
+  if (gameNumber !== 1 && gameNumber !== 2 && gameNumber !== 3) return false;
+  return nonNegativeInteger(value.handIndex) && nonNegativeInteger(value.revision);
+}
+
+function validSession(value: unknown): value is DailyFritzMatchSession {
+  if (!object(value) || !validSessionCursor(value.cursor) || !validMatch(value.match)) return false;
+  return isCoherentDailyFritzSession({
+    cursor: {
+      gameNumber: Number(value.cursor.gameNumber) as DailyFritzAuthorityCursor['gameNumber'],
+      handIndex: Number(value.cursor.handIndex),
+      revision: Number(value.cursor.revision),
+    },
+    match: value.match as BotMatchState,
+  });
+}
+
+function denormalizedFieldsMatchSession(
+  session: DailyFritzMatchSession,
+  gameNumber: number,
+  currentHandIndex: number,
+  authorityRevision: number,
+  match: BotMatchState,
+): boolean {
+  return session.cursor.gameNumber === gameNumber
+    && session.cursor.handIndex === currentHandIndex
+    && session.cursor.revision === authorityRevision
+    && match.handNumber === session.match.handNumber
+    && match.handNumber === currentHandIndex + 1
+    && match.handOver === session.match.handOver
+    && match.gameOver === session.match.gameOver;
+}
+
+export function buildDailyFritzMatchSessionFromLegacyFields(input: {
+  gameNumber: number;
+  currentHandIndex: number;
+  authorityRevision: number;
+  match: BotMatchState;
+}): DailyFritzMatchSession {
+  return {
+    cursor: {
+      gameNumber: input.gameNumber as DailyFritzAuthorityCursor['gameNumber'],
+      handIndex: input.currentHandIndex,
+      revision: input.authorityRevision,
+    },
+    match: input.match,
+  };
+}
+
+export function deriveLegacyFieldsFromSession(session: DailyFritzMatchSession): {
+  gameNumber: number;
+  currentHandIndex: number;
+  authorityRevision: number;
+  match: BotMatchState;
+} {
+  return {
+    gameNumber: session.cursor.gameNumber,
+    currentHandIndex: session.cursor.handIndex,
+    authorityRevision: session.cursor.revision,
+    match: session.match,
+  };
+}
+
+function finalizeParsedCheckpoint(
+  envelope: ParsedCheckpointEnvelope,
+  session: DailyFritzMatchSession,
+): DailyFritzPersistedSnapshot {
+  const legacy = deriveLegacyFieldsFromSession(session);
+  return {
+    ...envelope,
+    schemaVersion: DAILY_FRITZ_SESSION_SCHEMA_VERSION,
+    session,
+    gameNumber: legacy.gameNumber,
+    currentHandIndex: legacy.currentHandIndex,
+    authorityRevision: legacy.authorityRevision,
+    match: legacy.match,
+  };
+}
+
+function parseCheckpointEnvelope(value: Record<string, unknown>, now: Date): ParsedCheckpointEnvelope | null {
+  if (value.classification !== 'official') return null;
   if (!validChallenge(value.challenge) || !isDailyFritzChallengeCurrent(value.challenge, now)) return null;
   if (typeof value.attemptId !== 'string' || !value.attemptId || typeof value.runFingerprint !== 'string' || !value.runFingerprint) return null;
   if (!nonNegativeInteger(value.gameNumber) || !nonNegativeInteger(value.currentHandIndex) || !nonNegativeInteger(value.authorityRevision)) return null;
-  if (!['active_hand','hand_transition','completed'].includes(String(value.lifecyclePhase)) || !validMatch(value.match)) return null;
-  if (!nonNegativeInteger(value.movesUsed) || !Array.isArray(value.moveLog) || !validHandResult(value.handResult) || !validIso(value.startedAt) || !validIso(value.lastTransitionAt) || Date.parse(value.lastTransitionAt) < Date.parse(value.startedAt) || !nonNegativeInteger(value.checkpointRevision)) return null;
+  if (!['active_hand', 'hand_transition', 'completed'].includes(String(value.lifecyclePhase)) || !validMatch(value.match)) return null;
+  if (!nonNegativeInteger(value.movesUsed) || !Array.isArray(value.moveLog) || !validHandResult(value.handResult) || !validIso(value.startedAt) || !validIso(value.lastTransitionAt) || Date.parse(String(value.lastTransitionAt)) < Date.parse(String(value.startedAt)) || !nonNegativeInteger(value.checkpointRevision)) return null;
+
   const phase = value.lifecyclePhase as DailyFritzPersistedPhase;
   const match = value.match as BotMatchState;
   if (phase === 'active_hand' && (match.handOver || match.gameOver)) return null;
   if (phase === 'hand_transition' && (!match.handOver || match.gameOver || value.handResult === null)) return null;
   if (phase === 'completed' && !match.gameOver) return null;
   if (match.handNumber !== Number(value.currentHandIndex) + 1) return null;
+
   const verificationPhase = value.verificationPhase === 'pending' ? 'pending' : 'collecting';
   const transcriptProtocolVersion = value.transcriptProtocolVersion === 2 ? 2 : 1;
   if (value.fritzPolicyVersion != null && value.fritzPolicyVersion !== 1 && value.fritzPolicyVersion !== 2) return null;
   if (value.fritzPolicyContract != null && typeof value.fritzPolicyContract !== 'string') return null;
+
   return {
-    ...value,
-    schemaVersion: DAILY_FRITZ_SESSION_SCHEMA_VERSION,
+    challenge: value.challenge,
+    classification: 'official',
+    attemptId: value.attemptId,
     runFingerprint: value.runFingerprint,
-    transcript: object(value.transcript) ? value.transcript as unknown as DailyFritzTranscript : null,
+    gameNumber: Number(value.gameNumber),
+    currentHandIndex: Number(value.currentHandIndex),
+    authorityRevision: Number(value.authorityRevision),
+    lifecyclePhase: phase,
+    match,
+    handResult: value.handResult as BotHandReveal | null,
+    movesUsed: Number(value.movesUsed),
     moveLog: canonicalizeDailyFritzMoveLog(value.moveLog as MoveEntry[]),
+    transcript: object(value.transcript) ? value.transcript as unknown as DailyFritzTranscript : null,
     verificationPhase,
+    startedAt: String(value.startedAt),
+    lastTransitionAt: String(value.lastTransitionAt),
+    checkpointRevision: Number(value.checkpointRevision),
     transcriptProtocolVersion,
-  } as unknown as DailyFritzPersistedSnapshot;
+    ...(value.fritzPolicyVersion === 1 || value.fritzPolicyVersion === 2
+      ? { fritzPolicyVersion: value.fritzPolicyVersion as 1 | 2 }
+      : {}),
+    ...(typeof value.fritzPolicyContract === 'string'
+      ? { fritzPolicyContract: value.fritzPolicyContract }
+      : {}),
+  };
+}
+
+function parseSchema10Checkpoint(value: Record<string, unknown>, now: Date): DailyFritzPersistedSnapshot | null {
+  if (!validSession(value.session)) return null;
+  const envelope = parseCheckpointEnvelope(value, now);
+  if (!envelope) return null;
+  const session = value.session as DailyFritzMatchSession;
+  if (!denormalizedFieldsMatchSession(
+    session,
+    envelope.gameNumber,
+    envelope.currentHandIndex,
+    envelope.authorityRevision,
+    envelope.match,
+  )) {
+    return null;
+  }
+  return finalizeParsedCheckpoint(envelope, session);
+}
+
+function parseLegacySchema9Checkpoint(value: Record<string, unknown>, now: Date): DailyFritzPersistedSnapshot | null {
+  const envelope = parseCheckpointEnvelope(value, now);
+  if (!envelope) return null;
+  const session = buildDailyFritzMatchSessionFromLegacyFields({
+    gameNumber: envelope.gameNumber,
+    currentHandIndex: envelope.currentHandIndex,
+    authorityRevision: envelope.authorityRevision,
+    match: envelope.match,
+  });
+  return finalizeParsedCheckpoint(envelope, session);
+}
+
+export function parseDailyFritzPersistedSnapshot(value: unknown, now = new Date()): DailyFritzPersistedSnapshot | null {
+  if (!object(value)) return null;
+  if (value.schemaVersion === DAILY_FRITZ_SESSION_SCHEMA_VERSION) {
+    return parseSchema10Checkpoint(value, now);
+  }
+  if (value.schemaVersion === DAILY_FRITZ_LEGACY_SESSION_SCHEMA_VERSION) {
+    return parseLegacySchema9Checkpoint(value, now);
+  }
+  return null;
+}
+
+/** Build a schema-10 checkpoint with denormalized compat fields derived from `session`. */
+export function buildDailyFritzPersistedSnapshot(
+  session: DailyFritzMatchSession,
+  fields: Omit<
+    ParsedCheckpointEnvelope,
+    'gameNumber' | 'currentHandIndex' | 'authorityRevision' | 'match'
+  >,
+): DailyFritzPersistedSnapshot {
+  const legacy = deriveLegacyFieldsFromSession(session);
+  return finalizeParsedCheckpoint({
+    ...fields,
+    gameNumber: legacy.gameNumber,
+    currentHandIndex: legacy.currentHandIndex,
+    authorityRevision: legacy.authorityRevision,
+    match: legacy.match,
+  }, session);
+}
+
+/**
+ * Server checkpoint route still validates schema 9 flat layout.
+ * Strip `session` and emit v9 wire fields derived from the canonical blob.
+ */
+export function serializeDailyFritzCheckpointForServer(
+  snapshot: DailyFritzPersistedSnapshot,
+): Record<string, unknown> {
+  const legacy = deriveLegacyFieldsFromSession(snapshot.session);
+  const { session: _session, schemaVersion: _schemaVersion, ...rest } = snapshot;
+  return {
+    ...rest,
+    schemaVersion: DAILY_FRITZ_SERVER_CHECKPOINT_SCHEMA_VERSION,
+    gameNumber: legacy.gameNumber,
+    currentHandIndex: legacy.currentHandIndex,
+    authorityRevision: legacy.authorityRevision,
+    match: legacy.match,
+  };
 }
 
 export function reconcileDailyFritzResume(
@@ -143,10 +333,11 @@ export function reconcileDailyFritzResume(
   if (authority.runFingerprint && snapshot.runFingerprint !== authority.runFingerprint) {
     return { accepted: false, reason: 'run_mismatch' };
   }
-  if (snapshot.gameNumber !== authority.cursor.gameNumber) return { accepted: false, reason: 'game_mismatch' };
-  if (snapshot.currentHandIndex !== authority.cursor.handIndex) return { accepted: false, reason: 'hand_mismatch' };
-  if (snapshot.authorityRevision !== authority.cursor.revision) return { accepted: false, reason: 'revision_mismatch' };
-  if (snapshot.match.handNumber !== authority.cursor.handIndex + 1) {
+  const { cursor, match } = snapshot.session;
+  if (cursor.gameNumber !== authority.cursor.gameNumber) return { accepted: false, reason: 'game_mismatch' };
+  if (cursor.handIndex !== authority.cursor.handIndex) return { accepted: false, reason: 'hand_mismatch' };
+  if (cursor.revision !== authority.cursor.revision) return { accepted: false, reason: 'revision_mismatch' };
+  if (match.handNumber !== authority.cursor.handIndex + 1) {
     return { accepted: false, reason: 'match_hand_mismatch' };
   }
   if (
@@ -176,8 +367,8 @@ export function dailyFritzServerCheckpointToSnapshot(
 ): DailyFritzPersistedSnapshot | null {
   const withChallenge = {
     ...checkpoint,
-    schemaVersion: DAILY_FRITZ_SESSION_SCHEMA_VERSION,
-    classification: 'official',
+    schemaVersion: checkpoint.schemaVersion ?? DAILY_FRITZ_LEGACY_SESSION_SCHEMA_VERSION,
+    classification: checkpoint.classification ?? 'official',
     challenge: validChallenge(checkpoint.challenge)
       ? checkpoint.challenge
       : createDailyFritzChallengeIdentity(runDate),
@@ -185,12 +376,17 @@ export function dailyFritzServerCheckpointToSnapshot(
   return parseDailyFritzPersistedSnapshot(withChallenge, now);
 }
 
+function isKnownCheckpointSchemaVersion(schemaVersion: unknown): boolean {
+  return schemaVersion === DAILY_FRITZ_SESSION_SCHEMA_VERSION
+    || schemaVersion === DAILY_FRITZ_LEGACY_SESSION_SCHEMA_VERSION;
+}
+
 export function persistDailyFritzSnapshot(storageKey: string, snapshot: DailyFritzPersistedSnapshot): boolean {
   if (typeof window === 'undefined') return false;
   try {
     const existingRaw = window.localStorage.getItem(storageKey);
     const existing = existingRaw ? JSON.parse(existingRaw) as unknown : null;
-    if (object(existing) && existing.schemaVersion === DAILY_FRITZ_SESSION_SCHEMA_VERSION) {
+    if (object(existing) && isKnownCheckpointSchemaVersion(existing.schemaVersion)) {
       const revision = Number(existing.checkpointRevision);
       const transitionAt = typeof existing.lastTransitionAt === 'string'
         ? Date.parse(existing.lastTransitionAt)

--- a/client/src/modules/daily/index.ts
+++ b/client/src/modules/daily/index.ts
@@ -25,8 +25,13 @@ export type { DailyFritzSetOverlayViewModel } from './dailyFritzUiContracts.ts';
 export { buildShareText } from './dailyFritzUiContracts.ts';
 export {
   buildDailyFritzStorageKey,
+  buildDailyFritzPersistedSnapshot,
+  DAILY_FRITZ_LEGACY_SESSION_SCHEMA_VERSION,
+  DAILY_FRITZ_SERVER_CHECKPOINT_SCHEMA_VERSION,
+  DAILY_FRITZ_SESSION_SCHEMA_VERSION,
   pruneNonPlayableDailyFritzSnapshot,
   resolveDailyFritzStorageKey,
+  serializeDailyFritzCheckpointForServer,
 } from './dailyFritzSessionStorage.ts';
 export type { DailyFritzPersistedSnapshot } from './dailyFritzSessionStorage.ts';
 export {

--- a/client/src/modules/daily/resolveDailyFritzSession.test.ts
+++ b/client/src/modules/daily/resolveDailyFritzSession.test.ts
@@ -29,6 +29,32 @@ function startPackage(overrides: Partial<DailyFritzStartResponse> = {}): DailyFr
 }
 
 describe('resolveDailyFritzMatchSession', () => {
+  it('prefers persisted session cursor and match when resolving bootstrap state', () => {
+    const match = createBotMatch(60, 7);
+    match.handNumber = 3;
+    const session = {
+      cursor: { gameNumber: 1 as const, handIndex: 2, revision: 7 },
+      match,
+    };
+    const persisted = {
+      session,
+      currentHandIndex: 2,
+      authorityRevision: 7,
+      match,
+    } as DailyFritzPersistedSnapshot;
+
+    const resolved = resolveDailyFritzMatchSession({
+      dailyFritzPackage: startPackage(),
+      winningScore: 60,
+      persistedSnapshot: persisted,
+      preGameDrawEligible: false,
+    });
+
+    expect(resolved.cursor).toBe(session.cursor);
+    expect(resolved.match).toBe(match);
+    expect(isCoherentDailyFritzSession(resolved)).toBe(true);
+  });
+
   it('binds persisted snapshot cursor and match together', () => {
     const match = createBotMatch(60, 7);
     match.handNumber = 3;

--- a/client/src/modules/daily/resolveDailyFritzSession.ts
+++ b/client/src/modules/daily/resolveDailyFritzSession.ts
@@ -16,6 +16,9 @@ export function buildDailyFritzAuthorityCursor(
   dailyFritzPackage: DailyFritzStartResponse,
   persistedSnapshot: DailyFritzPersistedSnapshot | null,
 ): DailyFritzAuthorityCursor {
+  if (persistedSnapshot?.session) {
+    return persistedSnapshot.session.cursor;
+  }
   const gameNumber = (dailyFritzPackage.current_game_number ?? 1) as DailyFritzAuthorityCursor['gameNumber'];
   const handIndex = typeof persistedSnapshot?.currentHandIndex === 'number'
     ? persistedSnapshot.currentHandIndex
@@ -30,6 +33,9 @@ function resolveDailyFritzMatch(
   input: ResolveDailyFritzSessionInput,
 ): BotMatchState {
   const { dailyFritzPackage, winningScore, persistedSnapshot, preGameDrawEligible } = input;
+  if (persistedSnapshot?.session?.match) {
+    return persistedSnapshot.session.match;
+  }
   if (persistedSnapshot?.match) {
     return persistedSnapshot.match;
   }

--- a/client/src/modules/daily/useDailyFritzSessionPersistence.test.tsx
+++ b/client/src/modules/daily/useDailyFritzSessionPersistence.test.tsx
@@ -4,6 +4,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createBotMatch } from '../match/runtime/botEngine.ts';
 import { useDailyFritzSessionPersistence } from './useDailyFritzSessionPersistence.ts';
 import type { DailyFritzMatchSession } from './dailyFritzMatchSession.ts';
+import {
+  DAILY_FRITZ_SERVER_CHECKPOINT_SCHEMA_VERSION,
+  DAILY_FRITZ_SESSION_SCHEMA_VERSION,
+} from './dailyFritzSessionStorage.ts';
 import { DAILY_FRITZ_CHECKPOINT_SYNC_DEBOUNCE_MS } from '../../dailyFritz/dailyFritzCheckpointUnload.ts';
 
 const { saveDailyFritzCheckpointMock, flushDailyFritzCheckpointOnUnloadMock } = vi.hoisted(() => ({
@@ -80,7 +84,10 @@ describe('useDailyFritzSessionPersistence', () => {
     rerender({ drawSequenceActive: false });
 
     expect(window.localStorage.getItem(storageKey)).not.toBeNull();
-    expect(JSON.parse(window.localStorage.getItem(storageKey)!).transcriptProtocolVersion).toBe(2);
+    const persisted = JSON.parse(window.localStorage.getItem(storageKey)!);
+    expect(persisted.schemaVersion).toBe(DAILY_FRITZ_SESSION_SCHEMA_VERSION);
+    expect(persisted.session.cursor.handIndex).toBe(0);
+    expect(persisted.transcriptProtocolVersion).toBe(2);
   });
 
   it('persists coherent session snapshots atomically', () => {
@@ -113,6 +120,8 @@ describe('useDailyFritzSessionPersistence', () => {
     rerender({ session: handTwo });
 
     const afterBoundary = JSON.parse(window.localStorage.getItem(storageKey)!);
+    expect(afterBoundary.schemaVersion).toBe(DAILY_FRITZ_SESSION_SCHEMA_VERSION);
+    expect(afterBoundary.session.cursor.handIndex).toBe(1);
     expect(afterBoundary.currentHandIndex).toBe(1);
     expect(afterBoundary.authorityRevision).toBe(5);
     expect(afterBoundary.match.handNumber).toBe(2);
@@ -191,9 +200,16 @@ describe('useDailyFritzSessionPersistence', () => {
         attemptId: 'attempt-1',
         verifiedMatchId: 'verified-1',
         accessToken: 'test-token',
-        checkpoint: expect.objectContaining({ checkpointRevision: expect.any(Number) }),
+        checkpoint: expect.objectContaining({
+          schemaVersion: DAILY_FRITZ_SERVER_CHECKPOINT_SCHEMA_VERSION,
+          checkpointRevision: expect.any(Number),
+        }),
       }),
     );
+    const flushCall = flushDailyFritzCheckpointOnUnloadMock.mock.calls.at(0)?.at(0) as
+      | { checkpoint: Record<string, unknown> }
+      | undefined;
+    expect(flushCall?.checkpoint).not.toHaveProperty('session');
 
     act(() => {
       vi.advanceTimersByTime(500);

--- a/client/src/modules/daily/useDailyFritzSessionPersistence.ts
+++ b/client/src/modules/daily/useDailyFritzSessionPersistence.ts
@@ -4,8 +4,9 @@ import type { BotHandReveal } from '../match/types.ts';
 import { pruneNonPlayableDailyFritzSnapshot } from './dailyFritzSessionStorage';
 import { createDailyFritzChallengeIdentity } from '../../dailyFritz/dailyFritzChallengeIdentity.ts';
 import {
-  DAILY_FRITZ_SESSION_SCHEMA_VERSION,
+  buildDailyFritzPersistedSnapshot,
   persistDailyFritzSnapshot,
+  serializeDailyFritzCheckpointForServer,
   type DailyFritzPersistedSnapshot,
 } from './dailyFritzSessionStorage.ts';
 import { buildDailyFritzTranscript } from '../../dailyFritz/dailyFritzTranscript.ts';
@@ -88,6 +89,7 @@ export function useDailyFritzSessionPersistence({
     if (!attemptId || !verifiedMatchId) return;
     if (snapshot.checkpointRevision <= lastServerSyncRevisionRef.current) return;
     pendingServerSyncSnapshotRef.current = snapshot;
+    const serverCheckpoint = serializeDailyFritzCheckpointForServer(snapshot);
     const runSync = () => {
       pendingServerSyncSnapshotRef.current = null;
       void getAuthHeaders().then(({ headers }) => {
@@ -98,7 +100,7 @@ export function useDailyFritzSessionPersistence({
       void saveDailyFritzCheckpoint({
         attemptId,
         verifiedMatchId,
-        checkpoint: snapshot as unknown as Record<string, unknown>,
+        checkpoint: serverCheckpoint,
       }).then((response) => {
         if (response?.ok) {
           lastServerSyncRevisionRef.current = Math.max(
@@ -138,7 +140,7 @@ export function useDailyFritzSessionPersistence({
     flushDailyFritzCheckpointOnUnload({
       attemptId,
       verifiedMatchId,
-      checkpoint: snapshot as unknown as Record<string, unknown>,
+      checkpoint: serializeDailyFritzCheckpointForServer(snapshot),
       accessToken: accessTokenRef.current,
     });
   };
@@ -217,17 +219,12 @@ export function useDailyFritzSessionPersistence({
     divergenceReportedRef.current = '';
     const now = new Date().toISOString();
     const lifecyclePhase = match.gameOver ? 'completed' : match.handOver ? 'hand_transition' : 'active_hand';
-    const buildSnapshot = (): DailyFritzPersistedSnapshot => ({
-      schemaVersion: DAILY_FRITZ_SESSION_SCHEMA_VERSION,
+    const buildSnapshot = (): DailyFritzPersistedSnapshot => buildDailyFritzPersistedSnapshot(session, {
       challenge: createDailyFritzChallengeIdentity(runDate),
       classification: 'official',
       attemptId,
       runFingerprint,
-      gameNumber,
-      currentHandIndex: dailyFritzHandIndex,
-      authorityRevision,
       lifecyclePhase,
-      match,
       handResult,
       movesUsed,
       moveLog: [...moveLog],


### PR DESCRIPTION
## Summary

- **Schema 10 (client localStorage):** Checkpoints now persist `session: DailyFritzMatchSession` as the canonical blob. Denormalized top-level fields (`gameNumber`, `currentHandIndex`, `authorityRevision`, `match`) remain for one release, derived from `session` on write.
- **Schema 9 upgrade path:** Reading an existing schema-9 checkpoint upgrades it in memory to schema 10 (builds `session` from flat fields). No reset required for in-flight attempts.
- **Server wire unchanged:** `serializeDailyFritzCheckpointForServer()` strips `session` and emits schema 9 flat layout for `saveDailyFritzCheckpoint` / pagehide flush — server checkpoint policy untouched (M6 deferred).

## Audit — schema 9 shapes (pre-migration)

**Client localStorage (`DailyFritzPersistedSnapshot`, schema 9):**
- Flat cursor: `gameNumber`, `currentHandIndex`, `authorityRevision`
- Separate `match: BotMatchState`
- Plus envelope: `challenge`, `classification`, `attemptId`, `runFingerprint`, `lifecyclePhase`, `handResult`, `movesUsed`, `moveLog`, `transcript`, `verificationPhase`, `startedAt`, `lastTransitionAt`, `checkpointRevision`, optional policy fields
- G2 guard: rejects when `match.handNumber !== currentHandIndex + 1`

**Server checkpoint (`attempt.result.active_checkpoint`, schema 9):**
- Subset of client envelope: flat cursor + `match`, no `classification`, no `session`
- Server parser accepts only `schemaVersion === 9`

**Read sites updated / still compatible:**
- `parseDailyFritzPersistedSnapshot` — accepts v9 (upgrade) and v10
- `reconcileDailyFritzResume` — uses `snapshot.session` as authority
- `resolveDailyFritzMatch` / `buildDailyFritzAuthorityCursor` — prefer `persistedSnapshot.session`
- `useDailyFritzSessionPersistence` — writes v10 locally, syncs v9 to server

## What happens to an in-progress schema-9 checkpoint on next action

1. **Player returns / refreshes mid-hand:** Bootstrap reads localStorage (or server `resume_checkpoint`). `parseDailyFritzPersistedSnapshot` sees `schemaVersion: 9`, validates flat fields + G2, builds `session` in memory, returns normalized schema-10 shape. Game resumes at the same hand/scores — no data loss.
2. **Player makes a move (or any state change that triggers persistence):** `useDailyFritzSessionPersistence` writes schema **10** to localStorage (`session` + denormalized compat fields). Server sync sends schema **9** wire via `serializeDailyFritzCheckpointForServer`.
3. **Corrupt/torn checkpoint:** Same fail-closed behavior as before — parse returns `null`, reconcile rejects mismatched authority; G1/G4 guards remain (M6 not in this PR).

## Test plan

- [x] Schema 10 write → parse round-trip (localStorage JSON)
- [x] Schema 9 wire → parse upgrades to schema 10 without data loss
- [x] Corrupt schema 10 (session/cursor divergence, missing session) → fails closed
- [x] Server serialization strips `session`, emits schema 9
- [x] Full client suite: 1175 passed
- [x] `npm run build --prefix client`

## Scope guard

- Does **not** remove G1/G4 guards (M6 deferred)
- Does **not** change server attempt storage/finalize logic or server checkpoint schema


Made with [Cursor](https://cursor.com)