### PR TITLE
Private Match P1a: structured terminal join + unified archive recovery

### DIFF
--- a/client/src/multiplayer/handleTerminalJoinFailure.test.ts
+++ b/client/src/multiplayer/handleTerminalJoinFailure.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { RoomAckResponse } from './roomTransport';
+import { handleTerminalJoinFailure, isRecoverableTerminalJoinResponse } from './handleTerminalJoinFailure';
+import * as terminalRoomArchiveRecovery from './terminalRoomArchiveRecovery';
+
+describe('handleTerminalJoinFailure', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('recognizes structured match_terminal responses', () => {
+    const resp: RoomAckResponse = {
+      ok: false,
+      error: 'match_terminal',
+      terminal: {
+        status: 'completed',
+        matchId: '11111111-1111-4111-8111-111111111111',
+        recoverable: true,
+      },
+    };
+    expect(isRecoverableTerminalJoinResponse(resp)).toBe(true);
+  });
+
+  it('fetches archive and surfaces abandonedMatchNotice for match_terminal', async () => {
+    vi.spyOn(terminalRoomArchiveRecovery, 'recoverTerminalMatchArchive').mockResolvedValue({
+      status: 'found',
+      notice: {
+        context: 'multiplayer',
+        title: 'Match completed',
+        detail: 'Final score available.',
+      },
+    });
+
+    const setRecoveredTerminalMatchNotice = vi.fn();
+    const dispatchRecovery = vi.fn();
+
+    const result = await handleTerminalJoinFailure({
+      resp: {
+        ok: false,
+        error: 'match_terminal',
+        terminal: {
+          status: 'completed',
+          matchId: '11111111-1111-4111-8111-111111111111',
+          recoverable: true,
+        },
+      },
+      roomCode: 'ROOM7',
+      serverUrl: 'http://localhost:3001',
+      authToken: 'token',
+      setRecoveredTerminalMatchNotice,
+      dispatchRecovery,
+    });
+
+    expect(result).toBe('handled');
+    expect(setRecoveredTerminalMatchNotice).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Match completed' }),
+    );
+    expect(dispatchRecovery).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'ROOM_JOIN_TERMINAL' }),
+    );
+  });
+
+  it('returns not_terminal for transient join failures', async () => {
+    const fetchSpy = vi.spyOn(terminalRoomArchiveRecovery, 'recoverTerminalMatchArchive');
+
+    const result = await handleTerminalJoinFailure({
+      resp: { ok: false, error: 'room_degraded' },
+      roomCode: 'ROOM7',
+      serverUrl: 'http://localhost:3001',
+      authToken: 'token',
+    });
+
+    expect(result).toBe('not_terminal');
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});

--- a/client/src/multiplayer/handleTerminalJoinFailure.ts
+++ b/client/src/multiplayer/handleTerminalJoinFailure.ts
@@ -1,0 +1,100 @@
+import type { RecoveryEvent } from './recoveryMachine';
+import { isTerminalJoinError } from './recoveryMachine';
+import type { RoomAckResponse, RoomTerminalJoinPayload } from './roomTransport';
+import {
+  buildTerminalArchiveFallbackNotice,
+  recoverTerminalMatchArchive,
+  type RecoveredTerminalMatchNotice,
+} from './terminalRoomArchiveRecovery';
+
+export function isRecoverableTerminalJoinResponse(resp: RoomAckResponse | null | undefined): boolean {
+  if (!resp || resp.ok !== false) return false;
+  if (resp.terminal?.recoverable === true) return true;
+  const error = String(resp.error ?? '');
+  if (error === 'match_terminal') return true;
+  return isTerminalJoinError(error);
+}
+
+export type HandleTerminalJoinFailureParams = {
+  resp: RoomAckResponse;
+  roomCode: string;
+  serverUrl: string;
+  authToken: string | null;
+  lastRoomStorageKey?: string;
+  clearSavedRoomOnAttempt?: boolean;
+  restoreSavedRoomOnDegraded?: boolean;
+  setRecoveredTerminalMatchNotice?: (notice: RecoveredTerminalMatchNotice) => void;
+  onNavigateMultiplayer?: () => void;
+  dispatchRecovery?: (event: RecoveryEvent) => void;
+};
+
+export type HandleTerminalJoinFailureResult = 'handled' | 'not_terminal';
+
+function terminalJoinErrorText(resp: RoomAckResponse): string {
+  return String(resp.error ?? 'match_terminal');
+}
+
+function maybeDisableRecoveryPolicy(
+  resp: RoomAckResponse,
+  dispatchRecovery: HandleTerminalJoinFailureParams['dispatchRecovery'],
+): void {
+  const error = terminalJoinErrorText(resp).toLowerCase();
+  const terminal = resp.terminal as RoomTerminalJoinPayload | undefined;
+  if (error.includes('completed') || terminal?.status === 'completed') {
+    dispatchRecovery?.({ type: 'SET_POLICY', policy: 'disabled' });
+  }
+}
+
+export async function handleTerminalJoinFailure(
+  params: HandleTerminalJoinFailureParams,
+): Promise<HandleTerminalJoinFailureResult> {
+  if (!isRecoverableTerminalJoinResponse(params.resp)) {
+    return 'not_terminal';
+  }
+
+  const roomCode = params.roomCode.trim().toUpperCase();
+  maybeDisableRecoveryPolicy(params.resp, params.dispatchRecovery);
+
+  if (
+    params.clearSavedRoomOnAttempt &&
+    params.lastRoomStorageKey &&
+    typeof window !== 'undefined'
+  ) {
+    window.localStorage.removeItem(params.lastRoomStorageKey);
+  }
+
+  const archiveResult = await recoverTerminalMatchArchive({
+    serverUrl: params.serverUrl,
+    roomCode,
+    authToken: params.authToken,
+  });
+
+  const finishTerminalRecovery = (notice: RecoveredTerminalMatchNotice) => {
+    params.setRecoveredTerminalMatchNotice?.(notice);
+    params.onNavigateMultiplayer?.();
+    params.dispatchRecovery?.({
+      type: 'ROOM_JOIN_TERMINAL',
+      error: terminalJoinErrorText(params.resp),
+    });
+  };
+
+  if (archiveResult.status === 'found') {
+    finishTerminalRecovery(archiveResult.notice);
+    return 'handled';
+  }
+
+  if (archiveResult.status === 'temporarily_unavailable' || archiveResult.status === 'unauthorized') {
+    if (
+      params.restoreSavedRoomOnDegraded &&
+      params.lastRoomStorageKey &&
+      typeof window !== 'undefined'
+    ) {
+      window.localStorage.setItem(params.lastRoomStorageKey, roomCode);
+    }
+    finishTerminalRecovery(buildTerminalArchiveFallbackNotice(archiveResult.status, roomCode));
+    return 'handled';
+  }
+
+  finishTerminalRecovery(buildTerminalArchiveFallbackNotice('absent', roomCode));
+  return 'handled';
+}

--- a/client/src/multiplayer/recoveryMachine.behaviorTests.ts
+++ b/client/src/multiplayer/recoveryMachine.behaviorTests.ts
@@ -52,6 +52,8 @@ function testBackoffCurve(): void {
 function testTerminalJoinErrors(): void {
   assertEqual(isTerminalJoinError('Room abandoned'), true, 'abandoned');
   assertEqual(isTerminalJoinError('match_completed'), true, 'match_completed');
+  assertEqual(isTerminalJoinError('match_terminal'), true, 'match_terminal');
+  assertEqual(isTerminalJoinError('snapshot_terminal'), true, 'snapshot_terminal');
   assertEqual(isTerminalJoinError('Room not found'), true, 'not found');
   assertEqual(isTerminalJoinError('timeout'), false, 'timeout transient');
 }

--- a/client/src/multiplayer/recoveryMachine.ts
+++ b/client/src/multiplayer/recoveryMachine.ts
@@ -102,6 +102,8 @@ const TERMINAL_JOIN_MARKERS = [
   'abandoned',
   'completed',
   'match_completed',
+  'match_terminal',
+  'snapshot_terminal',
   'forfeited',
   'expired',
   'not found',

--- a/client/src/multiplayer/roomTransport.ts
+++ b/client/src/multiplayer/roomTransport.ts
@@ -13,9 +13,16 @@ export type SocketEmitter = {
   emit: (event: string, ...args: unknown[]) => void;
 };
 
+export type RoomTerminalJoinPayload = {
+  status: 'completed' | 'abandoned';
+  matchId: string;
+  recoverable: true;
+};
+
 export type RoomAckResponse = {
   ok?: boolean;
   error?: string;
+  terminal?: RoomTerminalJoinPayload;
   sequence?: number;
   forcedDraw?: { drewCount?: number };
   started?: boolean;

--- a/client/src/multiplayer/terminalJoinRecoveryPaths.test.ts
+++ b/client/src/multiplayer/terminalJoinRecoveryPaths.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { handleTerminalJoinFailure } from './handleTerminalJoinFailure';
+import * as terminalRoomArchiveRecovery from './terminalRoomArchiveRecovery';
+import type { RecoveryEvent } from './recoveryMachine';
+
+describe('terminal join recovery paths', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const archiveNotice = {
+    context: 'multiplayer' as const,
+    title: 'Match completed',
+    detail: 'Your saved room ROOM7 finished while you were away. Final score: You 60 - Opponent 40.',
+  };
+
+  it('recovery-room-join path handles match_terminal after archived cleanup', async () => {
+    vi.spyOn(terminalRoomArchiveRecovery, 'recoverTerminalMatchArchive').mockResolvedValue({
+      status: 'found',
+      notice: archiveNotice,
+    });
+    const setRecoveredTerminalMatchNotice = vi.fn();
+    const dispatchRecovery = vi.fn((event: RecoveryEvent) => event);
+
+    const handled = await handleTerminalJoinFailure({
+      resp: {
+        ok: false,
+        error: 'match_terminal',
+        terminal: {
+          status: 'completed',
+          matchId: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+          recoverable: true,
+        },
+      },
+      roomCode: 'ROOM7',
+      serverUrl: 'http://localhost:3001',
+      authToken: 'token',
+      setRecoveredTerminalMatchNotice,
+      onNavigateMultiplayer: vi.fn(),
+      dispatchRecovery,
+    });
+
+    expect(handled).toBe('handled');
+    expect(setRecoveredTerminalMatchNotice).toHaveBeenCalledWith(archiveNotice);
+    expect(dispatchRecovery).toHaveBeenCalledWith({
+      type: 'ROOM_JOIN_TERMINAL',
+      error: 'match_terminal',
+    });
+  });
+
+  it('saved-room auto-join path handles legacy match_completed the same way', async () => {
+    vi.spyOn(terminalRoomArchiveRecovery, 'recoverTerminalMatchArchive').mockResolvedValue({
+      status: 'found',
+      notice: archiveNotice,
+    });
+    const setRecoveredTerminalMatchNotice = vi.fn();
+    const dispatchRecovery = vi.fn((event: RecoveryEvent) => event);
+
+    const handled = await handleTerminalJoinFailure({
+      resp: { ok: false, error: 'match_completed' },
+      roomCode: 'ROOM7',
+      serverUrl: 'http://localhost:3001',
+      authToken: 'token',
+      lastRoomStorageKey: 'racehorse_last_room_code',
+      clearSavedRoomOnAttempt: true,
+      setRecoveredTerminalMatchNotice,
+      dispatchRecovery,
+    });
+
+    expect(handled).toBe('handled');
+    expect(setRecoveredTerminalMatchNotice).toHaveBeenCalledWith(archiveNotice);
+    expect(dispatchRecovery).toHaveBeenCalledWith({
+      type: 'ROOM_JOIN_TERMINAL',
+      error: 'match_completed',
+    });
+  });
+});

--- a/client/src/multiplayer/useMultiplayerConnection.ts
+++ b/client/src/multiplayer/useMultiplayerConnection.ts
@@ -17,7 +17,6 @@ import { getOrCreateGuestDisplayName } from '../match/recovery/matchRecovery';
 import { syncRecoveryLegacyRefs } from './recoveryConnectionBridge';
 import {
   createRecoveryMachine,
-  isTerminalJoinError,
   type RecoveryEffect,
   type RecoveryEvent,
   type RecoveryMachine,
@@ -42,11 +41,8 @@ import {
   selectJoinedRoomCode,
   selectMatchStarted,
 } from './session/sessionStateMachine';
-import {
-  buildTerminalArchiveFallbackNotice,
-  recoverTerminalMatchArchive,
-  type RecoveredTerminalMatchNotice,
-} from './terminalRoomArchiveRecovery';
+import type { RecoveredTerminalMatchNotice } from './terminalRoomArchiveRecovery';
+import { handleTerminalJoinFailure } from './handleTerminalJoinFailure';
 import {
   beginRoomOperation,
   invalidateRoomOperations,
@@ -154,8 +150,19 @@ export function useMultiplayerConnection(params: UseMultiplayerConnectionParams)
         }
 
         const errorText = String(resp?.error ?? 'not_ok');
-        if (isTerminalJoinError(errorText)) {
-          dispatchSocketEvent({ type: 'ROOM_JOIN_TERMINAL', payload: { error: errorText } });
+        const terminalHandled = await handleTerminalJoinFailure({
+          resp,
+          roomCode,
+          serverUrl: scope.config.serverUrl,
+          authToken: scope.auth.authAccessTokenRef.current,
+          setRecoveredTerminalMatchNotice,
+          onNavigateMultiplayer: () => scope.navigation.setAppMode('multiplayer'),
+          dispatchRecovery,
+        });
+        if (!isCurrentRoomOperation(scope.roomOperationEpochRef, operationToken)) {
+          return;
+        }
+        if (terminalHandled === 'handled') {
           return;
         }
         dispatchRecovery({ type: 'ROOM_JOIN_TRANSIENT', error: errorText });
@@ -328,42 +335,23 @@ export function useMultiplayerConnection(params: UseMultiplayerConnectionParams)
           recordJoinLatency(joinEndedAt - joinStartedAt, 'join');
         }
         if (!resp?.ok) {
-          const errorText = String(resp?.error ?? '').toLowerCase();
-          if (typeof window !== 'undefined') {
-            window.localStorage.removeItem(scope.config.lastRoomStorageKey);
+          const terminalHandled = await handleTerminalJoinFailure({
+            resp,
+            roomCode: savedCode,
+            serverUrl: scope.config.serverUrl,
+            authToken: scope.auth.authAccessTokenRef.current,
+            lastRoomStorageKey: scope.config.lastRoomStorageKey,
+            clearSavedRoomOnAttempt: true,
+            restoreSavedRoomOnDegraded: true,
+            setRecoveredTerminalMatchNotice,
+            onNavigateMultiplayer: () => scope.navigation.setAppMode('multiplayer'),
+            dispatchRecovery,
+          });
+          if (!isCurrentRoomOperation(scope.roomOperationEpochRef, operationToken)) {
+            return;
           }
-          if (errorText.includes('completed')) {
-            dispatchRecovery({ type: 'SET_POLICY', policy: 'disabled' });
-          }
-          if (errorText.includes('completed') || errorText.includes('abandoned')) {
-            const archiveResult = await recoverTerminalMatchArchive({
-              serverUrl: scope.config.serverUrl,
-              roomCode: savedCode,
-              authToken: scope.auth.authAccessTokenRef.current,
-            });
-            if (!isCurrentRoomOperation(scope.roomOperationEpochRef, operationToken)) {
-              return;
-            }
-            if (archiveResult.status === 'found') {
-              setRecoveredTerminalMatchNotice?.(archiveResult.notice);
-              scope.navigation.setAppMode('multiplayer');
-              dispatchRecovery({ type: 'ROOM_JOIN_TERMINAL', error: errorText });
-              return;
-            }
-            if (
-              archiveResult.status === 'temporarily_unavailable' ||
-              archiveResult.status === 'unauthorized'
-            ) {
-              if (typeof window !== 'undefined') {
-                window.localStorage.setItem(scope.config.lastRoomStorageKey, savedCode);
-              }
-              setRecoveredTerminalMatchNotice?.(
-                buildTerminalArchiveFallbackNotice(archiveResult.status, savedCode),
-              );
-              scope.navigation.setAppMode('multiplayer');
-              dispatchRecovery({ type: 'ROOM_JOIN_TERMINAL', error: errorText });
-              return;
-            }
+          if (terminalHandled === 'handled') {
+            return;
           }
           scope.config.showToast('Saved room is no longer available.', 2000);
           return;

--- a/client/src/multiplayer/useMultiplayerConnection.ts
+++ b/client/src/multiplayer/useMultiplayerConnection.ts
@@ -176,7 +176,7 @@ export function useMultiplayerConnection(params: UseMultiplayerConnectionParams)
         });
       }
     },
-    [dispatchRecovery],
+    [dispatchRecovery, setRecoveredTerminalMatchNotice],
   );
 
   const executeRecoveryResync = useCallback(

--- a/server/src/multiplayer/matchTerminalJoin.test.ts
+++ b/server/src/multiplayer/matchTerminalJoin.test.ts
@@ -1,0 +1,43 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { MatchTerminalJoinError, isTerminalHydrationError } from './matchTerminalJoin';
+import * as roomMatchLogPersistence from './roomMatchLogPersistence';
+
+describe('matchTerminalJoin', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('detects terminal hydration error codes', () => {
+    expect(isTerminalHydrationError('snapshot_terminal')).toBe(true);
+    expect(isTerminalHydrationError('snapshot_terminal_state')).toBe(true);
+    expect(isTerminalHydrationError('snapshot_stale')).toBe(false);
+  });
+
+  it('builds MatchTerminalJoinError from archived row', async () => {
+    vi.spyOn(roomMatchLogPersistence, 'queryLatestPersistedRoomMatchLogByRoomCode').mockResolvedValue({
+      match_id: '11111111-1111-4111-8111-111111111111',
+      room_code: 'ROOM1',
+      status: 'completed',
+      event_log_version: 1,
+      last_event_sequence: 3,
+      event_count: 3,
+      started_at: null,
+      archived_at: new Date().toISOString(),
+      participant_user_ids: [],
+      participants: [],
+      summary: null,
+      state_snapshot: null,
+      events: [],
+    });
+
+    const { resolveArchivedTerminalJoin } = await import('./matchTerminalJoin');
+    const error = await resolveArchivedTerminalJoin('ROOM1');
+    expect(error).toBeInstanceOf(MatchTerminalJoinError);
+    expect(error?.code).toBe('match_terminal');
+    expect(error?.terminal).toEqual({
+      status: 'completed',
+      matchId: '11111111-1111-4111-8111-111111111111',
+      recoverable: true,
+    });
+  });
+});

--- a/server/src/multiplayer/matchTerminalJoin.ts
+++ b/server/src/multiplayer/matchTerminalJoin.ts
@@ -1,0 +1,53 @@
+import {
+  queryLatestPersistedRoomMatchLogByRoomCode,
+  type PersistedRoomMatchLogRow,
+} from './roomMatchLogPersistence';
+
+export type MatchTerminalJoinPayload = {
+  status: 'completed' | 'abandoned';
+  matchId: string;
+  recoverable: true;
+};
+
+export class MatchTerminalJoinError extends Error {
+  readonly code = 'match_terminal' as const;
+
+  readonly terminal: MatchTerminalJoinPayload;
+
+  constructor(terminal: MatchTerminalJoinPayload) {
+    super('match_terminal');
+    this.name = 'MatchTerminalJoinError';
+    this.terminal = terminal;
+  }
+}
+
+const TERMINAL_HYDRATION_ERRORS = new Set(['snapshot_terminal', 'snapshot_terminal_state']);
+
+export function isTerminalHydrationError(error: string | undefined): boolean {
+  return typeof error === 'string' && TERMINAL_HYDRATION_ERRORS.has(error);
+}
+
+function toTerminalPayload(row: PersistedRoomMatchLogRow): MatchTerminalJoinPayload {
+  return {
+    status: row.status,
+    matchId: row.match_id,
+    recoverable: true,
+  };
+}
+
+export async function resolveArchivedTerminalJoin(
+  roomCode: string,
+): Promise<MatchTerminalJoinError | null> {
+  const archived = await queryLatestPersistedRoomMatchLogByRoomCode(roomCode);
+  if (!archived) return null;
+  return new MatchTerminalJoinError(toTerminalPayload(archived));
+}
+
+export async function throwArchivedTerminalJoinOrError(
+  roomCode: string,
+  fallbackError: string,
+): Promise<void> {
+  const terminal = await resolveArchivedTerminalJoin(roomCode);
+  if (terminal) throw terminal;
+  throw new Error(fallbackError);
+}

--- a/server/src/multiplayer/registerRoomJoinHandlers.test.ts
+++ b/server/src/multiplayer/registerRoomJoinHandlers.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { resetRoomRuntimeForTests } from '../rooms';
 import { initRoomSession, resetRoomSessionStoresForTests } from './roomSession';
 import { registerRoomJoinHandlers } from './registerRoomJoinHandlers';
+import { MatchTerminalJoinError } from './matchTerminalJoin';
 
 function makeSocket() {
   const handlers = new Map<string, (...args: unknown[]) => void>();
@@ -57,5 +58,43 @@ describe('registerRoomJoinHandlers', () => {
     const cb = vi.fn();
     await handlers.get('room:join')?.('MISSING', cb);
     expect(cb).toHaveBeenCalledWith({ ok: false, error: 'Room not found.' });
+  });
+
+  it('room:join surfaces structured match_terminal ack when archive exists', async () => {
+    const io = {} as any;
+    const { socket, handlers } = makeSocket();
+    const attachSocketToTrackedRoom = vi.fn(async () => {
+      throw new MatchTerminalJoinError({
+        status: 'completed',
+        matchId: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+        recoverable: true,
+      });
+    });
+
+    registerRoomJoinHandlers(io, socket, {
+      handlerDeps: {
+        resolveSocketIdentity: async () => ({ username: 'Guest', userId: 'user-1' }),
+        normalizeUsername: (v) => String(v ?? 'Guest'),
+        normalizeUserId: (v) => (typeof v === 'string' ? v : null),
+        tryHydrateMatchmakingRoomShell: async () => 'skipped',
+        waitUntilMatchmakingRoomSocketsReady: async () => undefined,
+        onAfterMatchStarted: async () => undefined,
+        notifyRoomPlayersInGame: () => undefined,
+        persistRoomMatchLog: async () => undefined,
+      },
+      attachSocketToTrackedRoom,
+    });
+
+    const cb = vi.fn();
+    await handlers.get('room:join')?.('ARCHV1', cb);
+    expect(cb).toHaveBeenCalledWith({
+      ok: false,
+      error: 'match_terminal',
+      terminal: {
+        status: 'completed',
+        matchId: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+        recoverable: true,
+      },
+    });
   });
 });

--- a/server/src/multiplayer/registerRoomJoinHandlers.ts
+++ b/server/src/multiplayer/registerRoomJoinHandlers.ts
@@ -7,6 +7,7 @@ import {
   type RoomSessionHandlerDeps,
 } from './roomSession';
 import type { AttachSocketToTrackedRoomFn } from './roomSocketAttach';
+import { MatchTerminalJoinError } from './matchTerminalJoin';
 import { failedRoomLookupLimiter, socketRateLimitKey } from '../rateLimit';
 
 const log = childLogger('multiplayer:join');
@@ -73,6 +74,13 @@ export function registerRoomJoinHandlers(
         scheduledTournamentMatchId: attached.room.scheduledTournamentMatchId ?? null,
       });
     } catch (err: unknown) {
+      if (err instanceof MatchTerminalJoinError) {
+        log.info(
+          `[room:join] TERMINAL: code=${roomCode} matchId=${err.terminal.matchId} status=${err.terminal.status}`,
+        );
+        cb?.({ ok: false, error: err.code, terminal: err.terminal });
+        return;
+      }
       const message = err instanceof Error ? err.message : 'unknown error';
       log.info(`[room:join] ERROR: ${message}`);
       if (message === 'Room not found.') {

--- a/server/src/multiplayer/roomSocketAttach.test.ts
+++ b/server/src/multiplayer/roomSocketAttach.test.ts
@@ -9,6 +9,8 @@ import {
 } from './roomSession';
 import { createRoomSocketAttach } from './roomSocketAttach';
 import * as livePersistence from './roomLivePersistence';
+import * as matchTerminalJoin from './matchTerminalJoin';
+import { MatchTerminalJoinError } from './matchTerminalJoin';
 
 function makeSocket(socketId: string) {
   const socket = {
@@ -42,6 +44,62 @@ describe('createRoomSocketAttach', () => {
       ...handlerDeps,
       onGameOver: () => null,
     });
+  });
+
+  it('returns match_terminal when live room is gone but archive exists', async () => {
+    const io = { sockets: { sockets: new Map() }, to: vi.fn(() => ({ emit: vi.fn() })) } as any;
+    const socket = makeSocket('sock-archive');
+    vi.spyOn(livePersistence, 'ensureRoomHydrated').mockResolvedValue({ kind: 'not_found' });
+    vi.spyOn(matchTerminalJoin, 'resolveArchivedTerminalJoin').mockResolvedValue(
+      new MatchTerminalJoinError({
+        status: 'completed',
+        matchId: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+        recoverable: true,
+      }),
+    );
+
+    const { attachSocketToTrackedRoom } = createRoomSocketAttach({ io, socket, handlerDeps });
+
+    await expect(
+      attachSocketToTrackedRoom({
+        roomCode: 'ARCHV1',
+        username: 'Guest',
+        userId: null,
+        via: 'room:join',
+        hydrateMatchmakingRoom: true,
+      }),
+    ).rejects.toBeInstanceOf(MatchTerminalJoinError);
+  });
+
+  it('maps snapshot_terminal hydration to match_terminal when archive exists', async () => {
+    const io = { sockets: { sockets: new Map() }, to: vi.fn(() => ({ emit: vi.fn() })) } as any;
+    const socket = makeSocket('sock-term');
+    vi.spyOn(livePersistence, 'ensureRoomHydrated').mockResolvedValue({
+      kind: 'snapshot_stale',
+      error: 'snapshot_terminal',
+    });
+    const throwSpy = vi
+      .spyOn(matchTerminalJoin, 'throwArchivedTerminalJoinOrError')
+      .mockRejectedValue(
+        new MatchTerminalJoinError({
+          status: 'abandoned',
+          matchId: 'bbbbbbbb-bbbb-cccc-dddd-eeeeeeeeeeee',
+          recoverable: true,
+        }),
+      );
+
+    const { attachSocketToTrackedRoom } = createRoomSocketAttach({ io, socket, handlerDeps });
+
+    await expect(
+      attachSocketToTrackedRoom({
+        roomCode: 'ARCHV2',
+        username: 'Guest',
+        userId: null,
+        via: 'room:join',
+        hydrateMatchmakingRoom: false,
+      }),
+    ).rejects.toBeInstanceOf(MatchTerminalJoinError);
+    expect(throwSpy).toHaveBeenCalledWith('ARCHV2', 'snapshot_terminal');
   });
 
   it('stashes leaveTrackedRoom on socket.__leaveTrackedRoom', async () => {

--- a/server/src/multiplayer/roomSocketAttach.ts
+++ b/server/src/multiplayer/roomSocketAttach.ts
@@ -11,6 +11,12 @@ import {
 } from '../rooms';
 import { supabaseFetch } from '../supabaseUtils';
 import { ensureRoomHydrated } from './roomLivePersistence';
+import {
+  isTerminalHydrationError,
+  MatchTerminalJoinError,
+  resolveArchivedTerminalJoin,
+  throwArchivedTerminalJoinOrError,
+} from './matchTerminalJoin';
 import { normalizeMatchmakingRoomShellHydrationResult } from '../matchmaking/roomShellHydration';
 import { onPlayerSocketRejoined } from './disconnectGrace';
 import { markMatchStartReady, tryStartMatchIfReady } from './matchStartReady';
@@ -215,6 +221,9 @@ export function createRoomSocketAttach(ctx: RoomSocketAttachContext): RoomSocket
       throw new Error('room_snapshot_uncommitted');
     }
     if (hydrated.kind === 'snapshot_invalid' || hydrated.kind === 'snapshot_stale') {
+      if (isTerminalHydrationError(hydrated.error)) {
+        await throwArchivedTerminalJoinOrError(roomCode, hydrated.error);
+      }
       throw new Error(hydrated.error);
     }
 
@@ -236,6 +245,14 @@ export function createRoomSocketAttach(ctx: RoomSocketAttachContext): RoomSocket
 
     let existingRoom = peekRoom(roomCode);
     if (!existingRoom) {
+      const archivedTerminal = await resolveArchivedTerminalJoin(roomCode);
+      if (archivedTerminal) {
+        log.info(
+          { roomCode, matchId: archivedTerminal.terminal.matchId, via },
+          'join rejected: archived terminal match',
+        );
+        throw archivedTerminal;
+      }
       const message = 'Room not found.';
       log.info(
         `[${via}] ERROR: ${message} live=${hydrated.kind} shell=${shellHydrationResult.kind}`,
@@ -243,9 +260,19 @@ export function createRoomSocketAttach(ctx: RoomSocketAttachContext): RoomSocket
       throw new Error(message);
     }
     if (existingRoom.abandonedAt) {
+      const archivedTerminal = await resolveArchivedTerminalJoin(roomCode);
+      if (archivedTerminal) throw archivedTerminal;
       throw new Error('match_abandoned');
     }
     if (existingRoom.state?.gameOver) {
+      const archivedTerminal = await resolveArchivedTerminalJoin(roomCode);
+      if (archivedTerminal) {
+        log.info(
+          { roomCode, matchId: archivedTerminal.terminal.matchId, via },
+          'join rejected: archived terminal match',
+        );
+        throw archivedTerminal;
+      }
       log.info({ roomCode }, 'rejected completed room');
       throw new Error('match_completed');
     }


### PR DESCRIPTION
## Summary
- **Server:** Before returning generic `Room not found`, check `room_match_logs` and respond with structured `{ error: 'match_terminal', terminal: { status, matchId, recoverable } }`. Same for `snapshot_terminal` / `snapshot_terminal_state` hydration failures.
- **Client:** Add `handleTerminalJoinFailure()` — one shared path that fetches `/api/room-events/by-room/:code` and surfaces the existing `abandonedMatchNotice` modal. Wired into both `executeRecoveryRoomJoin` (recovery machine) and `trySavedRoomAutoJoin` (saved-room auto-join).
- Fixes the offline-during-match bug: post-cleanup reconnects previously got `Room not found` with no archive fetch.

## Rating copy note (P1b)
When we add rating to the result endpoint, prefer neutral copy like **"Rating not updated for this match"** — verification skip can be caused by either seat's log or legacy capture gaps, not necessarily the viewing player.

## Test plan
- [x] `npm test --prefix server` — 37 files, 172 tests passed
- [x] `npm test --prefix client` — 166 files, 1183 tests passed
- [x] Server: `matchTerminalJoin`, `roomSocketAttach`, `registerRoomJoinHandlers` tests
- [x] Client: `handleTerminalJoinFailure`, `terminalJoinRecoveryPaths` tests (both join paths)
- [ ] Manual: disconnect mid-match → let match end → reload → confirm result notice (not generic unavailable)

## Out of scope (P1b/P1c)
- New `/api/private-match/result` endpoint
- Dedicated result recovery UI (still uses existing `abandonedMatchNotice` modal)

Made with [Cursor](https://cursor.com)