### PR TITLE
feat(ops): Daily Fritz health signal + checkpoint_saved fix + CI hang cap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,7 @@ jobs:
   client:
     name: Client Validation
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v5
 

--- a/client/e2e/routing.spec.ts
+++ b/client/e2e/routing.spec.ts
@@ -115,7 +115,7 @@ test.describe('browser routing', () => {
     '/tournament',
   ]) {
     test(`the shared logo returns ${path} to the current homepage without a reload`, async ({ page }) => {
-      await page.goto(path, { waitUntil: 'networkidle' });
+      await page.goto(path, { waitUntil: 'domcontentloaded' });
       const logo = page.getByRole('button', { name: 'Racehorse home' });
       await expect(logo).toBeVisible({ timeout: 15_000 });
 

--- a/client/src/AppRoutes.tsx
+++ b/client/src/AppRoutes.tsx
@@ -34,6 +34,7 @@ import {
 } from './routes/socialRoutes';
 import { TournamentRoute } from './routes/tournamentRoutes';
 import { MultiplayerRoute } from './routes/multiplayerRoute';
+import DailyFritzHealthAdminScreen from './admin/DailyFritzHealthAdminScreen';
 
 export default function AppRoutes({
   shell,
@@ -167,6 +168,10 @@ export default function AppRoutes({
     return (
       <TournamentRoute shell={shell} navigation={navigation} auth={auth} tournament={tournamentProps} />
     );
+  }
+
+  if (appMode === 'dailyFritzHealthAdmin') {
+    return <DailyFritzHealthAdminScreen />;
   }
 
   if (appMode === 'multiplayer') {

--- a/client/src/admin/DailyFritzHealthAdminScreen.tsx
+++ b/client/src/admin/DailyFritzHealthAdminScreen.tsx
@@ -1,0 +1,152 @@
+import { useEffect, useMemo, useState } from 'react';
+import { resolveGameServerUrl } from '../lib/gameServerUrl';
+
+type DayMetrics = {
+  runDate: string;
+  attemptsStarted: number;
+  attemptsCompleted: number;
+  completionRate: number;
+  verificationFailed: number;
+  verificationFailureRate: number;
+  requestFailed: number;
+  legacyUnverifiedCompletions: number;
+  unrankedCompletionRate: number;
+  recoveryStarted: number;
+  recoveryFailed: number;
+  firstMoveCount: number;
+};
+
+type HealthResponse = {
+  ok: boolean;
+  run_date: string;
+  compared_to: string;
+  status: 'healthy' | 'degraded' | 'critical';
+  today: DayMetrics;
+  yesterday: DayMetrics;
+  deltas: {
+    completionRatePctPoints: number;
+    verificationFailureRatePctPoints: number;
+    requestFailedDelta: number;
+    attemptsStartedDelta: number;
+  };
+  top_failures: Array<{ verifierCode: string | null; total: number }>;
+  error?: string;
+};
+
+function pct(value: number): string {
+  return `${(value * 100).toFixed(1)}%`;
+}
+
+function statusColor(status: HealthResponse['status']): string {
+  if (status === 'healthy') return '#2f9e44';
+  if (status === 'degraded') return '#e67700';
+  return '#c92a2a';
+}
+
+export default function DailyFritzHealthAdminScreen() {
+  const adminKey = useMemo(
+    () => new URLSearchParams(window.location.search).get('admin_key')?.trim() ?? '',
+    [],
+  );
+  const [health, setHealth] = useState<HealthResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!adminKey) {
+      setError('Add ?admin_key=YOUR_ADMIN_SECRET to the URL.');
+      return;
+    }
+    setLoading(true);
+    const url = new URL(`${resolveGameServerUrl()}/api/daily-fritz/health`);
+    url.searchParams.set('admin_key', adminKey);
+    void fetch(url.toString())
+      .then(async (response) => {
+        const body = await response.json() as HealthResponse;
+        if (!response.ok) {
+          throw new Error(body.error ?? `HTTP ${response.status}`);
+        }
+        setHealth(body);
+        setError(null);
+      })
+      .catch((err: unknown) => {
+        setHealth(null);
+        setError(err instanceof Error ? err.message : String(err));
+      })
+      .finally(() => setLoading(false));
+  }, [adminKey]);
+
+  return (
+    <div style={{ padding: '24px', fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace', color: '#e9ecef', background: '#0b1220', minHeight: '100dvh' }}>
+      <h1 style={{ margin: '0 0 8px', fontSize: '20px' }}>Daily Fritz Health</h1>
+      <p style={{ margin: '0 0 20px', color: '#9aa5b1' }}>
+        Pacific run_date snapshot vs yesterday. Bookmark with <code>?admin_key=...</code>
+      </p>
+      {loading && <p>Loading…</p>}
+      {error && <p style={{ color: '#ff6b6b' }}>{error}</p>}
+      {health && (
+        <>
+          <div style={{ display: 'flex', gap: '12px', alignItems: 'center', marginBottom: '20px' }}>
+            <span style={{
+              padding: '4px 10px',
+              borderRadius: '999px',
+              background: statusColor(health.status),
+              color: '#fff',
+              fontWeight: 700,
+              textTransform: 'uppercase',
+              fontSize: '12px',
+            }}>
+              {health.status}
+            </span>
+            <span>Today: {health.run_date}</span>
+            <span>vs {health.compared_to}</span>
+          </div>
+          <table style={{ width: '100%', borderCollapse: 'collapse', marginBottom: '24px' }}>
+            <thead>
+              <tr>
+                <th style={{ textAlign: 'left', padding: '8px', borderBottom: '1px solid #334155' }}>Metric</th>
+                <th style={{ textAlign: 'right', padding: '8px', borderBottom: '1px solid #334155' }}>Today</th>
+                <th style={{ textAlign: 'right', padding: '8px', borderBottom: '1px solid #334155' }}>Yesterday</th>
+                <th style={{ textAlign: 'right', padding: '8px', borderBottom: '1px solid #334155' }}>Delta</th>
+              </tr>
+            </thead>
+            <tbody>
+              {[
+                ['Attempts started', health.today.attemptsStarted, health.yesterday.attemptsStarted, `${health.deltas.attemptsStartedDelta >= 0 ? '+' : ''}${health.deltas.attemptsStartedDelta}`],
+                ['Completions', health.today.attemptsCompleted, health.yesterday.attemptsCompleted, '—'],
+                ['Completion rate', pct(health.today.completionRate), pct(health.yesterday.completionRate), `${health.deltas.completionRatePctPoints >= 0 ? '+' : ''}${health.deltas.completionRatePctPoints.toFixed(1)} pp`],
+                ['Verification failures', health.today.verificationFailed, health.yesterday.verificationFailed, '—'],
+                ['Verification reject rate', pct(health.today.verificationFailureRate), pct(health.yesterday.verificationFailureRate), `${health.deltas.verificationFailureRatePctPoints >= 0 ? '+' : ''}${health.deltas.verificationFailureRatePctPoints.toFixed(1)} pp`],
+                ['Request failures', health.today.requestFailed, health.yesterday.requestFailed, `${health.deltas.requestFailedDelta >= 0 ? '+' : ''}${health.deltas.requestFailedDelta}`],
+                ['Legacy unverified completions', health.today.legacyUnverifiedCompletions, health.yesterday.legacyUnverifiedCompletions, '—'],
+                ['Unranked completion rate', pct(health.today.unrankedCompletionRate), pct(health.yesterday.unrankedCompletionRate), '—'],
+                ['Recovery started', health.today.recoveryStarted, health.yesterday.recoveryStarted, '—'],
+                ['Recovery failed', health.today.recoveryFailed, health.yesterday.recoveryFailed, '—'],
+                ['First moves', health.today.firstMoveCount, health.yesterday.firstMoveCount, '—'],
+              ].map(([label, today, yesterday, delta]) => (
+                <tr key={label}>
+                  <td style={{ padding: '8px', borderBottom: '1px solid #1e293b' }}>{label}</td>
+                  <td style={{ padding: '8px', textAlign: 'right', borderBottom: '1px solid #1e293b' }}>{today}</td>
+                  <td style={{ padding: '8px', textAlign: 'right', borderBottom: '1px solid #1e293b' }}>{yesterday}</td>
+                  <td style={{ padding: '8px', textAlign: 'right', borderBottom: '1px solid #1e293b' }}>{delta}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          <h2 style={{ fontSize: '16px', marginBottom: '8px' }}>Top failures today</h2>
+          {health.top_failures.length === 0 ? (
+            <p style={{ color: '#9aa5b1' }}>None recorded.</p>
+          ) : (
+            <ul style={{ margin: 0, paddingLeft: '20px' }}>
+              {health.top_failures.map((row) => (
+                <li key={`${row.verifierCode ?? 'none'}:${row.total}`}>
+                  {row.verifierCode ?? 'unknown'} — {row.total}
+                </li>
+              ))}
+            </ul>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/client/src/admin/DailyFritzHealthAdminScreen.tsx
+++ b/client/src/admin/DailyFritzHealthAdminScreen.tsx
@@ -1,5 +1,7 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { resolveGameServerUrl } from '../lib/gameServerUrl';
+
+const ADMIN_KEY_STORAGE = 'racehorse:daily-fritz-admin-key';
 
 type DayMetrics = {
   runDate: string;
@@ -43,45 +45,200 @@ function statusColor(status: HealthResponse['status']): string {
   return '#c92a2a';
 }
 
+function readStoredAdminKey(): string {
+  try {
+    return window.sessionStorage.getItem(ADMIN_KEY_STORAGE)?.trim() ?? '';
+  } catch {
+    return '';
+  }
+}
+
+function persistAdminKey(key: string): void {
+  try {
+    window.sessionStorage.setItem(ADMIN_KEY_STORAGE, key);
+  } catch {
+    /* sessionStorage may be unavailable */
+  }
+}
+
+function clearStoredAdminKey(): void {
+  try {
+    window.sessionStorage.removeItem(ADMIN_KEY_STORAGE);
+  } catch {
+    /* sessionStorage may be unavailable */
+  }
+}
+
+/** One-time migration: legacy bookmarks may still carry ?admin_key= in the URL. */
+function consumeLegacyUrlAdminKey(): string {
+  const params = new URLSearchParams(window.location.search);
+  const fromUrl = params.get('admin_key')?.trim() ?? '';
+  if (!fromUrl) return '';
+  persistAdminKey(fromUrl);
+  params.delete('admin_key');
+  const nextSearch = params.toString();
+  const nextUrl = `${window.location.pathname}${nextSearch ? `?${nextSearch}` : ''}${window.location.hash}`;
+  window.history.replaceState(null, '', nextUrl);
+  return fromUrl;
+}
+
+function resolveInitialAdminKey(): string {
+  const legacy = consumeLegacyUrlAdminKey();
+  return legacy || readStoredAdminKey();
+}
+
+async function fetchDailyFritzHealth(key: string): Promise<HealthResponse> {
+  const url = new URL(`${resolveGameServerUrl()}/api/daily-fritz/health`);
+  const response = await fetch(url.toString(), {
+    headers: { 'x-admin-secret': key },
+  });
+  const body = await response.json() as HealthResponse;
+  if (!response.ok) {
+    throw new Error(body.error ?? `HTTP ${response.status}`);
+  }
+  return body;
+}
+
 export default function DailyFritzHealthAdminScreen() {
-  const adminKey = useMemo(
-    () => new URLSearchParams(window.location.search).get('admin_key')?.trim() ?? '',
-    [],
-  );
+  const [adminKey, setAdminKey] = useState(resolveInitialAdminKey);
+  const [draftKey, setDraftKey] = useState('');
   const [health, setHealth] = useState<HealthResponse | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
 
-  useEffect(() => {
-    if (!adminKey) {
-      setError('Add ?admin_key=YOUR_ADMIN_SECRET to the URL.');
-      return;
-    }
-    setLoading(true);
-    const url = new URL(`${resolveGameServerUrl()}/api/daily-fritz/health`);
-    url.searchParams.set('admin_key', adminKey);
-    void fetch(url.toString())
-      .then(async (response) => {
-        const body = await response.json() as HealthResponse;
-        if (!response.ok) {
-          throw new Error(body.error ?? `HTTP ${response.status}`);
-        }
-        setHealth(body);
-        setError(null);
-      })
-      .catch((err: unknown) => {
+  const refreshHealth = useCallback((key: string) => {
+    void (async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        setHealth(await fetchDailyFritzHealth(key));
+      } catch (err: unknown) {
         setHealth(null);
         setError(err instanceof Error ? err.message : String(err));
-      })
-      .finally(() => setLoading(false));
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, []);
+
+  useEffect(() => {
+    if (!adminKey) return;
+    let cancelled = false;
+    void (async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const data = await fetchDailyFritzHealth(adminKey);
+        if (!cancelled) setHealth(data);
+      } catch (err: unknown) {
+        if (!cancelled) {
+          setHealth(null);
+          setError(err instanceof Error ? err.message : String(err));
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
   }, [adminKey]);
+
+  const handleUnlock = (event: React.FormEvent) => {
+    event.preventDefault();
+    const trimmed = draftKey.trim();
+    if (!trimmed) return;
+    persistAdminKey(trimmed);
+    setAdminKey(trimmed);
+    setDraftKey('');
+  };
+
+  const handleSignOut = () => {
+    clearStoredAdminKey();
+    setAdminKey('');
+    setHealth(null);
+    setError(null);
+    setLoading(false);
+  };
 
   return (
     <div style={{ padding: '24px', fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace', color: '#e9ecef', background: '#0b1220', minHeight: '100dvh' }}>
       <h1 style={{ margin: '0 0 8px', fontSize: '20px' }}>Daily Fritz Health</h1>
       <p style={{ margin: '0 0 20px', color: '#9aa5b1' }}>
-        Pacific run_date snapshot vs yesterday. Bookmark with <code>?admin_key=...</code>
+        Pacific run_date snapshot vs yesterday. Admin key stays in this tab&apos;s sessionStorage — not the URL.
       </p>
+
+      {!adminKey && (
+        <form onSubmit={handleUnlock} style={{ marginBottom: '20px', maxWidth: '420px' }}>
+          <label htmlFor="admin-key-input" style={{ display: 'block', marginBottom: '8px', color: '#cbd5e1' }}>
+            Admin secret
+          </label>
+          <input
+            id="admin-key-input"
+            type="password"
+            autoComplete="off"
+            value={draftKey}
+            onChange={(event) => setDraftKey(event.target.value)}
+            style={{
+              width: '100%',
+              padding: '10px 12px',
+              marginBottom: '10px',
+              borderRadius: '6px',
+              border: '1px solid #334155',
+              background: '#111827',
+              color: '#e9ecef',
+            }}
+          />
+          <button
+            type="submit"
+            style={{
+              padding: '8px 14px',
+              borderRadius: '6px',
+              border: '1px solid #475569',
+              background: '#1e293b',
+              color: '#f8fafc',
+              cursor: 'pointer',
+            }}
+          >
+            Unlock dashboard
+          </button>
+        </form>
+      )}
+
+      {adminKey && (
+        <div style={{ marginBottom: '16px', display: 'flex', gap: '12px', alignItems: 'center' }}>
+          <button
+            type="button"
+            onClick={() => refreshHealth(adminKey)}
+            disabled={loading}
+            style={{
+              padding: '6px 12px',
+              borderRadius: '6px',
+              border: '1px solid #475569',
+              background: '#1e293b',
+              color: '#f8fafc',
+              cursor: 'pointer',
+            }}
+          >
+            Refresh
+          </button>
+          <button
+            type="button"
+            onClick={handleSignOut}
+            style={{
+              padding: '6px 12px',
+              borderRadius: '6px',
+              border: '1px solid #475569',
+              background: 'transparent',
+              color: '#94a3b8',
+              cursor: 'pointer',
+            }}
+          >
+            Clear key
+          </button>
+        </div>
+      )}
+
       {loading && <p>Loading…</p>}
       {error && <p style={{ color: '#ff6b6b' }}>{error}</p>}
       {health && (

--- a/client/src/appRouteTypes.ts
+++ b/client/src/appRouteTypes.ts
@@ -48,7 +48,8 @@ export type AppMode =
   | 'leaderboard'
   | 'profile'
   | 'feed'
-  | 'live';
+  | 'live'
+  | 'dailyFritzHealthAdmin';
 
 /** Shell chrome: auth-modal wrapper, fallback host, layout class, invite overlay. */
 export type AppRoutesShellProps = {

--- a/client/src/routing/appRoutePath.ts
+++ b/client/src/routing/appRoutePath.ts
@@ -40,6 +40,7 @@ const STATIC_PATHS: Record<string, AppRouteResolution> = {
   '/multiplayer': { mode: 'multiplayer', multiplayerView: 'quick' },
   '/multiplayer/private': { mode: 'multiplayer', multiplayerView: 'private' },
   '/social': { mode: 'feed' },
+  '/admin/daily-fritz-health': { mode: 'dailyFritzHealthAdmin' },
 };
 
 function normalizePathname(pathname: string): string {
@@ -116,6 +117,7 @@ export function buildAppPath(state: AppPathState): string {
     guidedMatchAnnotator: '/learn/guided-annotator',
     feed: '/social',
     leaderboard: '/social',
+    dailyFritzHealthAdmin: '/admin/daily-fritz-health',
   };
 
   // Active Fritz, Ghost, and Journey trial matches intentionally retain the

--- a/client/src/screens/HomeScreen.tsx
+++ b/client/src/screens/HomeScreen.tsx
@@ -32,7 +32,8 @@ type AppMode =
   | 'leaderboard'
   | 'profile'
   | 'feed'
-  | 'live';
+  | 'live'
+  | 'dailyFritzHealthAdmin';
 
 // These reference CSS custom property values from tokens.css — keep in sync if tokens change.
 const TOKEN = {

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -102,4 +102,5 @@ export type AppMode =
   | 'leaderboard'
   | 'profile'
   | 'feed'
-  | 'live';
+  | 'live'
+  | 'dailyFritzHealthAdmin';

--- a/server/src/dailyFritzTelemetry.test.ts
+++ b/server/src/dailyFritzTelemetry.test.ts
@@ -12,6 +12,10 @@ describe('Daily Fritz telemetry contract', () => {
     expect(isDailyFritzEventType('made_up_event')).toBe(false);
   });
 
+  it('allows checkpoint_saved in the canonical event taxonomy', () => {
+    expect(isDailyFritzEventType('checkpoint_saved')).toBe(true);
+  });
+
   it.each([
     ['stale_revision', 'command', 'authoritative_refresh'],
     ['authority_contract_unsupported', 'challenge', 'client_update_required'],

--- a/server/src/dbIdempotencySchema.test.ts
+++ b/server/src/dbIdempotencySchema.test.ts
@@ -285,6 +285,14 @@ describe('DB idempotency schema guardrails', () => {
     expect(sql).toContain('idx_daily_fritz_events_user_retention');
   });
 
+  it('allows checkpoint_saved in daily_fritz_events event taxonomy', () => {
+    const sql = compactSql(readRepoFile(
+      'supabase/migrations/2026-08-20_daily_fritz_events_checkpoint_saved.sql',
+    ));
+    expect(sql).toContain("'checkpoint_saved'");
+    expect(sql).toContain('daily_fritz_events_event_type_check');
+  });
+
   it('ships Fritz Challenge canonical funnel and failure metrics', () => {
     const sql = compactSql(readRepoFile(
       'supabase/migrations/2026-08-02_fritz_challenge_canonical_telemetry.sql',

--- a/server/src/http/routes/dailyFritzAdminRoutes.ts
+++ b/server/src/http/routes/dailyFritzAdminRoutes.ts
@@ -21,6 +21,13 @@ import {
   upsertDailyFritzRun,
 } from '../stores/dailyFritzStore';
 import { listDailyFritzEvents, listDailyFritzPersistedMetrics, recordDailyFritzEvent } from '../stores/dailyFritzEventStore';
+import {
+  buildDailyFritzHealthDeltas,
+  formatDailyFritzRunDatePacific,
+  listDailyFritzHealthSummary,
+  previousDailyFritzRunDate,
+} from '../stores/dailyFritzHealthSummary';
+import { evaluateDailyFritzHealthStatus } from './dailyFritzHealthPolicy';
 import { getDailyFritzMetricRates, getDailyFritzMetrics, incrementDailyFritzMetric } from './dailyFritzMetrics';
 import { buildDailyFritzPublishedChallenge } from '../../dailyFritzPublishedChallenge';
 import {
@@ -111,6 +118,44 @@ export function registerDailyFritzAdminRoutes(app: Application): void {
     rates: getDailyFritzMetricRates(),
     persisted_metrics: persistedMetrics,
   });
+  });
+
+  app.get('/api/daily-fritz/health', async (req, res) => {
+    const suppliedAdminSecret = req.get('x-admin-secret') ?? req.query.admin_key;
+    if (!isAdminSecret(suppliedAdminSecret)) {
+      res.status(401).json({ error: 'Unauthorized' });
+      return;
+    }
+    const requestedRunDate = typeof req.query.run_date === 'string' ? req.query.run_date.trim() : '';
+    const runDate = /^\d{4}-\d{2}-\d{2}$/.test(requestedRunDate)
+      ? requestedRunDate
+      : formatDailyFritzRunDatePacific();
+    const comparedTo = previousDailyFritzRunDate(runDate);
+    try {
+      const todaySummary = await listDailyFritzHealthSummary(runDate);
+      const yesterdaySummary = await listDailyFritzHealthSummary(comparedTo);
+      const deltas = buildDailyFritzHealthDeltas(todaySummary.metrics, yesterdaySummary.metrics);
+      const status = evaluateDailyFritzHealthStatus(
+        todaySummary.metrics,
+        yesterdaySummary.metrics,
+        deltas,
+      );
+      res.json({
+        ok: true,
+        run_date: runDate,
+        compared_to: comparedTo,
+        status,
+        today: todaySummary.metrics,
+        yesterday: yesterdaySummary.metrics,
+        deltas,
+        top_failures: todaySummary.topFailures,
+      });
+    } catch (error) {
+      capture500(error, { route: 'health' });
+      res.status(500).json({
+        error: prodSafeError(error, 'Daily Fritz health summary is unavailable.'),
+      });
+    }
   });
 
   app.get('/api/daily-fritz/events/:attemptId', async (req, res) => {

--- a/server/src/http/routes/dailyFritzCompletionRoutes.ts
+++ b/server/src/http/routes/dailyFritzCompletionRoutes.ts
@@ -79,6 +79,7 @@ export function registerDailyFritzCompletionRoutes(app: Application): void {
     }
     if (attempt.status === 'completed') {
       incrementDailyFritzMetric('retry_request');
+      const replayVerificationStatus = getDailyFritzVerificationStatus(attempt.result);
       await recordDailyFritzEventBestEffort({
         attemptId,
         runDate: attempt.runDate,
@@ -86,7 +87,7 @@ export function registerDailyFritzCompletionRoutes(app: Application): void {
         requestId: diagnostics.requestId,
         eventType: 'attempt_completed',
         idempotencyKey: `${attemptId}:attempt_completed:replay:${diagnostics.requestId}`,
-        payload: { replayed: true },
+        payload: { replayed: true, verification_status: replayVerificationStatus },
       });
       const leaderboard = await buildDailyFritzLeaderboard(runDate);
       const isVerified = getDailyFritzVerificationStatus(attempt.result) === 'verified';
@@ -117,6 +118,7 @@ export function registerDailyFritzCompletionRoutes(app: Application): void {
     // every other game produced a complete authority record.
     const isVerified = getDailyFritzVerificationStatus(attempt.result) !== 'rejected'
       && hasCompleteDailyFritzGameAuthority(attempt.result, setResult);
+    const completionVerificationStatus = isVerified ? 'verified' : 'legacy_unverified';
     if (!canFinalizeDailyFritzAttempt(attempt.result, setResult)) {
       res.status(409).json({ error: 'Daily Fritz verification is incomplete.' });
       return;
@@ -191,6 +193,7 @@ export function registerDailyFritzCompletionRoutes(app: Application): void {
           eventType: 'attempt_completed',
           payload: {
             verified: isVerified,
+            verification_status: completionVerificationStatus,
             finalScore: attempt.finalScore,
             opponentScore: attempt.opponentScore,
             setOutcome: `${attempt.finalScore}-${attempt.opponentScore}`,
@@ -228,6 +231,7 @@ export function registerDailyFritzCompletionRoutes(app: Application): void {
       idempotencyKey: `${attemptId}:attempt_completed:${serverReceipt}`,
       payload: {
         verified: isVerified,
+        verification_status: completionVerificationStatus,
         finalScore: attempt.finalScore,
         opponentScore: attempt.opponentScore,
         movesUsed: attempt.movesUsed,

--- a/server/src/http/routes/dailyFritzHealthPolicy.test.ts
+++ b/server/src/http/routes/dailyFritzHealthPolicy.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DAILY_FRITZ_HEALTH_THRESHOLDS,
+  evaluateDailyFritzHealthStatus,
+  type DailyFritzDayHealthMetrics,
+} from './dailyFritzHealthPolicy';
+
+function day(overrides: Partial<DailyFritzDayHealthMetrics> = {}): DailyFritzDayHealthMetrics {
+  return {
+    runDate: '2026-08-19',
+    attemptsStarted: 100,
+    attemptsCompleted: 70,
+    completionRate: 0.7,
+    verificationFailed: 2,
+    handVerified: 98,
+    verificationFailureRate: 0.02,
+    requestFailed: 0,
+    legacyUnverifiedCompletions: 3,
+    unrankedCompletionRate: 0.043,
+    recoveryStarted: 1,
+    recoveryFailed: 0,
+    firstMoveCount: 95,
+    ...overrides,
+  };
+}
+
+describe('evaluateDailyFritzHealthStatus', () => {
+  it('returns healthy when metrics are within thresholds', () => {
+    const today = day();
+    const yesterday = day({ completionRate: 0.72, verificationFailureRate: 0.02 });
+    const deltas = { completionRatePctPoints: -2, verificationFailureRatePctPoints: 0, requestFailedDelta: 0, attemptsStartedDelta: 0 };
+    expect(evaluateDailyFritzHealthStatus(today, yesterday, deltas)).toBe('healthy');
+  });
+
+  it('returns critical when request_failed exceeds the critical threshold', () => {
+    const today = day({ requestFailed: DAILY_FRITZ_HEALTH_THRESHOLDS.REQUEST_FAILED_CRITICAL + 1 });
+    const yesterday = day();
+    const deltas = { completionRatePctPoints: 0, verificationFailureRatePctPoints: 0, requestFailedDelta: 6, attemptsStartedDelta: 0 };
+    expect(evaluateDailyFritzHealthStatus(today, yesterday, deltas)).toBe('critical');
+  });
+
+  it('returns critical when completion rate collapses vs yesterday with enough sample', () => {
+    const yesterday = day({ completionRate: 0.8 });
+    const today = day({
+      attemptsStarted: DAILY_FRITZ_HEALTH_THRESHOLDS.MIN_SAMPLE_ATTEMPTS_STARTED,
+      completionRate: 0.3,
+    });
+    const deltas = { completionRatePctPoints: -50, verificationFailureRatePctPoints: 0, requestFailedDelta: 0, attemptsStartedDelta: 0 };
+    expect(evaluateDailyFritzHealthStatus(today, yesterday, deltas)).toBe('critical');
+  });
+
+  it('returns degraded when unranked completion rate is elevated', () => {
+    const today = day({
+      unrankedCompletionRate: DAILY_FRITZ_HEALTH_THRESHOLDS.UNRANKED_COMPLETION_RATE_DEGRADED + 0.05,
+      legacyUnverifiedCompletions: 12,
+      attemptsCompleted: 50,
+    });
+    const yesterday = day();
+    const deltas = { completionRatePctPoints: 0, verificationFailureRatePctPoints: 0, requestFailedDelta: 0, attemptsStartedDelta: 0 };
+    expect(evaluateDailyFritzHealthStatus(today, yesterday, deltas)).toBe('degraded');
+  });
+});

--- a/server/src/http/routes/dailyFritzHealthPolicy.ts
+++ b/server/src/http/routes/dailyFritzHealthPolicy.ts
@@ -1,0 +1,75 @@
+export type DailyFritzHealthStatus = 'healthy' | 'degraded' | 'critical';
+
+/** Tunable health thresholds — adjust after observing production baselines. */
+export const DAILY_FRITZ_HEALTH_THRESHOLDS = {
+  /** request_failed count above this → critical. */
+  REQUEST_FAILED_CRITICAL: 5,
+  /** verification_failure_rate above yesterday × this multiplier → critical. */
+  VERIFICATION_FAILURE_RATE_MULTIPLIER_CRITICAL: 2,
+  /** completion_rate below yesterday × this ratio → critical (with min sample). */
+  COMPLETION_RATE_YESTERDAY_RATIO_CRITICAL: 0.5,
+  /** Minimum attempts_started before completion-rate drop can trigger critical. */
+  MIN_SAMPLE_ATTEMPTS_STARTED: 10,
+  /** request_failed delta above this → degraded. */
+  REQUEST_FAILED_DEGRADED_DELTA: 2,
+  /** verification_failure_rate absolute above this → degraded. */
+  VERIFICATION_FAILURE_RATE_DEGRADED: 0.05,
+  /** completion_rate drop vs yesterday above this percentage points → degraded. */
+  COMPLETION_RATE_DROP_DEGRADED_PP: 15,
+  /** unranked_completion_rate above this → degraded. */
+  UNRANKED_COMPLETION_RATE_DEGRADED: 0.1,
+};
+
+export type DailyFritzDayHealthMetrics = {
+  runDate: string;
+  attemptsStarted: number;
+  attemptsCompleted: number;
+  completionRate: number;
+  verificationFailed: number;
+  handVerified: number;
+  verificationFailureRate: number;
+  requestFailed: number;
+  legacyUnverifiedCompletions: number;
+  unrankedCompletionRate: number;
+  recoveryStarted: number;
+  recoveryFailed: number;
+  firstMoveCount: number;
+};
+
+export type DailyFritzHealthDeltas = {
+  completionRatePctPoints: number;
+  verificationFailureRatePctPoints: number;
+  requestFailedDelta: number;
+  attemptsStartedDelta: number;
+};
+
+export function evaluateDailyFritzHealthStatus(
+  today: DailyFritzDayHealthMetrics,
+  yesterday: DailyFritzDayHealthMetrics,
+  deltas: DailyFritzHealthDeltas,
+): DailyFritzHealthStatus {
+  const t = DAILY_FRITZ_HEALTH_THRESHOLDS;
+
+  if (today.requestFailed > t.REQUEST_FAILED_CRITICAL) return 'critical';
+  if (
+    yesterday.verificationFailureRate > 0
+    && today.verificationFailureRate > yesterday.verificationFailureRate * t.VERIFICATION_FAILURE_RATE_MULTIPLIER_CRITICAL
+  ) {
+    return 'critical';
+  }
+  if (
+    today.attemptsStarted >= t.MIN_SAMPLE_ATTEMPTS_STARTED
+    && yesterday.completionRate > 0
+    && today.completionRate < yesterday.completionRate * t.COMPLETION_RATE_YESTERDAY_RATIO_CRITICAL
+  ) {
+    return 'critical';
+  }
+
+  if (deltas.requestFailedDelta > t.REQUEST_FAILED_DEGRADED_DELTA) return 'degraded';
+  if (today.verificationFailureRate > t.VERIFICATION_FAILURE_RATE_DEGRADED) return 'degraded';
+  if (deltas.completionRatePctPoints < -t.COMPLETION_RATE_DROP_DEGRADED_PP) return 'degraded';
+  if (today.unrankedCompletionRate > t.UNRANKED_COMPLETION_RATE_DEGRADED) return 'degraded';
+  if (today.recoveryFailed > today.recoveryStarted && today.recoveryStarted > 0) return 'degraded';
+
+  return 'healthy';
+}

--- a/server/src/http/routes/dailyFritzHealthRoute.test.ts
+++ b/server/src/http/routes/dailyFritzHealthRoute.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const { listHealthSummaryMock } = vi.hoisted(() => ({
+  listHealthSummaryMock: vi.fn(),
+}));
+
+vi.mock('../stores/dailyFritzHealthSummary', async () => {
+  const actual = await vi.importActual<typeof import('../stores/dailyFritzHealthSummary')>(
+    '../stores/dailyFritzHealthSummary',
+  );
+  return {
+    ...actual,
+    listDailyFritzHealthSummary: listHealthSummaryMock,
+    formatDailyFritzRunDatePacific: () => '2026-08-19',
+    previousDailyFritzRunDate: (runDate: string) => {
+      if (runDate === '2026-08-19') return '2026-08-18';
+      return '2026-08-17';
+    },
+  };
+});
+
+import { registerDailyFritzRoutes } from './dailyFritz';
+import type { Application } from 'express';
+
+type Handler = (req: unknown, res: unknown) => unknown | Promise<unknown>;
+
+function makeHarness() {
+  const routes = new Map<string, Handler>();
+  const app = {
+    get(path: string, handler: Handler) { routes.set(`GET ${path}`, handler); },
+    post(path: string, handler: Handler) { routes.set(`POST ${path}`, handler); },
+  };
+  registerDailyFritzRoutes(app as unknown as Application);
+
+  return async function request(
+    method: 'GET' | 'POST',
+    path: string,
+    input: {
+      adminSecret?: string;
+      query?: Record<string, string>;
+    } = {},
+  ) {
+    const handler = routes.get(`${method} ${path}`);
+    if (!handler) throw new Error(`Missing route ${method} ${path}`);
+    let status = 200;
+    let body: unknown;
+    const res = {
+      status(code: number) { status = code; return res; },
+      json(value: unknown) { body = value; return res; },
+    };
+    await handler({
+      headers: input.adminSecret ? { 'x-admin-secret': input.adminSecret } : {},
+      params: {},
+      query: input.query ?? {},
+      body: {},
+      method,
+      path,
+      get(name: string) { return name.toLowerCase() === 'x-admin-secret' ? input.adminSecret : undefined; },
+    }, res);
+    return { status, body };
+  };
+}
+
+describe('GET /api/daily-fritz/health', () => {
+  afterEach(() => {
+    delete process.env.ADMIN_SECRET;
+    listHealthSummaryMock.mockReset();
+  });
+
+  it('requires the admin secret', async () => {
+    process.env.ADMIN_SECRET = 'test-admin-secret';
+    const request = makeHarness();
+    await expect(request('GET', '/api/daily-fritz/health')).resolves.toMatchObject({ status: 401 });
+  });
+
+  it('returns today vs yesterday health with status heuristic', async () => {
+    process.env.ADMIN_SECRET = 'test-admin-secret';
+    listHealthSummaryMock.mockImplementation(async (runDate: string) => ({
+      metrics: {
+        runDate,
+        attemptsStarted: runDate === '2026-08-19' ? 120 : 100,
+        attemptsCompleted: runDate === '2026-08-19' ? 80 : 75,
+        completionRate: runDate === '2026-08-19' ? 0.667 : 0.75,
+        verificationFailed: 2,
+        handVerified: 90,
+        verificationFailureRate: 0.022,
+        requestFailed: 1,
+        legacyUnverifiedCompletions: 4,
+        unrankedCompletionRate: 0.05,
+        recoveryStarted: 1,
+        recoveryFailed: 0,
+        firstMoveCount: 110,
+      },
+      topFailures: [{ verifierCode: 'stale_revision', total: 2 }],
+    }));
+    const request = makeHarness();
+    const response = await request('GET', '/api/daily-fritz/health', {
+      adminSecret: 'test-admin-secret',
+      query: { run_date: '2026-08-19' },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      ok: true,
+      run_date: '2026-08-19',
+      compared_to: '2026-08-18',
+      status: 'healthy',
+      today: { attemptsStarted: 120, completionRate: 0.667 },
+      yesterday: { attemptsStarted: 100, completionRate: 0.75 },
+      top_failures: [{ verifierCode: 'stale_revision', total: 2 }],
+    });
+    expect(listHealthSummaryMock).toHaveBeenCalledWith('2026-08-19');
+    expect(listHealthSummaryMock).toHaveBeenCalledWith('2026-08-18');
+  });
+});

--- a/server/src/http/stores/dailyFritzEventStore.test.ts
+++ b/server/src/http/stores/dailyFritzEventStore.test.ts
@@ -112,6 +112,21 @@ describe('Daily Fritz event store', () => {
     expect(secondBody).toBe(firstBody);
   });
 
+  it('writes checkpoint_saved events for operational analytics', async () => {
+    vi.mocked(supabaseFetch).mockResolvedValue(undefined);
+    await recordDailyFritzEvent({
+      attemptId: 'attempt-1',
+      runDate: '2026-07-31',
+      userId: 'user-1',
+      eventType: 'checkpoint_saved',
+      idempotencyKey: 'attempt-1:checkpoint:12',
+      payload: { checkpointRevision: 12, handIndex: 2 },
+    });
+    const body = JSON.parse(String(vi.mocked(supabaseFetch).mock.calls[0]?.[1]?.body))[0];
+    expect(body.event_type).toBe('checkpoint_saved');
+    expect(body.idempotency_key).toBe('attempt-1:checkpoint:12');
+  });
+
   it('writes canonical dimensions only after the authority schema is enabled', async () => {
     vi.mocked(supabaseFetch).mockResolvedValue(undefined);
     process.env.DAILY_FRITZ_TRANSACTIONAL_COMMANDS = 'true';

--- a/server/src/http/stores/dailyFritzHealthSummary.ts
+++ b/server/src/http/stores/dailyFritzHealthSummary.ts
@@ -1,0 +1,121 @@
+import { supabaseFetch } from '../../supabaseUtils';
+import type { DailyFritzDayHealthMetrics } from '../routes/dailyFritzHealthPolicy';
+
+type FunnelRow = { event_type: string; total: number };
+type FailureRow = { verifier_code: string | null; total: number };
+type CompletedAttemptRow = { result: Record<string, unknown> | null };
+
+function sumEventCounts(rows: FunnelRow[]): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const row of rows) {
+    const eventType = String(row.event_type);
+    counts.set(eventType, (counts.get(eventType) ?? 0) + (Number(row.total) || 0));
+  }
+  return counts;
+}
+
+function rate(numerator: number, denominator: number): number {
+  return denominator === 0 ? 0 : numerator / denominator;
+}
+
+function buildDayMetrics(
+  runDate: string,
+  funnelRows: FunnelRow[],
+  failureRows: FailureRow[],
+  legacyUnverifiedCompletions: number,
+): DailyFritzDayHealthMetrics {
+  const eventCounts = sumEventCounts(funnelRows);
+  const attemptsStarted = eventCounts.get('attempt_started') ?? 0;
+  const attemptsCompleted = eventCounts.get('attempt_completed') ?? 0;
+  const verificationFailed = eventCounts.get('verification_failed') ?? 0;
+  const handVerified = eventCounts.get('hand_verified') ?? 0;
+  const requestFailed = eventCounts.get('request_failed') ?? 0;
+  const recoveryStarted = eventCounts.get('recovery_started') ?? 0;
+  const recoveryFailed = eventCounts.get('recovery_failed') ?? 0;
+  const firstMoveCount = eventCounts.get('first_move') ?? 0;
+
+  return {
+    runDate,
+    attemptsStarted,
+    attemptsCompleted,
+    completionRate: rate(attemptsCompleted, attemptsStarted),
+    verificationFailed,
+    handVerified,
+    verificationFailureRate: rate(verificationFailed, handVerified + verificationFailed),
+    requestFailed,
+    legacyUnverifiedCompletions,
+    unrankedCompletionRate: rate(legacyUnverifiedCompletions, attemptsCompleted),
+    recoveryStarted,
+    recoveryFailed,
+    firstMoveCount,
+  };
+}
+
+async function countLegacyUnverifiedCompletions(runDate: string): Promise<number> {
+  const rows = await supabaseFetch<CompletedAttemptRow[]>(
+    `/rest/v1/daily_fritz_attempts?run_date=eq.${encodeURIComponent(runDate)}&status=eq.completed&select=result`,
+    { method: 'GET' },
+  );
+  return rows.filter((row) => row.result?.verification_status === 'legacy_unverified').length;
+}
+
+export type DailyFritzHealthTopFailure = {
+  verifierCode: string | null;
+  total: number;
+};
+
+export async function listDailyFritzHealthSummary(runDate: string): Promise<{
+  metrics: DailyFritzDayHealthMetrics;
+  topFailures: DailyFritzHealthTopFailure[];
+}> {
+  const funnelRows = await supabaseFetch<FunnelRow[]>(
+    `/rest/v1/daily_fritz_funnel_metrics?run_date=eq.${encodeURIComponent(runDate)}&select=event_type,total`,
+    { method: 'GET' },
+  );
+  const failureRows = await supabaseFetch<FailureRow[]>(
+    `/rest/v1/daily_fritz_failure_metrics?run_date=eq.${encodeURIComponent(runDate)}&select=verifier_code,total`,
+    { method: 'GET' },
+  );
+  const legacyUnverifiedCompletions = await countLegacyUnverifiedCompletions(runDate);
+  const metrics = buildDayMetrics(runDate, funnelRows, failureRows, legacyUnverifiedCompletions);
+
+  const failureTotals = new Map<string | null, number>();
+  for (const row of failureRows) {
+    const key = row.verifier_code ?? null;
+    failureTotals.set(key, (failureTotals.get(key) ?? 0) + (Number(row.total) || 0));
+  }
+  const topFailures = [...failureTotals.entries()]
+    .map(([verifierCode, total]) => ({ verifierCode, total }))
+    .sort((a, b) => b.total - a.total)
+    .slice(0, 8);
+
+  return { metrics, topFailures };
+}
+
+export function formatDailyFritzRunDatePacific(date = new Date()): string {
+  return new Intl.DateTimeFormat('en-CA', { timeZone: 'America/Los_Angeles' }).format(date);
+}
+
+export function previousDailyFritzRunDate(runDate: string): string {
+  const [year, month, day] = runDate.split('-').map(Number);
+  const anchor = new Date(Date.UTC(year, month - 1, day, 20, 0, 0));
+  anchor.setUTCDate(anchor.getUTCDate() - 1);
+  return anchor.toISOString().slice(0, 10);
+}
+
+export function buildDailyFritzHealthDeltas(
+  today: DailyFritzDayHealthMetrics,
+  yesterday: DailyFritzDayHealthMetrics,
+): {
+  completionRatePctPoints: number;
+  verificationFailureRatePctPoints: number;
+  requestFailedDelta: number;
+  attemptsStartedDelta: number;
+} {
+  return {
+    completionRatePctPoints: (today.completionRate - yesterday.completionRate) * 100,
+    verificationFailureRatePctPoints: (today.verificationFailureRate - yesterday.verificationFailureRate) * 100,
+    requestFailedDelta: today.requestFailed - yesterday.requestFailed,
+    attemptsStartedDelta: today.attemptsStarted - yesterday.attemptsStarted,
+  };
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -434,6 +434,7 @@ app.use('/api/daily-fritz/generate', adminLimit);
 app.use('/api/daily-fritz/invalidate', adminLimit);
 app.use('/api/daily-fritz/reset-attempt', adminLimit);
 app.use('/api/daily-fritz/metrics', adminLimit);
+app.use('/api/daily-fritz/health', adminLimit);
 app.use('/api/daily-fritz/events', adminLimit);
 app.use('/api/ranking/process', adminLimit);
 app.use('/league/run-forfeits', adminLimit);

--- a/server/src/sentryScrubbers.test.ts
+++ b/server/src/sentryScrubbers.test.ts
@@ -6,12 +6,14 @@ describe('scrubSensitiveFields', () => {
     const scrubbed = scrubSensitiveFields({
       attempt_id: 'attempt-1',
       access_token: 'secret-jwt',
-      nested: { accessToken: 'nested-secret', gameNumber: 1 },
+      admin_key: 'admin-secret',
+      nested: { accessToken: 'nested-secret', adminKey: 'nested-admin', gameNumber: 1 },
     }) as Record<string, unknown>;
 
     expect(scrubbed.attempt_id).toBe('attempt-1');
     expect(scrubbed.access_token).toBe('[Filtered]');
-    expect(scrubbed.nested).toEqual({ accessToken: '[Filtered]', gameNumber: 1 });
+    expect(scrubbed.admin_key).toBe('[Filtered]');
+    expect(scrubbed.nested).toEqual({ accessToken: '[Filtered]', adminKey: '[Filtered]', gameNumber: 1 });
   });
 
   it('scrubs JSON string request bodies', () => {
@@ -58,5 +60,22 @@ describe('scrubSentryEventSensitiveData', () => {
     expect(event.request?.headers?.['content-type']).toBe('application/json');
     expect((event.request?.data as Record<string, unknown>).attempt_id).toBe('attempt-1');
     expect((event.request?.data as Record<string, unknown>).access_token).toBe('[Filtered]');
+  });
+
+  it('scrubs admin secrets from headers and query strings', () => {
+    const event = scrubSentryEventSensitiveData({
+      message: 'health failed',
+      request: {
+        url: 'https://racehorse.onrender.com/api/daily-fritz/health',
+        method: 'GET',
+        query_string: 'run_date=2026-08-19&admin_key=super-secret',
+        headers: {
+          'x-admin-secret': 'super-secret',
+        },
+      },
+    });
+
+    expect(event.request?.headers?.['x-admin-secret']).toBe('[Filtered]');
+    expect(event.request?.query_string).toBe('run_date=2026-08-19&admin_key=[Filtered]');
   });
 });

--- a/server/src/sentryScrubbers.ts
+++ b/server/src/sentryScrubbers.ts
@@ -3,7 +3,10 @@ import type { ErrorEvent, EventHint } from '@sentry/node';
 const REDACTED = '[Filtered]';
 
 function isSensitiveKey(key: string): boolean {
-  return key === 'access_token' || key === 'accessToken';
+  return key === 'access_token'
+    || key === 'accessToken'
+    || key === 'admin_key'
+    || key === 'adminKey';
 }
 
 /** Recursively redact bearer/session tokens from structured request payloads. */
@@ -41,7 +44,14 @@ export function scrubSentryEventSensitiveData<T extends ErrorEvent>(event: T): T
     const headers = { ...request.headers };
     if (typeof headers.Authorization === 'string') headers.Authorization = REDACTED;
     if (typeof headers.authorization === 'string') headers.authorization = REDACTED;
+    if (typeof headers['x-admin-secret'] === 'string') headers['x-admin-secret'] = REDACTED;
     request.headers = headers;
+  }
+  if (typeof request?.query_string === 'string' && request.query_string.includes('admin_key=')) {
+    request.query_string = request.query_string.replace(
+      /([?&]admin_key=)[^&]*/gi,
+      '$1[Filtered]',
+    );
   }
   return event;
 }

--- a/supabase/migrations/2026-08-20_daily_fritz_events_checkpoint_saved.sql
+++ b/supabase/migrations/2026-08-20_daily_fritz_events_checkpoint_saved.sql
@@ -1,0 +1,17 @@
+-- Allow checkpoint_saved analytics events (server + Phase 1.6 metric mirror).
+-- Regression: 2026-08-01 canonical telemetry migration omitted checkpoint_saved
+-- from event_type CHECK while the checkpoint route still emitted it.
+
+alter table public.daily_fritz_events
+  drop constraint if exists daily_fritz_events_event_type_check;
+
+alter table public.daily_fritz_events
+  add constraint daily_fritz_events_event_type_check check (event_type in (
+    'mode_impression', 'start_requested', 'attempt_started', 'attempt_resumed',
+    'first_move', 'hand_started', 'hand_verified', 'next_hand_replayed',
+    'game_started', 'game_recorded', 'set_continued', 'attempt_completed',
+    'attempt_abandoned', 'verification_failed', 'command_conflict',
+    'recovery_started', 'recovery_succeeded', 'recovery_failed',
+    'request_failed', 'retry_request', 'review_opened', 'leaderboard_opened',
+    'share_requested', 'share_completed', 'checkpoint_saved'
+  ));


### PR DESCRIPTION
## Summary

- **M4:** Migration adds `checkpoint_saved` to `daily_fritz_events` event_type CHECK (omitted in `2026-08-01` canonical telemetry migration while server still emitted the event).
- **M5:** `attempt_completed` event payload now includes `verification_status` (replay, transactional outbox, and direct persist paths).
- **M1–M3:** `GET /api/daily-fritz/health` (admin secret) with Pacific `run_date`, yesterday comparison, named threshold constants, and top failures. Plain admin page at `/admin/daily-fritz-health?admin_key=...`.
- **CI:** Client Validation job `timeout-minutes: 45`; routing logo tests use `domcontentloaded` + element-ready wait instead of `networkidle`.

## Historical impact — `checkpoint_saved` gap (M4)

**What failed:** Since `2026-08-01_daily_fritz_canonical_telemetry.sql` tightened `event_type` without `checkpoint_saved`, every `recordDailyFritzEventBestEffort({ eventType: 'checkpoint_saved' })` from `dailyFritzCheckpointRoute.ts` and the Phase 1.6 metric mirror would hit PostgREST CHECK constraint rejection.

**What did NOT break:** Checkpoint **persistence** itself — `attempt.result.active_checkpoint` still saved via `upsertDailyFritzAttempt`. Players were not stranded; only **analytics events** for checkpoint saves were dropped.

**Detection in code/logs (no live Sentry query in this PR):**
- Failures are swallowed by `recordDailyFritzEventBestEffort` → server log `[daily-fritz-event] persistence failed` + in-memory `event_persistence_failed` metric (not mirrored to durable events).
- State mismatch investigation already noted zero `checkpoint_saved` rows for a affected attempt while checkpoints existed in attempt result.
- Sentry would only surface this if someone configured alerts on `event_persistence_failed` logs — no dedicated `checkpoint_saved` alert exists in-repo.

**After this migration:** `checkpoint_saved` inserts and metric mirrors should persist to `daily_fritz_events`; health dashboard can eventually count checkpoint activity (not in v1 summary table).

## Test plan

- [x] Server: 179 passed
- [x] Client: 1169 passed
- [x] `npm run build --prefix client`
- [x] Health route + threshold unit tests
- [x] `checkpoint_saved` event store write test

## Usage

Bookmark: `https://your-host/admin/daily-fritz-health?admin_key=ADMIN_SECRET`

Or: `curl -H "x-admin-secret: $ADMIN_SECRET" "https://api.../api/daily-fritz/health?run_date=2026-08-19"`


Made with [Cursor](https://cursor.com)