### PR TITLE
Add visual excitement to Daily Fritz result screens

### DIFF
--- a/client/src/bot/BotDailyFritzSetOverlay.tsx
+++ b/client/src/bot/BotDailyFritzSetOverlay.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
 import { GameOverlayPortal } from '../components/GameOverlayPortal';
 import { DailyFritzFinalResultOverlay } from '../dailyFritz/DailyFritzFinalResultOverlay';
+import {
+  DailyFritzFritzReaction,
+  dailyFritzMoodFromGameHeadline,
+} from '../dailyFritz/DailyFritzFritzReaction';
 import type { DailyFritzSetOverlayViewModel } from '../dailyFritz/setOverlayViewModel';
 
 export interface BotDailyFritzSetOverlayProps {
@@ -30,19 +34,33 @@ export const BotDailyFritzSetOverlay: React.FC<BotDailyFritzSetOverlayProps> = (
     );
   }
 
+  const playerWonGame = overlay.headline.startsWith('You take');
+  const interstitialOutcome = playerWonGame ? 'is-player-win' : 'is-fritz-win';
+  const fritzMood = dailyFritzMoodFromGameHeadline(overlay.headline);
+
   return (
     <GameOverlayPortal>
       <div className="game-over-overlay daily-fritz-set-overlay" role="dialog" aria-label="Daily Fritz set interstitial">
-        <div className="game-over-card daily-fritz-set-overlay-card" onClick={(event) => event.stopPropagation()}>
+        <div
+          className={`game-over-card daily-fritz-set-overlay-card ${interstitialOutcome}`}
+          onClick={(event) => event.stopPropagation()}
+        >
           <div className="daily-fritz-set-overlay-hero">
-            <span className="daily-fritz-set-overlay-kicker">{overlay.eyebrow}</span>
-            {overlay.skunkBadge ? (
-              <span className="daily-fritz-skunk-badge" aria-label="Skunk result">
-                {overlay.skunkBadge}
-              </span>
-            ) : null}
-            <h2 className="daily-fritz-set-overlay-title" tabIndex={-1} autoFocus>{overlay.headline}</h2>
-            <p className="daily-fritz-set-overlay-copy">{overlay.subheadline}</p>
+            <DailyFritzFritzReaction
+              mood={fritzMood}
+              size="sm"
+              className="daily-fritz-set-overlay-fritz"
+            />
+            <div className="daily-fritz-set-overlay-copy-block">
+              <span className="daily-fritz-set-overlay-kicker">{overlay.eyebrow}</span>
+              {overlay.skunkBadge ? (
+                <span className="daily-fritz-skunk-badge" aria-label="Skunk result">
+                  {overlay.skunkBadge}
+                </span>
+              ) : null}
+              <h2 className="daily-fritz-set-overlay-title" tabIndex={-1} autoFocus>{overlay.headline}</h2>
+              <p className="daily-fritz-set-overlay-copy">{overlay.subheadline}</p>
+            </div>
           </div>
 
           <div className="daily-fritz-set-overlay-stats" aria-label="Daily Fritz set summary">

--- a/client/src/bot/botMatch.css
+++ b/client/src/bot/botMatch.css
@@ -718,7 +718,31 @@
 
 .daily-fritz-set-overlay-hero {
   display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: center;
+  gap: 14px;
+}
+
+.daily-fritz-set-overlay-copy-block {
+  display: grid;
   gap: 8px;
+  min-width: 0;
+}
+
+.daily-fritz-set-overlay-fritz {
+  align-self: center;
+}
+
+.daily-fritz-set-overlay-card.is-player-win {
+  border-color: rgba(149, 240, 202, 0.22);
+}
+
+.daily-fritz-set-overlay-card.is-fritz-win {
+  border-color: rgba(231, 182, 74, 0.3);
+  box-shadow:
+    0 28px 72px rgba(0, 0, 0, 0.44),
+    0 0 36px rgba(231, 182, 74, 0.08),
+    inset 0 1px 0 rgba(255, 255, 255, 0.05);
 }
 
 .daily-fritz-set-overlay-kicker {
@@ -1039,6 +1063,20 @@
     width: calc(100vw - 20px);
     border-radius: 22px;
     padding: 20px 14px;
+  }
+
+  .daily-fritz-set-overlay-hero {
+    grid-template-columns: 1fr;
+    justify-items: center;
+    text-align: center;
+  }
+
+  .daily-fritz-set-overlay-copy-block {
+    justify-items: center;
+  }
+
+  .daily-fritz-set-overlay-kicker {
+    margin-inline: auto;
   }
 
   .daily-fritz-set-overlay-title {

--- a/client/src/dailyFritz/DailyFritzFinalResultOverlay.tsx
+++ b/client/src/dailyFritz/DailyFritzFinalResultOverlay.tsx
@@ -1,3 +1,7 @@
+import {
+  DailyFritzFritzReaction,
+  dailyFritzMoodFromMarginTone,
+} from './DailyFritzFritzReaction';
 import type { DailyFritzSetOverlayViewModel } from './setOverlayViewModel';
 
 export type DailyFritzFinalResultOverlayProps = {
@@ -12,19 +16,29 @@ export function DailyFritzFinalResultOverlay({
   onShare,
 }: DailyFritzFinalResultOverlayProps) {
   const showMargin = Boolean(overlay.marginValue && overlay.marginValue !== '—');
+  const isVictory = overlay.marginTone === 'win';
+  const isDefeat = overlay.marginTone === 'loss';
+  const outcomeClass = isVictory ? 'is-victory' : isDefeat ? 'is-defeat' : 'is-neutral';
+  const fritzMood = dailyFritzMoodFromMarginTone(overlay.marginTone);
 
   return (
     <div className="game-over-overlay df-result-overlay" role="dialog" aria-label="Daily Fritz result">
-      <div className="game-over-card df-result-card" onClick={(event) => event.stopPropagation()}>
+      <div
+        className={`game-over-card df-result-card df-result-card--celebration ${outcomeClass}`}
+        onClick={(event) => event.stopPropagation()}
+      >
         <div className="df-result-panel">
+          <DailyFritzFritzReaction mood={fritzMood} size="lg" className="df-result-fritz" />
           <header className="df-result-hero">
             <p className="df-result-eyebrow">Daily Fritz</p>
             {overlay.skunkBadge ? (
-              <span className="daily-fritz-skunk-badge" aria-label="Skunk result">
+              <span className="daily-fritz-skunk-badge df-result-badge-glow" aria-label="Skunk result">
                 {overlay.skunkBadge}
               </span>
             ) : null}
-            <h2 className="df-result-title" tabIndex={-1} autoFocus>{overlay.headline}</h2>
+            <h2 className="df-result-title df-result-title-glow" tabIndex={-1} autoFocus>
+              {overlay.headline}
+            </h2>
             <p className="df-result-subtitle">{overlay.subheadline}</p>
           </header>
 

--- a/client/src/dailyFritz/DailyFritzFritzReaction.tsx
+++ b/client/src/dailyFritz/DailyFritzFritzReaction.tsx
@@ -1,0 +1,67 @@
+import { useCallback } from 'react';
+import { useDeferredAsset } from '../ui/useDeferredAsset';
+
+export type DailyFritzFritzMood = 'confident' | 'neutral' | 'defeated';
+
+type DailyFritzFritzReactionProps = {
+  mood: DailyFritzFritzMood;
+  size?: 'sm' | 'md' | 'lg';
+  className?: string;
+};
+
+export function DailyFritzFritzReaction({
+  mood,
+  size = 'md',
+  className,
+}: DailyFritzFritzReactionProps) {
+  const loadConfidentArt = useCallback(
+    () => import('../assets/bot/playfritz2png.webp'),
+    [],
+  );
+  const loadNeutralArt = useCallback(
+    () => import('../assets/singlePlayerHub/leftfacingfritzNOBRAINER.webp'),
+    [],
+  );
+  const loadDefeatedArt = useCallback(
+    () => import('../assets/bot/playfritz2png.webp'),
+    [],
+  );
+
+  const confidentSrc = useDeferredAsset('daily-fritz-fritz-confident', loadConfidentArt);
+  const neutralSrc = useDeferredAsset('daily-fritz-fritz-neutral', loadNeutralArt);
+  const defeatedSrc = useDeferredAsset('daily-fritz-fritz-defeated', loadDefeatedArt);
+
+  const src =
+    mood === 'confident' ? confidentSrc : mood === 'neutral' ? neutralSrc : defeatedSrc;
+
+  if (!src) return null;
+
+  return (
+    <div
+      className={[
+        'df-fritz-reaction',
+        `df-fritz-reaction--${size}`,
+        `df-fritz-reaction--${mood}`,
+        className,
+      ]
+        .filter(Boolean)
+        .join(' ')}
+      aria-hidden="true"
+    >
+      <div className="df-fritz-reaction-glow" />
+      <img src={src} alt="" className="df-fritz-reaction-img" decoding="async" />
+    </div>
+  );
+}
+
+export function dailyFritzMoodFromMarginTone(
+  marginTone: 'win' | 'loss' | 'idle',
+): DailyFritzFritzMood {
+  if (marginTone === 'win') return 'defeated';
+  if (marginTone === 'loss') return 'confident';
+  return 'neutral';
+}
+
+export function dailyFritzMoodFromGameHeadline(headline: string): DailyFritzFritzMood {
+  return headline.startsWith('You take') ? 'neutral' : 'confident';
+}

--- a/client/src/dailyFritz/DailyFritzLeaderboard.tsx
+++ b/client/src/dailyFritz/DailyFritzLeaderboard.tsx
@@ -164,7 +164,10 @@ export default function DailyFritzLeaderboard({
                   <strong className={`daily-fritz-rank-value rank-${row.rank <= 3 ? row.rank : 0}`}>#{row.rank}</strong>
                 </div>
                 <div className="daily-fritz-global-player">
-                  <span className={`daily-fritz-avatar ${isCurrentUser ? 'is-current-user' : ''}`} aria-hidden="true">
+                  <span
+                    className={`daily-fritz-avatar ${isCurrentUser ? 'is-current-user' : ''}${row.rank === 1 ? ' is-champion' : ''}`}
+                    aria-hidden="true"
+                  >
                     {initials}
                   </span>
                   <div className="daily-fritz-global-player-copy">

--- a/client/src/dailyFritz/DailyFritzLeaderboardScreen.tsx
+++ b/client/src/dailyFritz/DailyFritzLeaderboardScreen.tsx
@@ -172,11 +172,13 @@ function LeaderboardRow({
         <strong className={`dflb-rank-num${topRank ? ` is-${topRank}` : ''}`}>{row.rank}</strong>
       </div>
       <div className="dflb-player">
-        <PlayerInitialsAvatar
-          username={row.username}
-          size="md"
-          ring={topRank === 1 ? 'gold' : topRank === 2 ? 'silver' : topRank === 3 ? 'bronze' : 'none'}
-        />
+        <span className={topRank === 1 ? 'dflb-row-avatar-wrap is-champion' : 'dflb-row-avatar-wrap'}>
+          <PlayerInitialsAvatar
+            username={row.username}
+            size="md"
+            ring={topRank === 1 ? 'gold' : topRank === 2 ? 'silver' : topRank === 3 ? 'bronze' : 'none'}
+          />
+        </span>
         <div className="dflb-player-copy">
           <strong>
             {row.username}
@@ -228,8 +230,8 @@ function PodiumSlot({
         <span className="dflb-podium-avatar dflb-podium-avatar--empty" aria-hidden="true">
           <span className="dflb-podium-avatar__glyph">+</span>
         </span>
-        <span className="dflb-podium-name">—</span>
-        <span className="dflb-podium-empty-hint">Unclaimed</span>
+        <span className="dflb-podium-name">Open slot</span>
+        <span className="dflb-podium-empty-hint">Claim this spot</span>
       </div>
     );
   }
@@ -238,7 +240,9 @@ function PodiumSlot({
     <div className={`dflb-podium-slot place-${rank}${rank === 1 ? ' is-featured' : ''}`}>
       {crownBadge}
       {rankDisplay}
-      <PlayerInitialsAvatar username={row.username} size={rank === 1 ? 'lg' : 'md'} ring={ring} />
+      <span className={rank === 1 ? 'dflb-podium-avatar-wrap is-champion' : 'dflb-podium-avatar-wrap'}>
+        <PlayerInitialsAvatar username={row.username} size={rank === 1 ? 'lg' : 'md'} ring={ring} />
+      </span>
       <span className="dflb-podium-name">{row.username}</span>
       <span className="dflb-podium-score">{row.finalScore}–{row.opponentScore}</span>
       <span className="dflb-podium-margin">{formatMargin(row.pointDiff)}</span>

--- a/client/src/dailyFritz/dailyFritz.css
+++ b/client/src/dailyFritz/dailyFritz.css
@@ -2770,6 +2770,15 @@
   color: #95f0ca;
 }
 
+.daily-fritz-avatar.is-champion {
+  border-color: rgba(231, 182, 74, 0.52);
+  background: rgba(231, 182, 74, 0.12);
+  color: #f5d78a;
+  box-shadow:
+    0 0 0 1px rgba(231, 182, 74, 0.18),
+    0 0 22px rgba(231, 182, 74, 0.28);
+}
+
 .daily-fritz-player-name {
   min-width: 0;
   overflow: hidden;

--- a/client/src/dailyFritz/dailyFritzLeaderboardScreen.css
+++ b/client/src/dailyFritz/dailyFritzLeaderboardScreen.css
@@ -694,7 +694,64 @@
   padding-bottom: 16px;
   background: rgba(8, 12, 20, 0.96);
   border: 1px solid rgba(231, 182, 74, 0.32);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.05),
+    0 0 28px rgba(231, 182, 74, 0.12);
+}
+
+.dflb-podium-avatar-wrap {
+  display: inline-flex;
+}
+
+.dflb-podium-avatar-wrap.is-champion {
+  position: relative;
+}
+
+.dflb-podium-avatar-wrap.is-champion::before {
+  content: '';
+  position: absolute;
+  inset: -6px;
+  border-radius: 999px;
+  background: rgba(231, 182, 74, 0.18);
+  filter: blur(10px);
+  animation: dflb-champion-pulse 2.8s ease-in-out infinite;
+}
+
+.dflb-podium-avatar-wrap.is-champion .rh-hub-avatar--ring-gold::before {
+  box-shadow:
+    0 0 18px rgba(245, 185, 55, 0.45),
+    0 0 34px rgba(231, 182, 74, 0.22);
+}
+
+.dflb-row-avatar-wrap.is-champion {
+  position: relative;
+}
+
+.dflb-row-avatar-wrap.is-champion::before {
+  content: '';
+  position: absolute;
+  inset: -5px;
+  border-radius: 999px;
+  background: rgba(231, 182, 74, 0.16);
+  filter: blur(8px);
+}
+
+@keyframes dflb-champion-pulse {
+  0%,
+  100% {
+    opacity: 0.72;
+    transform: scale(0.96);
+  }
+  50% {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .dflb-podium-avatar-wrap.is-champion::before {
+    animation: none;
+  }
 }
 
 .dflb-podium-slot.place-2 {
@@ -715,8 +772,10 @@
   opacity: 1;
   border-style: dashed;
   background: rgba(8, 11, 18, 0.88);
-  border-color: rgba(148, 163, 184, 0.16);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03);
+  border-color: rgba(231, 182, 74, 0.22);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.03),
+    inset 0 0 0 1px rgba(231, 182, 74, 0.06);
 }
 
 .dflb-podium-crown-badge {
@@ -758,9 +817,11 @@
   width: 44px;
   height: 44px;
   border-radius: 50%;
-  border: 1px solid rgba(148, 163, 184, 0.2);
+  border: 1px dashed rgba(231, 182, 74, 0.28);
   background: rgba(12, 16, 24, 0.95);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.05),
+    0 0 16px rgba(231, 182, 74, 0.08);
 }
 
 .dflb-podium-avatar__glyph {
@@ -768,7 +829,7 @@
   font-size: 20px;
   font-weight: 800;
   line-height: 1;
-  color: rgba(148, 163, 184, 0.55);
+  color: rgba(231, 182, 74, 0.72);
 }
 
 .dflb-podium-empty-hint {
@@ -776,7 +837,7 @@
   font-weight: 700;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: rgba(148, 163, 184, 0.55);
+  color: rgba(231, 182, 74, 0.72);
 }
 
 .dflb-podium-name {

--- a/client/src/styles/match-hud-polish.css
+++ b/client/src/styles/match-hud-polish.css
@@ -528,4 +528,183 @@
   .df-result-overlay {
     animation: none;
   }
+
+  .df-result-card--celebration,
+  .df-fritz-reaction-img,
+  .df-result-badge-glow,
+  .df-result-title-glow {
+    animation: none;
+  }
+}
+
+/* Daily Fritz Fritz reaction art (final + interstitial overlays) */
+.df-fritz-reaction {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  pointer-events: none;
+}
+
+.df-fritz-reaction-glow {
+  position: absolute;
+  inset: 12% 8%;
+  border-radius: 999px;
+  background: rgba(231, 182, 74, 0.14);
+  filter: blur(18px);
+  opacity: 0.85;
+}
+
+.df-fritz-reaction-img {
+  position: relative;
+  z-index: 1;
+  width: 100%;
+  height: auto;
+  object-fit: contain;
+  filter: drop-shadow(0 10px 24px rgba(0, 0, 0, 0.45));
+  animation: df-fritz-reaction-enter 420ms cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+.df-fritz-reaction--sm {
+  width: 84px;
+  height: 84px;
+}
+
+.df-fritz-reaction--md {
+  width: 120px;
+  height: 120px;
+}
+
+.df-fritz-reaction--lg {
+  width: 156px;
+  height: 132px;
+  margin: -4px auto 2px;
+}
+
+.df-fritz-reaction--confident .df-fritz-reaction-glow {
+  background: rgba(231, 182, 74, 0.22);
+}
+
+.df-fritz-reaction--neutral .df-fritz-reaction-glow {
+  background: rgba(148, 163, 184, 0.16);
+  opacity: 0.7;
+}
+
+.df-fritz-reaction--neutral .df-fritz-reaction-img {
+  opacity: 0.92;
+  filter: drop-shadow(0 8px 18px rgba(0, 0, 0, 0.38)) saturate(0.88);
+}
+
+.df-fritz-reaction--defeated .df-fritz-reaction-glow {
+  background: rgba(231, 182, 74, 0.12);
+}
+
+.df-fritz-reaction--defeated .df-fritz-reaction-img {
+  transform: scaleX(-1);
+  opacity: 0.82;
+  filter: drop-shadow(0 8px 18px rgba(0, 0, 0, 0.42)) saturate(0.72) brightness(0.92);
+}
+
+@keyframes df-fritz-reaction-enter {
+  from {
+    opacity: 0;
+    transform: translateY(8px) scale(0.94);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+.df-fritz-reaction--defeated .df-fritz-reaction-img {
+  animation-name: df-fritz-reaction-enter-defeated;
+}
+
+@keyframes df-fritz-reaction-enter-defeated {
+  from {
+    opacity: 0;
+    transform: scaleX(-1) translateY(8px) scale(0.94);
+  }
+  to {
+    opacity: 0.82;
+    transform: scaleX(-1) translateY(0) scale(1);
+  }
+}
+
+/* Daily Fritz final result celebration */
+.df-result-card--celebration {
+  position: relative;
+  overflow: hidden;
+}
+
+.df-result-card--celebration::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  opacity: 0;
+}
+
+.df-result-card--celebration.is-victory::before {
+  opacity: 1;
+  background:
+    radial-gradient(circle at 18% 12%, rgba(231, 182, 74, 0.16), transparent 42%),
+    radial-gradient(circle at 82% 18%, rgba(231, 182, 74, 0.1), transparent 36%);
+}
+
+.df-result-card--celebration.is-defeat::before {
+  opacity: 1;
+  background: radial-gradient(circle at 50% 0%, rgba(148, 163, 184, 0.12), transparent 48%);
+}
+
+.df-result-card--celebration.is-victory::after {
+  content: '';
+  position: absolute;
+  inset: 8px 12px auto;
+  height: 1px;
+  background: rgba(231, 182, 74, 0.35);
+  box-shadow: 0 0 18px rgba(231, 182, 74, 0.35);
+  pointer-events: none;
+}
+
+.df-result-fritz {
+  align-self: center;
+}
+
+.df-result-card--celebration.is-victory .df-result-badge-glow,
+.df-result-card--celebration.is-victory .df-result-title-glow {
+  position: relative;
+  animation: df-result-victory-glow 2.4s ease-in-out infinite;
+}
+
+.df-result-card--celebration.is-victory .df-result-title-glow {
+  text-shadow:
+    0 0 24px rgba(231, 182, 74, 0.28),
+    0 2px 0 rgba(0, 0, 0, 0.25);
+}
+
+.df-result-card--celebration.is-victory .df-result-badge-glow {
+  box-shadow:
+    0 0 0 1px rgba(231, 182, 74, 0.35),
+    0 0 22px rgba(231, 182, 74, 0.35);
+}
+
+.df-result-card--celebration.is-defeat .df-result-title-glow {
+  color: rgba(255, 255, 255, 0.88);
+  text-shadow: 0 2px 0 rgba(0, 0, 0, 0.25);
+}
+
+.df-result-card--celebration.is-defeat .df-result-stat.is-defeat {
+  border-color: rgba(240, 160, 168, 0.16);
+}
+
+@keyframes df-result-victory-glow {
+  0%,
+  100% {
+    filter: brightness(1);
+  }
+  50% {
+    filter: brightness(1.08);
+  }
 }


### PR DESCRIPTION
## Summary
- Audit reused existing Fritz art: `playfritz2png.webp` (confident), `leftfacingfritzNOBRAINER.webp` (neutral/player-win), flipped/desaturated treatment for defeated on set wins.
- **Victory screen**: Fritz reaction hero, brass victory glow on title/skunk badge, win vs loss card treatments, existing fade/scale entrance preserved.
- **Game interstitial**: Small Fritz reaction beside headline (confident when Fritz takes the game, neutral when player wins), subtle border accent by outcome.
- **Leaderboard**: Champion glow on 1st-place podium/row avatars; unclaimed slots use brass dashed styling and “Claim this spot” copy instead of looking empty/broken.

## Preview notes (what to check on deploy)
1. **Between-game interstitial** — after game 1/2: Fritz portrait appears left of headline; gold border when Fritz wins, green-tint when you win.
2. **Final result overlay** — large Fritz reaction above “Victory” / “Defeat”; victory gets pulsing brass glow on title and skunk badge.
3. **Leaderboard** — 1st podium slot has halo on avatar; empty slots read as invitational brass dashed circles.

## Test plan
- [ ] Complete a Daily Fritz set (win and loss paths if possible) and confirm interstitial + final overlays render Fritz art without layout shift
- [ ] Open `/daily-fritz/leaderboard` with sparse board (<3 players) and confirm unclaimed podium slots look intentional
- [ ] Open with a #1 ranked player and confirm champion avatar glow
- [ ] Mobile width (~390px): interstitial stacks Fritz above copy cleanly
- [x] `npm run build --prefix client`


Made with [Cursor](https://cursor.com)