### PR TITLE
Private Match P2a: durable mp.authority events + fill emit gaps

### DIFF
--- a/server/src/dbIdempotencySchema.test.ts
+++ b/server/src/dbIdempotencySchema.test.ts
@@ -307,4 +307,20 @@ describe('DB idempotency schema guardrails', () => {
     expect(sql).toContain('create or replace view public.fritz_challenge_funnel_metrics');
     expect(sql).toContain('create or replace view public.fritz_challenge_failure_metrics');
   });
+
+  it('ships durable mp.authority events and Pacific funnel view', () => {
+    const sql = compactSql(readRepoFile(
+      'supabase/migrations/2026-08-20_mp_authority_events.sql',
+    ));
+    expect(sql).toContain('create table if not exists public.mp_authority_events');
+    expect(sql).toContain("'private_terminal_recovery'");
+    expect(sql).toContain("'private_match_archived'");
+    expect(sql).toContain("source_type in ('private', 'quick', 'tournament')");
+    expect(sql).toContain('create or replace view public.mp_authority_funnel_metrics');
+    expect(sql).toContain("(ts at time zone 'america/los_angeles')::date as event_date");
+    expect(sql).toContain('with (security_invoker = true)');
+    expect(sql).toContain('revoke all on public.mp_authority_funnel_metrics from anon, authenticated');
+    expect(sql).toContain('grant select on public.mp_authority_funnel_metrics to service_role');
+    expect(sql).toContain('mp_authority_events_no_client_access');
+  });
 });

--- a/server/src/http/routes/privateMatchResult.test.ts
+++ b/server/src/http/routes/privateMatchResult.test.ts
@@ -1,8 +1,9 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { Application } from 'express';
 import type { PersistedRoomMatchLogRow } from '../../multiplayer/roomMatchLogPersistence';
 import { RANKING_NOT_UPDATED_COPY } from '../../multiplayer/rankingOutcome';
 import { registerPrivateMatchResultRoutes } from './privateMatchResult';
+import * as telemetry from '../../multiplayer/mpAuthorityTelemetry';
 
 type Handler = (req: unknown, res: unknown) => unknown | Promise<unknown>;
 
@@ -100,7 +101,11 @@ function makeHarness(options: {
 }
 
 describe('GET /api/private-match/result', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
   it('returns the product result shape for a participant, without events or state_snapshot', async () => {
+    const emit = vi.spyOn(telemetry, 'emitMpAuthorityFunnel');
     const request = makeHarness();
     const response = await request({ matchId: MATCH_ID });
 
@@ -131,6 +136,14 @@ describe('GET /api/private-match/result', () => {
     expect(JSON.stringify(response.body)).not.toContain('must-not-leak');
     expect(JSON.stringify(response.body)).not.toContain('state_snapshot');
     expect(JSON.stringify(response.body)).not.toContain('"events"');
+    expect(emit).toHaveBeenCalledWith('private_terminal_recovery', expect.objectContaining({
+      roomCode: 'ROOM1',
+      extra: expect.objectContaining({
+        source: 'result_ok',
+        matchId: MATCH_ID,
+        status: 'completed',
+      }),
+    }));
   });
 
   it('returns 403 when an authenticated user is not a participant', async () => {
@@ -150,11 +163,13 @@ describe('GET /api/private-match/result', () => {
   });
 
   it('returns 404 when no archive exists for the given id', async () => {
+    const emit = vi.spyOn(telemetry, 'emitMpAuthorityFunnel');
     const request = makeHarness({ log: null });
     await expect(request({ matchId: MATCH_ID })).resolves.toMatchObject({
       status: 404,
       body: { error: 'Match result not found.' },
     });
+    expect(emit).not.toHaveBeenCalled();
   });
 
   it('reports verification-skipped ranking with the neutral copy field', async () => {

--- a/server/src/http/routes/privateMatchResult.ts
+++ b/server/src/http/routes/privateMatchResult.ts
@@ -5,6 +5,7 @@ import {
   type RankedGameRatingRow,
 } from '../../multiplayer/buildPrivateMatchResult';
 import { isRankedGameSourceColumnsEnabled } from '../../ranking/rankedGamePayload';
+import { emitMpAuthorityFunnel } from '../../multiplayer/mpAuthorityTelemetry';
 import { supabaseFetch } from '../../supabaseUtils';
 
 export type PrivateMatchResultRouteDeps = {
@@ -99,6 +100,14 @@ export function registerPrivateMatchResultRoutes(
       }
 
       res.setHeader('Cache-Control', 'private, max-age=300, stale-while-revalidate=3600');
+      emitMpAuthorityFunnel('private_terminal_recovery', {
+        roomCode: log.room_code,
+        extra: {
+          source: 'result_ok',
+          matchId: log.match_id,
+          status: log.status,
+        },
+      });
       res.json({ ok: true, result: built.result });
     } catch (error) {
       res.status(500).json({

--- a/server/src/matchmaking/handleMatched.funnel.test.ts
+++ b/server/src/matchmaking/handleMatched.funnel.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Server } from 'socket.io';
+import { resetRoomRuntimeForTests, getRoom } from '../rooms';
+import * as telemetry from '../multiplayer/mpAuthorityTelemetry';
+import { handleMatched } from './index';
+import type { QueuedPlayer } from './types';
+
+vi.mock('./persistence', () => ({
+  recordMatchStart: vi.fn(async () => ({
+    id: 'mm-match-1',
+    roomCode: 'MMTEST',
+    playerAId: 'user-a',
+    playerBId: 'user-b',
+    playerARating: 800,
+    playerBRating: 810,
+    status: 'in_progress',
+    winnerId: null,
+    playerARatingChange: null,
+    playerBRatingChange: null,
+    isSim: false,
+    startedAt: '2026-08-20T00:00:00.000Z',
+    endedAt: null,
+  })),
+}));
+
+function player(overrides: Partial<QueuedPlayer>): QueuedPlayer {
+  return {
+    socketId: 'sock-a',
+    userId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+    username: 'A',
+    rating: 800,
+    joinedAt: Date.now(),
+    isSim: false,
+    ...overrides,
+  };
+}
+
+describe('quick-match lobby funnel', () => {
+  beforeEach(() => {
+    resetRoomRuntimeForTests();
+  });
+
+  it('emits private_lobby_created with sourceType quick after matchmaking records the match', async () => {
+    const emit = vi.spyOn(telemetry, 'emitMpAuthorityFunnel');
+    const io = {
+      to: vi.fn(() => ({ emit: vi.fn() })),
+    } as unknown as Server;
+
+    await handleMatched(
+      io,
+      player({ socketId: 'sock-a', userId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa' }),
+      player({ socketId: 'sock-b', userId: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb', username: 'B', rating: 810 }),
+    );
+
+    expect(emit).toHaveBeenCalledWith('private_lobby_created', expect.objectContaining({
+      sourceType: 'quick',
+      extra: { matchmakingMatchId: 'mm-match-1' },
+    }));
+    const roomCode = emit.mock.calls.find((call) => call[0] === 'private_lobby_created')?.[1]?.roomCode;
+    expect(roomCode).toBeTruthy();
+    expect(getRoom(String(roomCode)).matchmakingMatchId).toBe('mm-match-1');
+  });
+});

--- a/server/src/matchmaking/index.ts
+++ b/server/src/matchmaking/index.ts
@@ -6,6 +6,7 @@ import { QueueService } from './queueService';
 import type { MatchFoundPayload, QueuedPlayer } from './types';
 import { recordMatchStart } from './persistence';
 import { isForbiddenMatchmakingPlayer } from './forbiddenQueuePlayer';
+import { emitMpAuthorityFunnel } from '../multiplayer/mpAuthorityTelemetry';
 
 const log = childLogger('matchmaking');
 
@@ -259,7 +260,7 @@ function tryRequeueHumanAfterAbortedMatch(p: QueuedPlayer): void {
   }
 }
 
-async function handleMatched(io: Server, a: QueuedPlayer, b: QueuedPlayer): Promise<void> {
+export async function handleMatched(io: Server, a: QueuedPlayer, b: QueuedPlayer): Promise<void> {
   if (isForbiddenMatchmakingPlayer(a) || isForbiddenMatchmakingPlayer(b)) {
     log.warn({
       a: { userId: a.userId, username: a.username, isSim: a.isSim },
@@ -279,6 +280,11 @@ async function handleMatched(io: Server, a: QueuedPlayer, b: QueuedPlayer): Prom
     const room = getRoom(code);
     if (room) {
       room.matchmakingMatchId = record.id;
+      emitMpAuthorityFunnel('private_lobby_created', {
+        roomCode: code,
+        sourceType: 'quick',
+        extra: { matchmakingMatchId: record.id },
+      });
     }
 
     const aPayload: MatchFoundPayload = {

--- a/server/src/multiplayer/botSeating.test.ts
+++ b/server/src/multiplayer/botSeating.test.ts
@@ -20,6 +20,7 @@ vi.mock('../supabaseUtils', () => ({
     if (path.includes('/room_live_sessions') && init?.method === 'POST') {
       return undefined;
     }
+    if (path.includes('/mp_authority_events')) return undefined;
     throw new Error(`unexpected supabaseFetch call: ${init?.method ?? 'GET'} ${path}`);
   }),
 }));

--- a/server/src/multiplayer/matchStartReady.test.ts
+++ b/server/src/multiplayer/matchStartReady.test.ts
@@ -1,0 +1,34 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createReservedRoom, joinRoom, resetRoomRuntimeForTests } from '../rooms';
+import * as rooms from '../rooms';
+import { markMatchStartReady, tryStartMatchIfReady } from './matchStartReady';
+import * as telemetry from './mpAuthorityTelemetry';
+
+describe('tryStartMatchIfReady authority funnel', () => {
+  beforeEach(() => {
+    resetRoomRuntimeForTests();
+  });
+
+  it('emits private_match_started only when the match actually starts', async () => {
+    const emit = vi.spyOn(telemetry, 'emitMpAuthorityFunnel');
+    vi.spyOn(rooms, 'initiatePregameDrawOrStart').mockImplementation(async (code) => rooms.getRoom(code));
+
+    createReservedRoom('STRT0');
+    joinRoom('STRT0', 'seat-a');
+    joinRoom('STRT0', 'seat-b');
+    markMatchStartReady('STRT0', 'seat-a');
+
+    await expect(tryStartMatchIfReady('STRT0', {} as never, {
+      broadcastStateUpdate: vi.fn(),
+    })).resolves.toEqual({ started: false, waitingFor: ['seat-b'] });
+    expect(emit).not.toHaveBeenCalledWith('private_match_started', expect.anything());
+
+    markMatchStartReady('STRT0', 'seat-b');
+    await expect(tryStartMatchIfReady('STRT0', {} as never, {
+      broadcastStateUpdate: vi.fn(),
+    })).resolves.toEqual({ started: true });
+    expect(emit).toHaveBeenCalledWith('private_match_started', expect.objectContaining({
+      roomCode: 'STRT0',
+    }));
+  });
+});

--- a/server/src/multiplayer/matchStartReady.ts
+++ b/server/src/multiplayer/matchStartReady.ts
@@ -1,5 +1,7 @@
 import type { Server } from 'socket.io';
-import { getRoom, initiatePregameDrawOrStart, type Room } from '../rooms';
+import * as rooms from '../rooms';
+import type { Room } from '../rooms';
+import { emitMpAuthorityFunnel, resolveMpAuthoritySourceType } from './mpAuthorityTelemetry';
 
 export type MatchStartDeps = {
   broadcastStateUpdate: (roomCode: string) => void;
@@ -11,7 +13,7 @@ function requiredStartPlayers(room: Room): string[] {
 }
 
 export function markMatchStartReady(roomCode: string, socketId: string): Room {
-  const room = getRoom(roomCode);
+  const room = rooms.getRoom(roomCode);
   room.matchStartReady.add(socketId);
   return room;
 }
@@ -21,7 +23,7 @@ export async function tryStartMatchIfReady(
   io: Server,
   deps: MatchStartDeps,
 ): Promise<{ started: boolean; waitingFor?: string[] }> {
-  const room = getRoom(roomCode);
+  const room = rooms.getRoom(roomCode);
   if (room.state) {
     return { started: false };
   }
@@ -36,8 +38,12 @@ export async function tryStartMatchIfReady(
     return { started: false, waitingFor: missing };
   }
 
-  const startedRoom = await initiatePregameDrawOrStart(roomCode, io);
+  const startedRoom = await rooms.initiatePregameDrawOrStart(roomCode, io);
   room.matchStartReady.clear();
   deps.broadcastStateUpdate(startedRoom.code);
+  emitMpAuthorityFunnel('private_match_started', {
+    roomCode: startedRoom.code,
+    sourceType: resolveMpAuthoritySourceType(startedRoom),
+  });
   return { started: true };
 }

--- a/server/src/multiplayer/mpAuthorityEventStore.test.ts
+++ b/server/src/multiplayer/mpAuthorityEventStore.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../supabaseUtils', () => ({ supabaseFetch: vi.fn() }));
+
+import { supabaseFetch } from '../supabaseUtils';
+import {
+  MP_AUTHORITY_EVENT_WRITE_TIMEOUT_MS,
+  flushMpAuthorityEventPersistForTests,
+  groupMpAuthorityFunnelMetrics,
+  pacificEventDate,
+  queryMpAuthorityFunnelMetrics,
+  recordMpAuthorityEvent,
+  recordMpAuthorityEventBestEffort,
+} from './mpAuthorityEventStore';
+import { emitMpAuthorityFunnel } from './mpAuthorityTelemetry';
+
+describe('mp.authority event store', () => {
+  beforeEach(() => {
+    vi.mocked(supabaseFetch).mockReset();
+  });
+
+  afterEach(async () => {
+    await flushMpAuthorityEventPersistForTests();
+  });
+
+  it('writes a funnel row to PostgREST', async () => {
+    vi.mocked(supabaseFetch).mockResolvedValue(undefined);
+
+    await recordMpAuthorityEvent({
+      event: 'private_lobby_created',
+      ts: '2026-08-20T07:30:00.000Z',
+      roomCode: 'ROOM1',
+      seatId: 'seat-a',
+      requestId: 'req-1',
+      failureCode: null,
+      sourceType: 'private',
+      payload: { host: true },
+    });
+
+    expect(supabaseFetch).toHaveBeenCalledWith(
+      '/rest/v1/mp_authority_events',
+      expect.objectContaining({
+        method: 'POST',
+        headers: { Prefer: 'return=minimal' },
+        timeoutMs: MP_AUTHORITY_EVENT_WRITE_TIMEOUT_MS,
+      }),
+    );
+    const body = JSON.parse(String(vi.mocked(supabaseFetch).mock.calls[0]?.[1]?.body))[0];
+    expect(body).toEqual({
+      event: 'private_lobby_created',
+      ts: '2026-08-20T07:30:00.000Z',
+      room_code: 'ROOM1',
+      seat_id: 'seat-a',
+      request_id: 'req-1',
+      failure_code: null,
+      source_type: 'private',
+      payload: { host: true },
+    });
+  });
+
+  it('best-effort insert failure does not throw', async () => {
+    vi.mocked(supabaseFetch).mockRejectedValue(new Error('db_down'));
+    await expect(recordMpAuthorityEventBestEffort({
+      event: 'private_action_committed',
+      ts: new Date().toISOString(),
+      roomCode: 'ROOM1',
+      seatId: null,
+      requestId: 'req-1',
+      failureCode: null,
+      sourceType: 'private',
+      payload: {},
+    })).resolves.toBeUndefined();
+  });
+
+  it('emitMpAuthorityFunnel keeps the console line and does not throw when persist fails', async () => {
+    vi.mocked(supabaseFetch).mockRejectedValue(new Error('db_down'));
+    const info = vi.spyOn(console, 'info').mockImplementation(() => {});
+
+    expect(() => emitMpAuthorityFunnel('private_action_uncertain', {
+      roomCode: 'ROOM1',
+      requestId: 'req-1',
+      failureCode: 'missing_request_id',
+    })).not.toThrow();
+
+    expect(info).toHaveBeenCalledWith(
+      '[mp.authority]',
+      expect.stringContaining('"event":"private_action_uncertain"'),
+    );
+
+    await flushMpAuthorityEventPersistForTests();
+    expect(supabaseFetch).toHaveBeenCalled();
+    info.mockRestore();
+  });
+
+  it('round-trips inserts through the funnel view grouping (Pacific date + event)', async () => {
+    const inserted: Array<{ event: string; ts: string }> = [];
+    vi.mocked(supabaseFetch).mockImplementation(async (path: string, init?: RequestInit) => {
+      if (String(path).includes('/mp_authority_events') && init?.method === 'POST') {
+        const rows = JSON.parse(String(init.body)) as Array<{ event: string; ts: string }>;
+        inserted.push(...rows);
+        return undefined;
+      }
+      if (String(path).includes('/mp_authority_funnel_metrics')) {
+        return groupMpAuthorityFunnelMetrics(inserted).map((row) => ({
+          event_date: row.eventDate,
+          event: row.event,
+          total: row.total,
+        }));
+      }
+      throw new Error(`unexpected ${init?.method} ${path}`);
+    });
+
+    // 2026-08-20T06:30Z is still 2026-08-19 in America/Los_Angeles (PDT, UTC-7).
+    await recordMpAuthorityEvent({
+      event: 'private_lobby_created',
+      ts: '2026-08-20T06:30:00.000Z',
+      roomCode: 'A',
+      seatId: null,
+      requestId: null,
+      failureCode: null,
+      sourceType: 'private',
+      payload: {},
+    });
+    await recordMpAuthorityEvent({
+      event: 'private_lobby_created',
+      ts: '2026-08-20T07:30:00.000Z',
+      roomCode: 'B',
+      seatId: null,
+      requestId: null,
+      failureCode: null,
+      sourceType: 'private',
+      payload: {},
+    });
+    await recordMpAuthorityEvent({
+      event: 'private_match_started',
+      ts: '2026-08-20T07:45:00.000Z',
+      roomCode: 'B',
+      seatId: null,
+      requestId: null,
+      failureCode: null,
+      sourceType: 'private',
+      payload: {},
+    });
+
+    expect(pacificEventDate('2026-08-20T06:30:00.000Z')).toBe('2026-08-19');
+    expect(pacificEventDate('2026-08-20T07:30:00.000Z')).toBe('2026-08-20');
+
+    await expect(queryMpAuthorityFunnelMetrics()).resolves.toEqual([
+      { eventDate: '2026-08-19', event: 'private_lobby_created', total: 1 },
+      { eventDate: '2026-08-20', event: 'private_lobby_created', total: 1 },
+      { eventDate: '2026-08-20', event: 'private_match_started', total: 1 },
+    ]);
+  });
+});

--- a/server/src/multiplayer/mpAuthorityEventStore.ts
+++ b/server/src/multiplayer/mpAuthorityEventStore.ts
@@ -1,0 +1,108 @@
+import { supabaseFetch } from '../supabaseUtils';
+import { childLogger } from '../logger';
+import type {
+  MpAuthorityFailureCode,
+  MpAuthorityFunnelEvent,
+  MpAuthoritySourceType,
+} from './mpAuthorityTelemetry';
+
+const log = childLogger('mp-authority-events');
+
+export const MP_AUTHORITY_EVENT_WRITE_TIMEOUT_MS = 2_500;
+
+export type MpAuthorityEventRecord = {
+  event: MpAuthorityFunnelEvent;
+  ts: string;
+  roomCode: string | null;
+  seatId: string | null;
+  requestId: string | null;
+  failureCode: MpAuthorityFailureCode | null;
+  sourceType: MpAuthoritySourceType | null;
+  payload: Record<string, unknown>;
+};
+
+export type MpAuthorityFunnelMetricRow = {
+  eventDate: string;
+  event: string;
+  total: number;
+};
+
+/** Calendar date in America/Los_Angeles, matching mp_authority_funnel_metrics. */
+export function pacificEventDate(ts: string | Date): string {
+  return new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'America/Los_Angeles',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).format(new Date(ts));
+}
+
+export function groupMpAuthorityFunnelMetrics(
+  rows: Array<{ event: string; ts: string }>,
+): MpAuthorityFunnelMetricRow[] {
+  const counts = new Map<string, number>();
+  for (const row of rows) {
+    const key = `${pacificEventDate(row.ts)}\0${row.event}`;
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
+  return [...counts.entries()]
+    .map(([key, total]) => {
+      const [eventDate, event] = key.split('\0');
+      return { eventDate, event, total };
+    })
+    .sort((a, b) => a.eventDate.localeCompare(b.eventDate) || a.event.localeCompare(b.event));
+}
+
+export async function recordMpAuthorityEvent(row: MpAuthorityEventRecord): Promise<void> {
+  await supabaseFetch('/rest/v1/mp_authority_events', {
+    method: 'POST',
+    headers: {
+      Prefer: 'return=minimal',
+    },
+    timeoutMs: MP_AUTHORITY_EVENT_WRITE_TIMEOUT_MS,
+    body: JSON.stringify([{
+      event: row.event,
+      ts: row.ts,
+      room_code: row.roomCode,
+      seat_id: row.seatId,
+      request_id: row.requestId,
+      failure_code: row.failureCode,
+      source_type: row.sourceType,
+      payload: row.payload,
+    }]),
+  });
+}
+
+export async function recordMpAuthorityEventBestEffort(row: MpAuthorityEventRecord): Promise<void> {
+  try {
+    await recordMpAuthorityEvent(row);
+  } catch (error) {
+    log.warn({
+      event: row.event,
+      roomCode: row.roomCode,
+      error: error instanceof Error ? error.message : String(error),
+    }, '[mp.authority] persistence failed');
+  }
+}
+
+export async function queryMpAuthorityFunnelMetrics(): Promise<MpAuthorityFunnelMetricRow[]> {
+  const rows = await supabaseFetch<Array<Record<string, unknown>>>(
+    '/rest/v1/mp_authority_funnel_metrics?select=event_date,event,total',
+    { method: 'GET' },
+  );
+  return rows.map((row) => ({
+    eventDate: String(row.event_date),
+    event: String(row.event),
+    total: Number(row.total) || 0,
+  }));
+}
+
+let persistChain: Promise<void> = Promise.resolve();
+
+export function queueMpAuthorityEventPersist(row: MpAuthorityEventRecord): void {
+  persistChain = persistChain.then(() => recordMpAuthorityEventBestEffort(row));
+}
+
+export async function flushMpAuthorityEventPersistForTests(): Promise<void> {
+  await persistChain;
+}

--- a/server/src/multiplayer/mpAuthorityEventStore.ts
+++ b/server/src/multiplayer/mpAuthorityEventStore.ts
@@ -97,12 +97,15 @@ export async function queryMpAuthorityFunnelMetrics(): Promise<MpAuthorityFunnel
   }));
 }
 
-let persistChain: Promise<void> = Promise.resolve();
+const pendingPersists = new Set<Promise<void>>();
 
 export function queueMpAuthorityEventPersist(row: MpAuthorityEventRecord): void {
-  persistChain = persistChain.then(() => recordMpAuthorityEventBestEffort(row));
+  const pending = recordMpAuthorityEventBestEffort(row).finally(() => {
+    pendingPersists.delete(pending);
+  });
+  pendingPersists.add(pending);
 }
 
 export async function flushMpAuthorityEventPersistForTests(): Promise<void> {
-  await persistChain;
+  await Promise.all([...pendingPersists]);
 }

--- a/server/src/multiplayer/mpAuthorityTelemetry.ts
+++ b/server/src/multiplayer/mpAuthorityTelemetry.ts
@@ -3,6 +3,11 @@
  * Emits operational logs with a stable failure/funnel taxonomy for dashboards.
  */
 
+import {
+  queueMpAuthorityEventPersist,
+  type MpAuthorityEventRecord,
+} from './mpAuthorityEventStore';
+
 export type MpAuthorityFunnelEvent =
   | 'private_lobby_created'
   | 'private_match_started'
@@ -16,7 +21,8 @@ export type MpAuthorityFunnelEvent =
   | 'private_match_archived'
   | 'private_durability_degraded'
   | 'private_durability_failed'
-  | 'private_move_log_verification_failed';
+  | 'private_move_log_verification_failed'
+  | 'private_terminal_recovery';
 
 export type MpAuthorityFailureCode =
   | 'missing_request_id'
@@ -29,30 +35,86 @@ export type MpAuthorityFailureCode =
   | 'recovery_exhausted'
   | 'move_log_verification_failed';
 
+export type MpAuthoritySourceType = 'private' | 'quick' | 'tournament';
+
 type EmitPayload = {
   roomCode?: string;
   seatId?: string;
   requestId?: string;
   sequence?: number | null;
   failureCode?: MpAuthorityFailureCode;
+  sourceType?: MpAuthoritySourceType;
   extra?: Record<string, unknown>;
 };
+
+export function resolveMpAuthoritySourceType(room: {
+  matchmakingMatchId?: string | null;
+  scheduledTournamentMatchId?: string | null;
+  config?: { tournamentId?: string };
+}): MpAuthoritySourceType {
+  if (room.scheduledTournamentMatchId || room.config?.tournamentId) return 'tournament';
+  if (room.matchmakingMatchId) return 'quick';
+  return 'private';
+}
 
 export function emitMpAuthorityFunnel(
   event: MpAuthorityFunnelEvent,
   payload: EmitPayload = {},
 ): void {
+  const ts = new Date().toISOString();
   const line = {
     channel: 'mp.authority',
     event,
-    ts: new Date().toISOString(),
+    ts,
     roomCode: payload.roomCode ?? null,
     seatId: payload.seatId ?? null,
     requestId: payload.requestId ?? null,
     sequence: payload.sequence ?? null,
     failureCode: payload.failureCode ?? null,
+    sourceType: payload.sourceType ?? null,
     ...(payload.extra ?? {}),
   };
   // Structured single-line JSON for log shippers / Sentry breadcrumbs.
   console.info('[mp.authority]', JSON.stringify(line));
+
+  const record: MpAuthorityEventRecord = {
+    event,
+    ts,
+    roomCode: payload.roomCode ?? null,
+    seatId: payload.seatId ?? null,
+    requestId: payload.requestId ?? null,
+    failureCode: payload.failureCode ?? null,
+    sourceType: payload.sourceType ?? null,
+    payload: {
+      ...(payload.extra ?? {}),
+      ...(payload.sequence != null ? { sequence: payload.sequence } : {}),
+    },
+  };
+  queueMpAuthorityEventPersist(record);
+}
+
+const HYDRATION_REJECT_KINDS = new Set([
+  'snapshot_invalid',
+  'snapshot_stale',
+  'snapshot_freshness_unknown',
+  'persistence_unavailable',
+]);
+
+export function emitMpAuthorityHydrationResult(
+  roomCode: string,
+  result: { kind: string; error?: string },
+): void {
+  if (result.kind === 'hydrated') {
+    emitMpAuthorityFunnel('private_reconnect_hydrated', { roomCode });
+    return;
+  }
+  if (!HYDRATION_REJECT_KINDS.has(result.kind)) return;
+  const failed = result.kind === 'snapshot_invalid' || result.kind === 'persistence_unavailable';
+  emitMpAuthorityFunnel(failed ? 'private_durability_failed' : 'private_durability_degraded', {
+    roomCode,
+    failureCode: result.kind === 'persistence_unavailable'
+      ? 'room_persistence_failed'
+      : 'hydration_rejected',
+    extra: { hydrationKind: result.kind, error: result.error ?? null },
+  });
 }

--- a/server/src/multiplayer/registerRematchPregameHandlers.test.ts
+++ b/server/src/multiplayer/registerRematchPregameHandlers.test.ts
@@ -24,6 +24,7 @@ vi.mock('../supabaseUtils', () => ({
     if (path.includes('/room_command_receipts')) {
       return undefined;
     }
+    if (path.includes('/mp_authority_events')) return undefined;
     throw new Error(`unexpected supabaseFetch call: ${init?.method ?? 'GET'} ${path}`);
   }),
 }));

--- a/server/src/multiplayer/registerRoomJoinHandlers.test.ts
+++ b/server/src/multiplayer/registerRoomJoinHandlers.test.ts
@@ -3,6 +3,7 @@ import { resetRoomRuntimeForTests } from '../rooms';
 import { initRoomSession, resetRoomSessionStoresForTests } from './roomSession';
 import { registerRoomJoinHandlers } from './registerRoomJoinHandlers';
 import { MatchTerminalJoinError } from './matchTerminalJoin';
+import * as telemetry from './mpAuthorityTelemetry';
 
 function makeSocket() {
   const handlers = new Map<string, (...args: unknown[]) => void>();
@@ -86,6 +87,7 @@ describe('registerRoomJoinHandlers', () => {
     });
 
     const cb = vi.fn();
+    const emit = vi.spyOn(telemetry, 'emitMpAuthorityFunnel');
     await handlers.get('room:join')?.('ARCHV1', cb);
     expect(cb).toHaveBeenCalledWith({
       ok: false,
@@ -96,5 +98,13 @@ describe('registerRoomJoinHandlers', () => {
         recoverable: true,
       },
     });
+    expect(emit).toHaveBeenCalledWith('private_terminal_recovery', expect.objectContaining({
+      roomCode: 'ARCHV1',
+      extra: expect.objectContaining({
+        source: 'join_ack',
+        matchId: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+        status: 'completed',
+      }),
+    }));
   });
 });

--- a/server/src/multiplayer/registerRoomJoinHandlers.ts
+++ b/server/src/multiplayer/registerRoomJoinHandlers.ts
@@ -8,6 +8,7 @@ import {
 } from './roomSession';
 import type { AttachSocketToTrackedRoomFn } from './roomSocketAttach';
 import { MatchTerminalJoinError } from './matchTerminalJoin';
+import { emitMpAuthorityFunnel } from './mpAuthorityTelemetry';
 import { failedRoomLookupLimiter, socketRateLimitKey } from '../rateLimit';
 
 const log = childLogger('multiplayer:join');
@@ -78,6 +79,14 @@ export function registerRoomJoinHandlers(
         log.info(
           `[room:join] TERMINAL: code=${roomCode} matchId=${err.terminal.matchId} status=${err.terminal.status}`,
         );
+        emitMpAuthorityFunnel('private_terminal_recovery', {
+          roomCode,
+          extra: {
+            source: 'join_ack',
+            matchId: err.terminal.matchId,
+            status: err.terminal.status,
+          },
+        });
         cb?.({ ok: false, error: err.code, terminal: err.terminal });
         return;
       }

--- a/server/src/multiplayer/registerRoomLifecycleHandlers.test.ts
+++ b/server/src/multiplayer/registerRoomLifecycleHandlers.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { getRoom, resetRoomRuntimeForTests } from '../rooms';
 import { initRoomSession, resetRoomSessionStoresForTests } from './roomSession';
 import { registerRoomLifecycleHandlers } from './registerRoomLifecycleHandlers';
+import * as telemetry from './mpAuthorityTelemetry';
 
 function makeSocket(socketId: string) {
   const handlers = new Map<string, (...args: unknown[]) => void>();
@@ -58,6 +59,7 @@ describe('registerRoomLifecycleHandlers', () => {
     });
 
     const ack = vi.fn();
+    const emit = vi.spyOn(telemetry, 'emitMpAuthorityFunnel');
     await handlers.get('room:create')?.({}, ack);
 
     expect(leaveExistingSocketRooms).toHaveBeenCalledTimes(1);
@@ -70,6 +72,10 @@ describe('registerRoomLifecycleHandlers', () => {
     );
     const roomCode = ack.mock.calls[0][0].roomCode as string;
     expect(getRoom(roomCode).players).toHaveLength(1);
+    expect(emit).toHaveBeenCalledWith('private_lobby_created', expect.objectContaining({
+      roomCode,
+      sourceType: 'private',
+    }));
   });
 
   it('room:leave rejects missing_code and delegates valid codes to leaveTrackedRoom', async () => {

--- a/server/src/multiplayer/roomDurability.test.ts
+++ b/server/src/multiplayer/roomDurability.test.ts
@@ -15,6 +15,7 @@ import {
   schedulePersistLiveRoomSession,
   type LiveRosterEntry,
 } from './roomLivePersistence';
+import * as telemetry from './mpAuthorityTelemetry';
 
 const t = (low: number, high: number) => ({ low: Math.min(low, high), high: Math.max(low, high) });
 
@@ -23,7 +24,8 @@ const persistPlan = vi.hoisted(() => ({
 }));
 
 vi.mock('../supabaseUtils', () => ({
-  supabaseFetch: vi.fn(async () => {
+  supabaseFetch: vi.fn(async (path: string) => {
+    if (String(path).includes('mp_authority_events')) return undefined;
     const next = persistPlan.outcomes.shift() ?? 'ok';
     if (next === 'ok') {
       return undefined;
@@ -134,6 +136,7 @@ describe('room durability contract', () => {
   it('marks a failed snapshot write as degraded', async () => {
     persistPlan.outcomes.push('error');
     const room = mkRoom();
+    const emit = vi.spyOn(telemetry, 'emitMpAuthorityFunnel');
 
     await expect(persistLiveRoomSessionNow(room, roster)).resolves.toBe(false);
 
@@ -142,12 +145,17 @@ describe('room durability contract', () => {
       consecutiveFailures: 1,
       lastError: 'db_down',
     });
+    expect(emit).toHaveBeenCalledWith('private_durability_degraded', expect.objectContaining({
+      roomCode: room.code,
+      failureCode: 'room_degraded',
+    }));
     expect(isLiveRoomDurablyRecoverable(room)).toBe(false);
   });
 
   it('marks table-unavailable persistence as failed', async () => {
     persistPlan.outcomes.push('missing_table');
     const room = mkRoom();
+    const emit = vi.spyOn(telemetry, 'emitMpAuthorityFunnel');
 
     await expect(persistLiveRoomSessionNow(room, roster)).resolves.toBe(false);
 
@@ -155,6 +163,10 @@ describe('room durability contract', () => {
       status: 'failed',
       consecutiveFailures: 1,
     });
+    expect(emit).toHaveBeenCalledWith('private_durability_failed', expect.objectContaining({
+      roomCode: room.code,
+      failureCode: 'room_failed',
+    }));
     expect(isLiveRoomDurablyRecoverable(room)).toBe(false);
   });
 

--- a/server/src/multiplayer/roomDurability.ts
+++ b/server/src/multiplayer/roomDurability.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'crypto';
 import type { Room } from '../rooms';
+import { emitMpAuthorityFunnel, resolveMpAuthoritySourceType } from './mpAuthorityTelemetry';
 
 export type RoomDurabilityStatus = 'pending' | 'healthy' | 'degraded' | 'failed';
 
@@ -159,6 +160,18 @@ export function markRoomDurabilityPersistFailure(
     lastError: params.error,
     lastAttemptedAtMs: Date.now(),
   };
+  emitMpAuthorityFunnel(
+    params.status === 'failed' ? 'private_durability_failed' : 'private_durability_degraded',
+    {
+      roomCode: room.code,
+      failureCode: params.status === 'failed' ? 'room_failed' : 'room_degraded',
+      sourceType: resolveMpAuthoritySourceType(room),
+      extra: {
+        error: params.error,
+        consecutiveFailures: room.durability.consecutiveFailures,
+      },
+    },
+  );
   return true;
 }
 

--- a/server/src/multiplayer/roomLiveHydration.test.ts
+++ b/server/src/multiplayer/roomLiveHydration.test.ts
@@ -39,6 +39,7 @@ vi.mock('../supabaseUtils', () => ({
     if (path.includes('/room_command_receipts') && (!init?.method || init.method === 'GET')) {
       return [];
     }
+    if (path.includes('/mp_authority_events')) return undefined;
     throw new Error(`unexpected supabaseFetch call: ${init?.method ?? 'GET'} ${path}`);
   }),
 }));
@@ -115,6 +116,7 @@ describe('room live session restart hydration', () => {
     persistenceStore.liveSessions.set('RST001', row);
     expect(peekRoom('RST001')).toBeUndefined();
 
+    const info = vi.spyOn(console, 'info').mockImplementation(() => {});
     const hydrated = await livePersistence.ensureRoomHydrated('RST001');
     expect(hydrated.kind).toBe('hydrated');
     if (hydrated.kind !== 'hydrated') return;
@@ -136,6 +138,10 @@ describe('room live session restart hydration', () => {
       },
     });
     expect(isLiveRoomDurablyRecoverable(hydrated.room)).toBe(true);
+    expect(info).toHaveBeenCalledWith(
+      '[mp.authority]',
+      expect.stringContaining('"event":"private_reconnect_hydrated"'),
+    );
   });
 
   it('returns already_in_memory without querying persistence', async () => {
@@ -167,11 +173,20 @@ describe('room live session restart hydration', () => {
     persistenceStore.liveSessions.set('BAD001', row);
     resetRoomRuntimeForTests();
 
+    const info = vi.spyOn(console, 'info').mockImplementation(() => {});
     const hydrated = await livePersistence.ensureRoomHydrated('BAD001');
     expect(hydrated).toEqual({
       kind: 'snapshot_invalid',
       error: 'snapshot_missing_game_state',
     });
+    expect(info).toHaveBeenCalledWith(
+      '[mp.authority]',
+      expect.stringContaining('"event":"private_durability_failed"'),
+    );
+    expect(info).toHaveBeenCalledWith(
+      '[mp.authority]',
+      expect.stringContaining('"hydrationKind":"snapshot_invalid"'),
+    );
     expect(peekRoom('BAD001')).toBeUndefined();
   });
 

--- a/server/src/multiplayer/roomLivePersistence.flush.test.ts
+++ b/server/src/multiplayer/roomLivePersistence.flush.test.ts
@@ -31,6 +31,7 @@ vi.mock('../supabaseUtils', () => ({
       }
       return undefined;
     }
+    if (path.includes('/mp_authority_events')) return undefined;
     throw new Error(`unexpected supabaseFetch call: ${init?.method ?? 'GET'} ${path}`);
   }),
 }));
@@ -154,7 +155,8 @@ describe('roomLivePersistence flush', () => {
         await persistGate;
         return undefined;
       }
-      throw new Error(`unexpected supabaseFetch call: ${init?.method ?? 'GET'} ${path}`);
+      if (path.includes('/mp_authority_events')) return undefined;
+    throw new Error(`unexpected supabaseFetch call: ${init?.method ?? 'GET'} ${path}`);
     });
 
     const room = mkRoom({ code: 'HANG1' });
@@ -200,7 +202,8 @@ describe('roomLivePersistence flush', () => {
         }
         return undefined;
       }
-      throw new Error(`unexpected supabaseFetch call: ${init?.method ?? 'GET'} ${path}`);
+      if (path.includes('/mp_authority_events')) return undefined;
+    throw new Error(`unexpected supabaseFetch call: ${init?.method ?? 'GET'} ${path}`);
     });
 
     const room = mkRoom({ code: 'LATEST1' });
@@ -247,7 +250,8 @@ describe('roomLivePersistence flush', () => {
         }
         return undefined;
       }
-      throw new Error(`unexpected supabaseFetch call: ${init?.method ?? 'GET'} ${path}`);
+      if (path.includes('/mp_authority_events')) return undefined;
+    throw new Error(`unexpected supabaseFetch call: ${init?.method ?? 'GET'} ${path}`);
     });
 
     const room = mkRoom({ code: 'EVENT1' });

--- a/server/src/multiplayer/roomLivePersistence.ts
+++ b/server/src/multiplayer/roomLivePersistence.ts
@@ -33,7 +33,7 @@ import {
   snapshotGameActionReceiptsForRoom,
   type PersistedGameActionReceipt,
 } from './gameActionIdempotency';
-import { emitMpAuthorityFunnel } from './mpAuthorityTelemetry';
+import { emitMpAuthorityFunnel, emitMpAuthorityHydrationResult } from './mpAuthorityTelemetry';
 import { loadRoomCommandReceiptsForRoom } from './roomCommandReceiptStore';
 
 const LIVE_PERSIST_DEBOUNCE_MS = 75;
@@ -934,6 +934,20 @@ export async function ensureRoomHydrated(roomCode: string): Promise<ActiveRoomHy
   if (inFlight) return inFlight;
 
   const hydrationPromise = (async (): Promise<ActiveRoomHydrationResult> => {
+    const result = await runLiveRoomHydration(code);
+    emitMpAuthorityHydrationResult(code, result);
+    return result;
+  })().finally(() => {
+    if (inFlightHydrationByRoomCode.get(code) === hydrationPromise) {
+      inFlightHydrationByRoomCode.delete(code);
+    }
+  });
+
+  inFlightHydrationByRoomCode.set(code, hydrationPromise);
+  return hydrationPromise;
+}
+
+async function runLiveRoomHydration(code: string): Promise<ActiveRoomHydrationResult> {
     const loaded = await loadLiveRoomSession(code);
     if (loaded.kind === 'not_found') {
       return { kind: 'not_found' };
@@ -998,14 +1012,6 @@ export async function ensureRoomHydrated(roomCode: string): Promise<ActiveRoomHy
         error: error instanceof Error ? error.message : String(error),
       };
     }
-  })().finally(() => {
-    if (inFlightHydrationByRoomCode.get(code) === hydrationPromise) {
-      inFlightHydrationByRoomCode.delete(code);
-    }
-  });
-
-  inFlightHydrationByRoomCode.set(code, hydrationPromise);
-  return hydrationPromise;
 }
 
 /** Test-only reset for debounce timers and table-availability cache. */

--- a/server/src/multiplayer/roomMatchLogPersistence.test.ts
+++ b/server/src/multiplayer/roomMatchLogPersistence.test.ts
@@ -17,6 +17,8 @@ import {
   queryPersistedRoomMatchLog,
   resetRoomMatchLogPersistenceForTests,
 } from './roomMatchLogPersistence';
+import * as telemetry from './mpAuthorityTelemetry';
+import { flushMpAuthorityEventPersistForTests } from './mpAuthorityEventStore';
 import { getRoomRoster, resetRoomSessionStoresForTests, setRoomRoster } from './roomSession';
 
 const t = (low: number, high: number) => ({ low: Math.min(low, high), high: Math.max(low, high) });
@@ -69,6 +71,7 @@ vi.mock('../supabaseUtils', () => ({
       return row ? [row] : [];
     }
 
+    if (path.includes('/mp_authority_events')) return undefined;
     throw new Error(`unexpected supabaseFetch call: ${init?.method ?? 'GET'} ${path}`);
   }),
 }));
@@ -220,9 +223,11 @@ describe('roomMatchLogPersistence terminal cleanup', () => {
         const row = persistenceStore.liveSessions.get(code);
         return row ? [row] : [];
       }
-      throw new Error(`unexpected supabaseFetch call: ${init?.method ?? 'GET'} ${path}`);
+      if (path.includes('/mp_authority_events')) return undefined;
+    throw new Error(`unexpected supabaseFetch call: ${init?.method ?? 'GET'} ${path}`);
     });
 
+    const emit = vi.spyOn(telemetry, 'emitMpAuthorityFunnel');
     await persistRoomMatchLog(room, 'completed');
 
     const archived = persistenceStore.matchLogs.get(room.matchId);
@@ -238,6 +243,10 @@ describe('roomMatchLogPersistence terminal cleanup', () => {
     });
     expect(terminalLiveStatuses).toContain('game_over');
     expect(persistenceStore.liveSessions.has('CLN001')).toBe(false);
+    expect(emit).toHaveBeenCalledWith('private_match_archived', expect.objectContaining({
+      roomCode: 'CLN001',
+      extra: expect.objectContaining({ status: 'completed' }),
+    }));
 
     const loadedArchive = await queryPersistedRoomMatchLog(room.matchId);
     expect(loadedArchive?.status).toBe('completed');
@@ -290,12 +299,17 @@ describe('roomMatchLogPersistence terminal cleanup', () => {
         const row = persistenceStore.liveSessions.get(code);
         return row ? [row] : [];
       }
-      throw new Error(`unexpected supabaseFetch call: ${init?.method ?? 'GET'} ${path}`);
+      if (path.includes('/mp_authority_events')) return undefined;
+    throw new Error(`unexpected supabaseFetch call: ${init?.method ?? 'GET'} ${path}`);
     });
 
+    const emit = vi.spyOn(telemetry, 'emitMpAuthorityFunnel');
     await persistRoomMatchLog(room, 'abandoned');
 
     expect(persistenceStore.matchLogs.get(room.matchId)?.status).toBe('abandoned');
+    expect(emit).toHaveBeenCalledWith('private_match_archived', expect.objectContaining({
+      extra: expect.objectContaining({ status: 'abandoned' }),
+    }));
     expect(terminalLiveStatuses).toContain('abandoned');
     expect(persistenceStore.liveSessions.has('CLN002')).toBe(false);
   });
@@ -326,7 +340,8 @@ describe('roomMatchLogPersistence terminal cleanup', () => {
         );
         return row ? [row] : [];
       }
-      throw new Error(`unexpected supabaseFetch call: ${init?.method ?? 'GET'} ${path}`);
+      if (path.includes('/mp_authority_events')) return undefined;
+    throw new Error(`unexpected supabaseFetch call: ${init?.method ?? 'GET'} ${path}`);
     });
 
     await persistRoomMatchLog(room, 'completed');
@@ -343,7 +358,8 @@ describe('roomMatchLogPersistence terminal cleanup', () => {
       if (path.includes('/room_match_logs') && (!init?.method || init.method === 'GET')) {
         return [];
       }
-      throw new Error(`unexpected supabaseFetch call: ${init?.method ?? 'GET'} ${path}`);
+      if (path.includes('/mp_authority_events')) return undefined;
+    throw new Error(`unexpected supabaseFetch call: ${init?.method ?? 'GET'} ${path}`);
     });
 
     const ok = await probeRoomMatchLogsTable();
@@ -359,5 +375,32 @@ describe('roomMatchLogPersistence terminal cleanup', () => {
     const ok = await probeRoomMatchLogsTable();
     expect(ok).toBe(false);
     expect(getRoomMatchLogsPersistenceAvailability()).toBe(false);
+  });
+
+  it('archive still completes when mp.authority insert fails', async () => {
+    const room = seedTerminalRoom('CLN004');
+    vi.mocked(supabaseFetch).mockImplementation(async (path: string, init?: RequestInit) => {
+      if (path.includes('/mp_authority_events')) {
+        throw new Error('mp_authority_events down');
+      }
+      if (path.includes('/room_match_logs') && init?.method === 'POST') {
+        const rows = JSON.parse(String(init.body)) as ArchiveRow[];
+        for (const row of rows) {
+          persistenceStore.matchLogs.set(String(row.match_id), row);
+        }
+        return undefined;
+      }
+      if (path.includes('/room_live_sessions')) return undefined;
+      if (path.includes('/room_match_logs')) {
+        const matchId = decodeURIComponent(path.match(/match_id=eq\.([^&]+)/)?.[1] ?? '');
+        const row = persistenceStore.matchLogs.get(matchId);
+        return row ? [row] : [];
+      }
+      throw new Error(`unexpected supabaseFetch call: ${init?.method ?? 'GET'} ${path}`);
+    });
+
+    await expect(persistRoomMatchLog(room, 'completed')).resolves.toBeUndefined();
+    await flushMpAuthorityEventPersistForTests();
+    expect(persistenceStore.matchLogs.get(room.matchId)?.status).toBe('completed');
   });
 });

--- a/server/src/multiplayer/roomMatchLogPersistence.ts
+++ b/server/src/multiplayer/roomMatchLogPersistence.ts
@@ -2,6 +2,7 @@ import type { Room } from '../rooms';
 import { getRoomMatchEventSnapshot } from '../rooms';
 import { supabaseFetch } from '../supabaseUtils';
 import { finalizeAndDeleteLiveRoomSession } from './roomLivePersistence';
+import { emitMpAuthorityFunnel, resolveMpAuthoritySourceType } from './mpAuthorityTelemetry';
 import { getRoomPlayersWithFallback, type PersistedRoomMatchLogStatus } from './roomSession';
 
 const UUID_RE =
@@ -167,6 +168,11 @@ export async function persistRoomMatchLog(
       },
     );
     persistentRoomMatchLogsAvailable = true;
+    emitMpAuthorityFunnel('private_match_archived', {
+      roomCode: room.code,
+      sourceType: resolveMpAuthoritySourceType(room),
+      extra: { status, matchId: room.matchId },
+    });
     await finalizeAndDeleteLiveRoomSession(room, status);
   } catch (error) {
     if (isMissingRoomMatchLogsTable(error)) {

--- a/server/src/rooms.ts
+++ b/server/src/rooms.ts
@@ -31,6 +31,7 @@ import {
 } from './multiplayer/roomDurability';
 import { flushScheduledLiveRoomPersistence, isLiveRoomDurablyRecoverable } from './multiplayer/roomLivePersistence';
 import { assertRoomDurabilityOperationAllowed } from './multiplayer/roomDurabilityPolicy';
+import { emitMpAuthorityFunnel, resolveMpAuthoritySourceType } from './multiplayer/mpAuthorityTelemetry';
 import type { RankingOutcome } from './multiplayer/rankingOutcome';
 import { childLogger } from './logger';
 
@@ -319,6 +320,11 @@ export function createRoom(hostPlayerSeatId: string, config: RoomConfig = {}): R
 
   rooms.set(code, room);
   notifyLiveRoomStateCommitted(room);
+  emitMpAuthorityFunnel('private_lobby_created', {
+    roomCode: code,
+    seatId: hostPlayerSeatId,
+    sourceType: resolveMpAuthoritySourceType(room),
+  });
   return room;
 }
 

--- a/supabase/migrations/2026-08-20_mp_authority_events.sql
+++ b/supabase/migrations/2026-08-20_mp_authority_events.sql
@@ -1,0 +1,65 @@
+-- Durable mp.authority funnel (service-role insert). Best-effort from the
+-- game server — insert failure must never block gameplay.
+
+create table if not exists public.mp_authority_events (
+  id uuid primary key default gen_random_uuid(),
+  event text not null check (
+    event in (
+      'private_lobby_created',
+      'private_match_started',
+      'private_action_committed',
+      'private_action_uncertain',
+      'private_action_duplicate',
+      'private_reconnect_hydrated',
+      'private_receipts_hydrated',
+      'private_rematch_started',
+      'private_match_abandoned',
+      'private_match_archived',
+      'private_durability_degraded',
+      'private_durability_failed',
+      'private_move_log_verification_failed',
+      'private_terminal_recovery'
+    )
+  ),
+  ts timestamptz not null default now(),
+  room_code text null,
+  seat_id text null,
+  request_id text null,
+  failure_code text null,
+  payload jsonb not null default '{}'::jsonb,
+  source_type text null check (
+    source_type is null or source_type in ('private', 'quick', 'tournament')
+  )
+);
+
+create index if not exists idx_mp_authority_events_event_ts
+  on public.mp_authority_events (event, ts);
+
+create index if not exists idx_mp_authority_events_room_ts
+  on public.mp_authority_events (room_code, ts);
+
+alter table public.mp_authority_events enable row level security;
+
+drop policy if exists "mp_authority_events_no_client_access" on public.mp_authority_events;
+create policy "mp_authority_events_no_client_access"
+  on public.mp_authority_events
+  for all
+  to authenticated
+  using (false)
+  with check (false);
+
+revoke all on public.mp_authority_events from anon, authenticated;
+grant insert, select on public.mp_authority_events to service_role;
+
+-- Pacific calendar date + event, same operational shape as daily_fritz_funnel_metrics.
+create or replace view public.mp_authority_funnel_metrics
+  with (security_invoker = true) as
+select
+  (ts at time zone 'America/Los_Angeles')::date as event_date,
+  event,
+  count(*)::bigint as total
+from public.mp_authority_events
+group by 1, 2;
+
+revoke all on public.mp_authority_funnel_metrics from anon, authenticated;
+grant select on public.mp_authority_funnel_metrics to service_role;


### PR DESCRIPTION
## Summary
- Persist `mp.authority` funnel rows in Postgres (`mp_authority_events`) in addition to the existing `console.info` line. Inserts are service-role, best-effort, and never throw into gameplay.
- Add `mp_authority_funnel_metrics` grouped by Pacific `event_date` + `event` (same operational shape as Daily Fritz funnel views).
- Fill previously unused emits: lobby created (private + quick), match started, archive completed/abandoned, durability degraded/failed (persist + hydration reject), reconnect hydrated, and a new server `private_terminal_recovery` on P1a `match_terminal` join acks and successful P1b result fetches.
- **Not in this PR:** health endpoint / admin UI (P2b/P2c). Incomplete funnel data would make a dashboard misleading.

## Test plan
- [ ] Apply `supabase/migrations/2026-08-20_mp_authority_events.sql` and confirm service-role can insert; anon/authenticated cannot.
- [ ] Create a private room, start a match, finish/archive — confirm rows for `private_lobby_created`, `private_match_started`, `private_match_archived`.
- [ ] Force a live-session persist failure — confirm `private_durability_degraded` / `_failed` without blocking moves.
- [ ] Offline-at-gameover: join an archived room (`match_terminal`) and hit `GET /api/private-match/result` — confirm `private_terminal_recovery` with `source` `join_ack` / `result_ok`.
- [ ] Query `mp_authority_funnel_metrics` and confirm Pacific date grouping.


Made with [Cursor](https://cursor.com)