### PR TITLE
Private Match P1b: dedicated result recovery endpoint

### DIFF
--- a/server/src/http/routes/privateMatchResult.test.ts
+++ b/server/src/http/routes/privateMatchResult.test.ts
@@ -1,0 +1,226 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { Application } from 'express';
+import type { PersistedRoomMatchLogRow } from '../../multiplayer/roomMatchLogPersistence';
+import { RANKING_NOT_UPDATED_COPY } from '../../multiplayer/rankingOutcome';
+import { registerPrivateMatchResultRoutes } from './privateMatchResult';
+
+type Handler = (req: unknown, res: unknown) => unknown | Promise<unknown>;
+
+const VIEWER_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const OPPONENT_ID = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+const MATCH_ID = '11111111-1111-4111-8111-111111111111';
+
+function archive(overrides: Partial<PersistedRoomMatchLogRow> = {}): PersistedRoomMatchLogRow {
+  return {
+    match_id: MATCH_ID,
+    room_code: 'ROOM1',
+    status: 'completed',
+    event_log_version: 1,
+    last_event_sequence: 4,
+    event_count: 4,
+    started_at: '2026-08-19T00:00:00.000Z',
+    archived_at: '2026-08-19T00:10:00.000Z',
+    participant_user_ids: [VIEWER_ID, OPPONENT_ID],
+    participants: [
+      { id: 'seat-a', username: 'Alice', userId: VIEWER_ID, seatIndex: 0 },
+      { id: 'seat-b', username: 'Bob', userId: OPPONENT_ID, seatIndex: 1 },
+    ],
+    summary: {
+      status: 'completed',
+      winnerId: 'seat-a',
+      scores: { 'seat-a': 60, 'seat-b': 42 },
+      rankingOutcome: {
+        glickoEligible: true,
+        glickoApplied: true,
+        skipReason: null,
+      },
+    },
+    state_snapshot: { secret: 'must-not-leak' },
+    events: [{ type: 'must-not-leak' } as never],
+    ...overrides,
+  };
+}
+
+function makeHarness(options: {
+  userId?: string | null;
+  log?: PersistedRoomMatchLogRow | null;
+  rankedGame?: { player_id: string; rating_before: number; rating_after: number; delta: number } | null;
+  persistenceAvailable?: boolean;
+} = {}) {
+  const routes = new Map<string, Handler>();
+  const app = {
+    get(path: string, handler: Handler) {
+      routes.set(`GET ${path}`, handler);
+    },
+  };
+
+  const authenticatedUserId = Object.prototype.hasOwnProperty.call(options, 'userId')
+    ? options.userId ?? null
+    : VIEWER_ID;
+  const log = Object.prototype.hasOwnProperty.call(options, 'log') ? options.log ?? null : archive();
+
+  registerPrivateMatchResultRoutes(app as unknown as Application, {
+    getAuthenticatedUserId: async () => authenticatedUserId,
+    queryPersistedRoomMatchLog: async () => log,
+    queryLatestPersistedRoomMatchLogByRoomCode: async () => log,
+    isRoomMatchLogsPersistenceAvailable: () => options.persistenceAvailable ?? true,
+    queryRankedGameForMatch: async () =>
+      Object.prototype.hasOwnProperty.call(options, 'rankedGame')
+        ? options.rankedGame ?? null
+        : {
+            player_id: VIEWER_ID,
+            rating_before: 1500,
+            rating_after: 1512,
+            delta: 12,
+          },
+  });
+
+  return async function request(query: Record<string, string> = { roomCode: 'ROOM1' }) {
+    const handler = routes.get('GET /api/private-match/result');
+    if (!handler) throw new Error('Missing private match result route');
+    let status = 200;
+    let body: unknown;
+    const headers: Record<string, string> = {};
+    const res = {
+      status(code: number) {
+        status = code;
+        return res;
+      },
+      json(value: unknown) {
+        body = value;
+        return res;
+      },
+      setHeader(name: string, value: string) {
+        headers[name] = value;
+      },
+    };
+    await handler({ query, headers: {}, params: {}, body: {}, method: 'GET' }, res);
+    return { status, body, headers };
+  };
+}
+
+describe('GET /api/private-match/result', () => {
+  it('returns the product result shape for a participant, without events or state_snapshot', async () => {
+    const request = makeHarness();
+    const response = await request({ matchId: MATCH_ID });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      ok: true,
+      result: {
+        matchId: MATCH_ID,
+        roomCode: 'ROOM1',
+        terminalStatus: 'completed',
+        archivedAt: '2026-08-19T00:10:00.000Z',
+        you: { seatId: 'seat-a', userId: VIEWER_ID, username: 'Alice' },
+        opponent: { seatId: 'seat-b', userId: OPPONENT_ID, username: 'Bob' },
+        outcome: 'win',
+        yourScore: 60,
+        opponentScore: 42,
+        ranking: {
+          eligible: true,
+          applied: true,
+          skipReason: null,
+          message: null,
+          ratingBefore: 1500,
+          ratingAfter: 1512,
+          ratingDelta: 12,
+        },
+      },
+    });
+    expect(JSON.stringify(response.body)).not.toContain('must-not-leak');
+    expect(JSON.stringify(response.body)).not.toContain('state_snapshot');
+    expect(JSON.stringify(response.body)).not.toContain('"events"');
+  });
+
+  it('returns 403 when an authenticated user is not a participant', async () => {
+    const request = makeHarness({ userId: 'cccccccc-cccc-4ccc-8ccc-cccccccccccc' });
+    await expect(request({ roomCode: 'ROOM1' })).resolves.toMatchObject({
+      status: 403,
+      body: { error: 'Forbidden' },
+    });
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    const request = makeHarness({ userId: null });
+    await expect(request({ roomCode: 'ROOM1' })).resolves.toMatchObject({
+      status: 401,
+      body: { error: 'Unauthorized' },
+    });
+  });
+
+  it('returns 404 when no archive exists for the given id', async () => {
+    const request = makeHarness({ log: null });
+    await expect(request({ matchId: MATCH_ID })).resolves.toMatchObject({
+      status: 404,
+      body: { error: 'Match result not found.' },
+    });
+  });
+
+  it('reports verification-skipped ranking with the neutral copy field', async () => {
+    const request = makeHarness({
+      rankedGame: null,
+      log: archive({
+        summary: {
+          status: 'completed',
+          winnerId: 'seat-a',
+          scores: { 'seat-a': 60, 'seat-b': 42 },
+          rankingOutcome: {
+            glickoEligible: false,
+            glickoApplied: false,
+            skipReason: 'move_log_verification_failed',
+          },
+        },
+      }),
+    });
+
+    const response = await request({ roomCode: 'ROOM1' });
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      ok: true,
+      result: {
+        ranking: {
+          eligible: false,
+          applied: false,
+          skipReason: 'move_log_verification_failed',
+          message: RANKING_NOT_UPDATED_COPY,
+          ratingBefore: null,
+          ratingAfter: null,
+          ratingDelta: null,
+        },
+      },
+    });
+  });
+
+  /**
+   * P1 scope is authed-only. Guests have `userId: null`, so they never appear in
+   * `participant_user_ids`. Without a JWT they get 401. If they later sign in,
+   * that new UUID is still not on the archive, so they get 403 — same as any
+   * non-participant. They cannot recover a private-match result through this
+   * endpoint.
+   */
+  it('treats guest seats as out of scope: unauthenticated 401, later account 403', async () => {
+    const guestArchive = archive({
+      participant_user_ids: [VIEWER_ID],
+      participants: [
+        { id: 'seat-a', username: 'Alice', userId: VIEWER_ID, seatIndex: 0 },
+        { id: 'seat-b', username: 'Guest', userId: null, seatIndex: 1 },
+      ],
+    });
+
+    const unauthenticated = makeHarness({ userId: null, log: guestArchive });
+    await expect(unauthenticated({ roomCode: 'ROOM1' })).resolves.toMatchObject({
+      status: 401,
+      body: { error: 'Unauthorized' },
+    });
+
+    const laterAccount = makeHarness({
+      userId: 'dddddddd-dddd-4ddd-8ddd-dddddddddddd',
+      log: guestArchive,
+    });
+    await expect(laterAccount({ roomCode: 'ROOM1' })).resolves.toMatchObject({
+      status: 403,
+      body: { error: 'Forbidden' },
+    });
+  });
+});

--- a/server/src/http/routes/privateMatchResult.ts
+++ b/server/src/http/routes/privateMatchResult.ts
@@ -1,0 +1,109 @@
+import type { Application, Request, Response } from 'express';
+import type { PersistedRoomMatchLogRow } from '../../multiplayer/roomMatchLogPersistence';
+import {
+  buildPrivateMatchResult,
+  type RankedGameRatingRow,
+} from '../../multiplayer/buildPrivateMatchResult';
+import { isRankedGameSourceColumnsEnabled } from '../../ranking/rankedGamePayload';
+import { supabaseFetch } from '../../supabaseUtils';
+
+export type PrivateMatchResultRouteDeps = {
+  getAuthenticatedUserId: (req: Request) => Promise<string | null>;
+  queryPersistedRoomMatchLog: (matchId: string) => Promise<PersistedRoomMatchLogRow | null>;
+  queryLatestPersistedRoomMatchLogByRoomCode: (
+    roomCode: string,
+  ) => Promise<PersistedRoomMatchLogRow | null>;
+  isRoomMatchLogsPersistenceAvailable: () => boolean;
+  queryRankedGameForMatch?: (
+    playerId: string,
+    sourceMatchId: string,
+  ) => Promise<RankedGameRatingRow | null>;
+};
+
+export async function queryRankedGameForMatch(
+  playerId: string,
+  sourceMatchId: string,
+): Promise<RankedGameRatingRow | null> {
+  if (!isRankedGameSourceColumnsEnabled()) return null;
+  try {
+    const rows = await supabaseFetch<RankedGameRatingRow[]>(
+      `/rest/v1/ranked_games?select=player_id,rating_before,rating_after,delta,source_match_id&player_id=eq.${encodeURIComponent(playerId)}&source_match_id=eq.${encodeURIComponent(sourceMatchId)}&limit=1`,
+      { method: 'GET' },
+    );
+    return rows[0] ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function firstQueryValue(value: unknown): string {
+  if (typeof value === 'string') return value.trim();
+  if (Array.isArray(value) && typeof value[0] === 'string') return value[0].trim();
+  return '';
+}
+
+export function registerPrivateMatchResultRoutes(
+  app: Application,
+  deps: PrivateMatchResultRouteDeps,
+): void {
+  const {
+    getAuthenticatedUserId,
+    queryPersistedRoomMatchLog,
+    queryLatestPersistedRoomMatchLogByRoomCode,
+    isRoomMatchLogsPersistenceAvailable,
+    queryRankedGameForMatch: queryRankedGame = queryRankedGameForMatch,
+  } = deps;
+
+  app.get('/api/private-match/result', async (req: Request, res: Response) => {
+    try {
+      const authenticatedUserId = await getAuthenticatedUserId(req);
+      if (!authenticatedUserId) {
+        res.status(401).json({ error: 'Unauthorized' });
+        return;
+      }
+
+      const matchId = firstQueryValue(req.query.matchId);
+      const roomCode = firstQueryValue(req.query.roomCode);
+      if (!matchId && !roomCode) {
+        res.status(400).json({ error: 'matchId or roomCode is required.' });
+        return;
+      }
+
+      const log = matchId
+        ? await queryPersistedRoomMatchLog(matchId)
+        : await queryLatestPersistedRoomMatchLogByRoomCode(roomCode);
+
+      if (!log) {
+        if (!isRoomMatchLogsPersistenceAvailable()) {
+          res.status(503).json({ error: 'Room event persistence is not configured.' });
+          return;
+        }
+        res.status(404).json({ error: 'Match result not found.' });
+        return;
+      }
+
+      if (!log.participant_user_ids.includes(authenticatedUserId)) {
+        res.status(403).json({ error: 'Forbidden' });
+        return;
+      }
+
+      const rankedGame = await queryRankedGame(authenticatedUserId, log.match_id);
+      const built = buildPrivateMatchResult({
+        log,
+        viewerUserId: authenticatedUserId,
+        rankedGame,
+      });
+      if (!built.ok) {
+        res.status(403).json({ error: 'Forbidden' });
+        return;
+      }
+
+      res.setHeader('Cache-Control', 'private, max-age=300, stale-while-revalidate=3600');
+      res.json({ ok: true, result: built.result });
+    } catch (error) {
+      res.status(500).json({
+        error: error instanceof Error ? error.message : 'Failed to load match result.',
+      });
+    }
+  });
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -295,6 +295,10 @@ import {
 } from './http/stores/dailyFritzAuthorityReadiness';
 import { isDailyFritzTransactionalAuthorityEnabled } from './dailyFritzAuthorityFeature';
 import { registerRoomEventsRoutes } from './http/routes/roomEvents';
+import {
+  queryRankedGameForMatch,
+  registerPrivateMatchResultRoutes,
+} from './http/routes/privateMatchResult';
 import type { BotMatchPendingRow } from './supabaseTypes';
 import {
   listCompletedDailyFritzDatesForUser,
@@ -579,6 +583,14 @@ registerRoomEventsRoutes(app, {
   queryPersistedRoomMatchLog,
   queryLatestPersistedRoomMatchLogByRoomCode,
   isRoomMatchLogsPersistenceAvailable,
+});
+
+registerPrivateMatchResultRoutes(app, {
+  getAuthenticatedUserId,
+  queryPersistedRoomMatchLog,
+  queryLatestPersistedRoomMatchLogByRoomCode,
+  isRoomMatchLogsPersistenceAvailable,
+  queryRankedGameForMatch,
 });
 
 

--- a/server/src/multiplayer/buildPrivateMatchResult.ts
+++ b/server/src/multiplayer/buildPrivateMatchResult.ts
@@ -1,0 +1,173 @@
+import type { PersistedRoomMatchLogRow } from './roomMatchLogPersistence';
+import {
+  rankingMessage,
+  type RankingOutcome,
+  type RankingSkipReason,
+} from './rankingOutcome';
+
+export type PrivateMatchSeat = {
+  seatId: string;
+  userId: string | null;
+  username: string;
+};
+
+export type PrivateMatchRankingBlock = {
+  eligible: boolean;
+  applied: boolean;
+  skipReason: RankingSkipReason | null;
+  message: string | null;
+  ratingBefore: number | null;
+  ratingAfter: number | null;
+  ratingDelta: number | null;
+};
+
+export type PrivateMatchResult = {
+  matchId: string;
+  roomCode: string;
+  terminalStatus: 'completed' | 'abandoned';
+  archivedAt: string;
+  you: PrivateMatchSeat;
+  opponent: PrivateMatchSeat;
+  outcome: 'win' | 'loss' | 'draw';
+  yourScore: number;
+  opponentScore: number;
+};
+
+export type RankedGameRatingRow = {
+  player_id: string;
+  rating_before?: number | null;
+  rating_after?: number | null;
+  delta?: number | null;
+};
+
+type Participant = {
+  id: string;
+  username: string;
+  userId: string | null;
+  seatIndex: number;
+};
+
+function asParticipants(value: unknown): Participant[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((entry) => {
+    if (!entry || typeof entry !== 'object') return [];
+    const row = entry as Record<string, unknown>;
+    if (typeof row.id !== 'string') return [];
+    return [
+      {
+        id: row.id,
+        username: typeof row.username === 'string' && row.username.trim() ? row.username : 'Player',
+        userId: typeof row.userId === 'string' ? row.userId : null,
+        seatIndex: typeof row.seatIndex === 'number' ? row.seatIndex : 0,
+      },
+    ];
+  });
+}
+
+function asScores(summary: Record<string, unknown> | null): Record<string, number> {
+  const scores = summary?.scores;
+  if (!scores || typeof scores !== 'object') return {};
+  return Object.fromEntries(
+    Object.entries(scores as Record<string, unknown>).filter(
+      (entry): entry is [string, number] => typeof entry[1] === 'number' && Number.isFinite(entry[1]),
+    ),
+  );
+}
+
+function asRankingOutcome(summary: Record<string, unknown> | null): RankingOutcome | null {
+  const raw = summary?.rankingOutcome;
+  if (!raw || typeof raw !== 'object') return null;
+  const row = raw as Record<string, unknown>;
+  return {
+    glickoEligible: row.glickoEligible === true,
+    glickoApplied: row.glickoApplied === true,
+    skipReason:
+      row.skipReason === 'move_log_verification_failed' ||
+      row.skipReason === 'duplicate' ||
+      row.skipReason === 'not_ranked'
+        ? row.skipReason
+        : null,
+  };
+}
+
+function resolveOutcome(params: {
+  yourSeatId: string;
+  yourScore: number;
+  opponentScore: number;
+  winnerId: string | null;
+}): 'win' | 'loss' | 'draw' {
+  if (params.winnerId) {
+    if (params.winnerId === params.yourSeatId) return 'win';
+    return 'loss';
+  }
+  if (params.yourScore === params.opponentScore) return 'draw';
+  return params.yourScore > params.opponentScore ? 'win' : 'loss';
+}
+
+export function buildPrivateMatchResult(params: {
+  log: PersistedRoomMatchLogRow;
+  viewerUserId: string;
+  rankedGame?: RankedGameRatingRow | null;
+}):
+  | { ok: true; result: PrivateMatchResult & { ranking: PrivateMatchRankingBlock } }
+  | { ok: false; reason: 'not_a_participant' } {
+  const participants = asParticipants(params.log.participants);
+  const you = participants.find((participant) => participant.userId === params.viewerUserId);
+  if (!you) {
+    return { ok: false, reason: 'not_a_participant' };
+  }
+  const opponent =
+    participants.find((participant) => participant.id !== you.id) ?? {
+      id: 'unknown',
+      username: 'Opponent',
+      userId: null,
+      seatIndex: you.seatIndex === 0 ? 1 : 0,
+    };
+
+  const scores = asScores(params.log.summary);
+  const yourScore = scores[you.id] ?? 0;
+  const opponentScore = scores[opponent.id] ?? 0;
+  const winnerId =
+    typeof params.log.summary?.winnerId === 'string' ? params.log.summary.winnerId : null;
+  const rankingOutcome = asRankingOutcome(params.log.summary);
+  const inferredFromRankedGame =
+    !rankingOutcome && params.rankedGame != null && params.rankedGame.rating_after != null;
+  const applied = rankingOutcome?.glickoApplied === true || inferredFromRankedGame;
+  const eligible = rankingOutcome?.glickoEligible === true || inferredFromRankedGame;
+  const skipReason = applied
+    ? null
+    : rankingOutcome?.skipReason ?? (eligible ? null : 'not_ranked');
+
+  return {
+    ok: true,
+    result: {
+      matchId: params.log.match_id,
+      roomCode: params.log.room_code,
+      terminalStatus: params.log.status,
+      archivedAt: params.log.archived_at,
+      you: { seatId: you.id, userId: you.userId, username: you.username },
+      opponent: {
+        seatId: opponent.id,
+        userId: opponent.userId,
+        username: opponent.username,
+      },
+      outcome: resolveOutcome({
+        yourSeatId: you.id,
+        yourScore,
+        opponentScore,
+        winnerId,
+      }),
+      yourScore,
+      opponentScore,
+      ranking: {
+        eligible,
+        applied,
+        skipReason,
+        message: rankingMessage(applied),
+        ratingBefore: params.rankedGame?.rating_before ?? null,
+        ratingAfter: params.rankedGame?.rating_after ?? null,
+        ratingDelta: params.rankedGame?.delta ?? null,
+      },
+    },
+  };
+}

--- a/server/src/multiplayer/rankingOutcome.ts
+++ b/server/src/multiplayer/rankingOutcome.ts
@@ -1,0 +1,37 @@
+export type RankingSkipReason = 'move_log_verification_failed' | 'duplicate' | 'not_ranked';
+
+export type RankingOutcome = {
+  glickoEligible: boolean;
+  glickoApplied: boolean;
+  skipReason?: RankingSkipReason | null;
+};
+
+export const RANKING_NOT_UPDATED_COPY = 'Rating not updated for this match';
+
+export function rankingMessage(applied: boolean): string | null {
+  return applied ? null : RANKING_NOT_UPDATED_COPY;
+}
+
+export function rankingOutcomeNotRanked(): RankingOutcome {
+  return { glickoEligible: false, glickoApplied: false, skipReason: 'not_ranked' };
+}
+
+export function rankingOutcomeVerificationSkipped(): RankingOutcome {
+  return {
+    glickoEligible: false,
+    glickoApplied: false,
+    skipReason: 'move_log_verification_failed',
+  };
+}
+
+export function rankingOutcomeApplied(): RankingOutcome {
+  return { glickoEligible: true, glickoApplied: true, skipReason: null };
+}
+
+export function rankingOutcomeDuplicate(): RankingOutcome {
+  return { glickoEligible: true, glickoApplied: false, skipReason: 'duplicate' };
+}
+
+export function rankingOutcomeEligibleNotApplied(): RankingOutcome {
+  return { glickoEligible: true, glickoApplied: false, skipReason: null };
+}

--- a/server/src/multiplayer/roomMatchLogPersistence.test.ts
+++ b/server/src/multiplayer/roomMatchLogPersistence.test.ts
@@ -129,6 +129,11 @@ function seedTerminalRoom(roomCode = 'CLN001') {
   room.eventLogVersion = 1;
   room.eventSequence = 1;
   room.events = [mkEvent(room)];
+  room.rankingOutcome = {
+    glickoEligible: false,
+    glickoApplied: false,
+    skipReason: 'move_log_verification_failed',
+  };
 
   setRoomRoster(roomCode, [
     {
@@ -224,6 +229,13 @@ describe('roomMatchLogPersistence terminal cleanup', () => {
     expect(archived).toBeDefined();
     expect(archived?.status).toBe('completed');
     expect(archived?.room_code).toBe('CLN001');
+    expect(archived?.summary).toMatchObject({
+      rankingOutcome: {
+        glickoEligible: false,
+        glickoApplied: false,
+        skipReason: 'move_log_verification_failed',
+      },
+    });
     expect(terminalLiveStatuses).toContain('game_over');
     expect(persistenceStore.liveSessions.has('CLN001')).toBe(false);
 

--- a/server/src/multiplayer/roomMatchLogPersistence.ts
+++ b/server/src/multiplayer/roomMatchLogPersistence.ts
@@ -94,6 +94,7 @@ function buildPersistedRoomSummary(
         typeof (room.config as Record<string, unknown>)?.winningScore === 'number'
           ? (room.config as Record<string, unknown>).winningScore
           : null,
+      rankingOutcome: room.rankingOutcome ?? null,
     };
   }
 
@@ -112,6 +113,7 @@ function buildPersistedRoomSummary(
     handCounts: Object.fromEntries(
       room.state.playerIds.map((playerId) => [playerId, room.state?.players[playerId]?.hand.length ?? 0]),
     ),
+    rankingOutcome: room.rankingOutcome ?? null,
   };
 }
 

--- a/server/src/realtime/gameOverPersistence.test.ts
+++ b/server/src/realtime/gameOverPersistence.test.ts
@@ -503,8 +503,9 @@ describe('createGameOverPersistScheduler', () => {
     it('verifies both logs before ranked insert and applies Glicko when both pass', async () => {
       verifyPlayerMoveLogMock.mockReturnValue({ ok: true });
       const { profileA, profileB, gameA, gameB } = mockHumanProfilesAndInserts();
+      const input = buildHumanInput();
 
-      await runPersist(buildHumanInput());
+      await runPersist(input);
 
       expect(verifyPlayerMoveLogMock).toHaveBeenCalledWith(logA, { strictHandContinuity: true });
       expect(verifyPlayerMoveLogMock).toHaveBeenCalledWith(logB, { strictHandContinuity: true });
@@ -521,6 +522,11 @@ describe('createGameOverPersistScheduler', () => {
       expect(completeGhostGameMock).toHaveBeenCalledWith(
         expect.objectContaining({ userId: 'user-b', applyGlicko: undefined }),
       );
+      expect(input.room.rankingOutcome).toEqual({
+        glickoEligible: true,
+        glickoApplied: true,
+        skipReason: null,
+      });
     });
 
     it('does not insert ranked_games or apply Glicko when either log fails verification', async () => {
@@ -528,11 +534,17 @@ describe('createGameOverPersistScheduler', () => {
         .mockReturnValueOnce({ ok: true })
         .mockReturnValueOnce({ ok: false, reason: 'fabricated board_state', entryIndex: 0 });
       mockHumanProfilesAndInserts();
+      const input = buildHumanInput();
 
-      await runPersist(buildHumanInput());
+      await runPersist(input);
 
       expect(insertRankedGameIdempotentMock).not.toHaveBeenCalled();
       expect(processRealtimeMultiplayerGameMock).not.toHaveBeenCalled();
+      expect(input.room.rankingOutcome).toEqual({
+        glickoEligible: false,
+        glickoApplied: false,
+        skipReason: 'move_log_verification_failed',
+      });
       expect(logWarnMock).toHaveBeenCalledWith(
         expect.objectContaining({
           roomCode: 'ROOM1',

--- a/server/src/realtime/gameOverPersistence.ts
+++ b/server/src/realtime/gameOverPersistence.ts
@@ -26,6 +26,13 @@ import type { GameOverPersistInput } from '../multiplayer/roomSession';
 import { emitMpAuthorityFunnel } from '../multiplayer/mpAuthorityTelemetry';
 import type { GhostMoveLogEntry } from '../ghost/service';
 import type { GhostMoveLogVerificationResult } from '../ghost/verifier';
+import {
+  rankingOutcomeApplied,
+  rankingOutcomeDuplicate,
+  rankingOutcomeEligibleNotApplied,
+  rankingOutcomeNotRanked,
+  rankingOutcomeVerificationSkipped,
+} from '../multiplayer/rankingOutcome';
 
 const log = childLogger('realtime:game-over');
 
@@ -184,6 +191,7 @@ export function createGameOverPersistScheduler(io: Server) {
         const rankedInsertResults = new Map<string, Awaited<ReturnType<typeof insertRankedGameIdempotent>>>();
         const rankedPlayedAt = new Date().toISOString();
         const rankedSourceColumnsEnabled = isRankedGameSourceColumnsEnabled();
+        let realtimeRankingApplied = false;
         log.info({
           roomCode: room.code,
           sourceMatchId,
@@ -299,6 +307,7 @@ export function createGameOverPersistScheduler(io: Server) {
                 playerAGame: playerAInsert.game,
                 playerBGame: playerBInsert.game,
               });
+              realtimeRankingApplied = true;
               log.info({
                 playerA: a.userId,
                 playerB: b.userId,
@@ -329,6 +338,21 @@ export function createGameOverPersistScheduler(io: Server) {
               sourceMatchId,
             }, 'Skipping real-time update — duplicate or missing ranked insert');
           }
+        }
+
+        if (!isHumanVsHuman) {
+          room.rankingOutcome = rankingOutcomeNotRanked();
+        } else if (!humanGlickoEligible) {
+          room.rankingOutcome = rankingOutcomeVerificationSkipped();
+        } else if (realtimeRankingApplied) {
+          room.rankingOutcome = rankingOutcomeApplied();
+        } else if (
+          (a.userId && rankedInsertResults.get(a.userId)?.isNew === false) ||
+          (b.userId && rankedInsertResults.get(b.userId)?.isNew === false)
+        ) {
+          room.rankingOutcome = rankingOutcomeDuplicate();
+        } else {
+          room.rankingOutcome = rankingOutcomeEligibleNotApplied();
         }
 
         const linkedFixtureRows = await supabaseFetch<any[]>(

--- a/server/src/rooms.ts
+++ b/server/src/rooms.ts
@@ -31,6 +31,7 @@ import {
 } from './multiplayer/roomDurability';
 import { flushScheduledLiveRoomPersistence, isLiveRoomDurablyRecoverable } from './multiplayer/roomLivePersistence';
 import { assertRoomDurabilityOperationAllowed } from './multiplayer/roomDurabilityPolicy';
+import type { RankingOutcome } from './multiplayer/rankingOutcome';
 import { childLogger } from './logger';
 
 const log = childLogger('rooms');
@@ -101,6 +102,8 @@ export type Room = {
   /** Active tile pool size when pre-game draw eliminated tiles (default: full double-6 set). */
   activeTileSetSize?: number;
   durability: RoomDurabilityState;
+  /** Written at game-over ranking time; copied into `room_match_logs.summary.rankingOutcome`. */
+  rankingOutcome?: RankingOutcome;
 };
 
 export type DrawAnimationStep = {


### PR DESCRIPTION
## Summary
- Adds `GET /api/private-match/result?roomCode=` / `?matchId=` with the product result shape (seats, scores, outcome, ranking) and **no** `events` / `state_snapshot`.
- Access control matches `roomEvents.ts`: 401 unauthenticated, 403 authenticated non-participant, 404 missing archive, 503 if `room_match_logs` is unavailable.
- Persists `summary.rankingOutcome` at game-over so the endpoint does not guess Glicko status. When `applied` is false, `ranking.message` is always the neutral copy **Rating not updated for this match**.

## Guest / P1 scope
This route is **authed-only**. Guests (`userId: null`) are omitted from `participant_user_ids`, so they get **401** without a JWT. A later signed-in account that was not on the match still gets **403**.

## Test plan
- [x] Participant fetch → 200, correct result shape, no event-log dump
- [x] Non-participant → 403
- [x] Unauthenticated → 401
- [x] No archive → 404
- [x] Verification-skipped match → `ranking.applied: false`, `skipReason: move_log_verification_failed`, neutral `message`
- [x] Guest seats documented as 401 / 403 (authed-only)
- [ ] Review access-control tests in `server/src/http/routes/privateMatchResult.test.ts` specifically


Made with [Cursor](https://cursor.com)