### PR TITLE
Fix Daily Fritz post-play recovery draw (protocol 2)

### DIFF
--- a/client/src/dailyFritz/dailyFritzMoveEvidence.ts
+++ b/client/src/dailyFritz/dailyFritzMoveEvidence.ts
@@ -1,4 +1,5 @@
 import type { MoveEntry, TileTuple } from '../game/moveLogger.ts';
+import { isPostPlayRecoveryMoveLogEntry } from './dailyFritzPostPlayRecovery.ts';
 
 function normalizedTileKey(tile: TileTuple): string {
   const low = Math.min(tile[0], tile[1]);
@@ -93,6 +94,11 @@ export function canonicalizeDailyFritzMoveLog(
       && typeof handNumber === 'number'
       && previous?.handNumber === handNumber
       && samePreActionEvidence(previous, entry)
+    ) continue;
+    // Protocol 2: drop draw/pass already absorbed into the preceding play.
+    if (
+      typeof handNumber === 'number'
+      && isPostPlayRecoveryMoveLogEntry(previous, entry)
     ) continue;
     if (key) seenPlacements.add(key);
     canonical.push(entry);

--- a/client/src/dailyFritz/dailyFritzPostPlayRecovery.test.ts
+++ b/client/src/dailyFritz/dailyFritzPostPlayRecovery.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import type { DailyFritzTranscriptAction } from '@racehorse/game-core';
+import {
+  isPostPlayRecoveryMoveLogEntry,
+  stripPostPlayRecoveryTranscriptActions,
+} from './dailyFritzPostPlayRecovery.ts';
+import { canonicalizeDailyFritzMoveLog } from './dailyFritzMoveEvidence.ts';
+import type { MoveEntry } from '../game/moveLogger.ts';
+
+const base = {
+  boardEnds: [-1, -1] as [number, number],
+  handBefore: [] as MoveEntry['handBefore'],
+  validMoves: [] as MoveEntry['validMoves'],
+  pipDelta: 0,
+  pointsScored: 0,
+  boardState: [] as MoveEntry['boardState'],
+  boardRenderState: null,
+  handSnapshot: [] as MoveEntry['handSnapshot'],
+  engineBestMove: null,
+};
+
+describe('stripPostPlayRecoveryTranscriptActions', () => {
+  it('drops draw immediately after the same actor play and resequences', () => {
+    const actions: DailyFritzTranscriptAction[] = [
+      { sequence: 0, actor: 'player', kind: 'play', tile: { low: 1, high: 5 }, position: 'right' },
+      { sequence: 1, actor: 'player', kind: 'draw' },
+      { sequence: 2, actor: 'player', kind: 'play', tile: { low: 1, high: 6 }, position: 'left' },
+      { sequence: 3, actor: 'fritz', kind: 'draw' },
+    ];
+    expect(stripPostPlayRecoveryTranscriptActions(actions)).toEqual([
+      { sequence: 0, actor: 'player', kind: 'play', tile: { low: 1, high: 5 }, position: 'right' },
+      { sequence: 1, actor: 'player', kind: 'play', tile: { low: 1, high: 6 }, position: 'left' },
+      { sequence: 2, actor: 'fritz', kind: 'draw' },
+    ]);
+  });
+
+  it('keeps an explicit pass after a play (empty-boneyard extra turn)', () => {
+    const actions: DailyFritzTranscriptAction[] = [
+      { sequence: 0, actor: 'player', kind: 'play', tile: { low: 1, high: 1 }, position: 'left' },
+      { sequence: 1, actor: 'player', kind: 'pass' },
+      { sequence: 2, actor: 'fritz', kind: 'pass' },
+    ];
+    expect(stripPostPlayRecoveryTranscriptActions(actions)).toEqual(actions);
+  });
+});
+
+describe('canonicalizeDailyFritzMoveLog post-play recovery', () => {
+  it('drops draw after place by the same player in the same hand', () => {
+    const moveLog: MoveEntry[] = [
+      {
+        ...base,
+        moveNumber: 1,
+        handNumber: 7,
+        action: 'place',
+        player: 'you',
+        tile: [1, 5],
+        position: 'right',
+        handBefore: [[1, 5]],
+      },
+      {
+        ...base,
+        moveNumber: 2,
+        handNumber: 7,
+        action: 'draw',
+        player: 'you',
+        handBefore: [[2, 2]],
+        boardEnds: [5, 5],
+      },
+      {
+        ...base,
+        moveNumber: 3,
+        handNumber: 7,
+        action: 'place',
+        player: 'you',
+        tile: [1, 6],
+        position: 'left',
+        handBefore: [[1, 6]],
+        boardEnds: [5, 5],
+      },
+    ];
+    expect(isPostPlayRecoveryMoveLogEntry(moveLog[0], moveLog[1])).toBe(true);
+    const canonical = canonicalizeDailyFritzMoveLog(moveLog);
+    expect(canonical.map((entry) => entry.action)).toEqual(['place', 'place']);
+  });
+});

--- a/client/src/dailyFritz/dailyFritzPostPlayRecovery.ts
+++ b/client/src/dailyFritz/dailyFritzPostPlayRecovery.ts
@@ -1,0 +1,41 @@
+import type { DailyFritzTranscriptAction } from '@racehorse/game-core';
+import type { MoveEntry } from '../game/moveLogger.ts';
+
+/**
+ * Protocol 2 contract: `applyMove` absorbs the forced-draw chain inside a
+ * scoring/double play. Separate draw actions logged immediately after that
+ * play are obsolete recovery noise — the same class protocol 1 skipped via
+ * `allowLegacyRecoverySkip` when `!canDraw`.
+ *
+ * Passes are NOT stripped here: an extra-turn play with an empty drawable
+ * boneyard and no legal follow-up returns without an embedded pass, and the
+ * client must still journal an explicit pass (fidelity seed 28).
+ *
+ * Aunt G2H6 (2026-08-20): a mid-presentation race re-ran the no-move draw
+ * path after `play 1|5` had already embedded `2|2` / `1|6`, producing an
+ * illegal protocol-2 `draw` and stranding verification.
+ */
+export function isPostPlayRecoveryMoveLogEntry(
+  previous: Pick<MoveEntry, 'action' | 'player' | 'handNumber'> | null | undefined,
+  entry: Pick<MoveEntry, 'action' | 'player' | 'handNumber'>,
+): boolean {
+  if (!previous) return false;
+  if (previous.handNumber !== entry.handNumber) return false;
+  if (previous.action !== 'place' || previous.player !== entry.player) return false;
+  return entry.action === 'draw';
+}
+
+export function stripPostPlayRecoveryTranscriptActions(
+  actions: readonly DailyFritzTranscriptAction[],
+): DailyFritzTranscriptAction[] {
+  const out: DailyFritzTranscriptAction[] = [];
+  let lastPlayActor: DailyFritzTranscriptAction['actor'] | null = null;
+  for (const action of actions) {
+    if (lastPlayActor === action.actor && action.kind === 'draw') {
+      continue;
+    }
+    out.push({ ...action, sequence: out.length });
+    lastPlayActor = action.kind === 'play' ? action.actor : null;
+  }
+  return out;
+}

--- a/client/src/dailyFritz/dailyFritzTranscript.ts
+++ b/client/src/dailyFritz/dailyFritzTranscript.ts
@@ -12,6 +12,7 @@ import {
 } from '@racehorse/game-core';
 import type { MoveEntry } from '../game/moveLogger.ts';
 import { canonicalizeDailyFritzMoveLog } from './dailyFritzMoveEvidence.ts';
+import { stripPostPlayRecoveryTranscriptActions } from './dailyFritzPostPlayRecovery.ts';
 
 type TranscriptActor = DailyFritzTranscriptAction['actor'];
 
@@ -146,6 +147,10 @@ export function buildDailyFritzTranscript(input: {
     ? input.fritzPolicyVersion
     : FRITZ_POLICY_VERSION;
 
+  // Journal is the preferred evidence, but a presentation-layer race can still
+  // append a spurious draw after a play whose applyMove already absorbed the
+  // recovery chain. Strip those before sealing/submit (protocol-2 contract).
+  const rawActions = journalActions ?? actions;
   const transcript: DailyFritzTranscript = {
     protocolVersion: input.protocolVersion ?? DAILY_FRITZ_TRANSCRIPT_PROTOCOL_VERSION,
     rulesVersion: GAME_RULES_VERSION,
@@ -157,7 +162,7 @@ export function buildDailyFritzTranscript(input: {
     attemptId: input.attemptId,
     gameNumber: input.gameNumber,
     handIndex: input.handIndex,
-    actions: journalActions ?? actions,
+    actions: stripPostPlayRecoveryTranscriptActions(rawActions),
   };
 
   // A journalled transcript is already exactly what the engine applied; sealing

--- a/client/src/modules/player-turn/usePlayerNoMoveEffect.test.tsx
+++ b/client/src/modules/player-turn/usePlayerNoMoveEffect.test.tsx
@@ -3,6 +3,62 @@ import { describe, expect, it, vi } from 'vitest';
 import { createFixedBotHand } from '../match/runtime/botEngine.ts';
 import { usePlayerNoMoveEffect } from './usePlayerNoMoveEffect.ts';
 
+function makeStablePorts(overrides: Record<string, unknown> = {}) {
+  const drawSequenceActiveRef = { current: false };
+  let activeRun = false;
+  return {
+    userPlayMoves: [] as unknown[],
+    ports: {
+      appendGhostMove: vi.fn(),
+      appendMove: vi.fn(),
+      pushToast: vi.fn(),
+      setIsOffAuthoredLine: vi.fn(),
+      setLessonStepIndex: vi.fn(),
+      setAuthoringV2Events: vi.fn(),
+      setSelectedTile: vi.fn(),
+      acceptGuidedTranscriptTurn: vi.fn(),
+      captureGuidedMatchCandidateAction: vi.fn(),
+      recordAuthoringStep: vi.fn(),
+      createV2Event: vi.fn(),
+      showBoardToast: vi.fn(),
+    },
+    guided: {
+      currentTranscriptTurn: null,
+      isGuidedTranscriptMode: false,
+      isGuidedV2Mode: false,
+      isGuidedV2OffLine: false,
+      isGuidedMode: false,
+      frozenLesson: null,
+    },
+    authoring: {
+      isAuthoringMode: false,
+      isAuthoringV2Mode: false,
+      authoringV2NextEventIndexRef: { current: 0 },
+    },
+    ghost: { isGhostMode: false },
+    isDailyFritzMode: true,
+    fritzDifficulty: 'hard',
+    moveCounterRef: { current: 0 },
+    drawSequenceActiveRef,
+    setDrawSequenceActiveBoth: vi.fn((value: boolean) => {
+      drawSequenceActiveRef.current = value;
+    }),
+    isTransitioningRef: { current: false },
+    localRun: {
+      beginLocalRun: vi.fn(() => {
+        activeRun = true;
+        return { id: 1, lifecycleVersion: 0, kind: 'player-draw' as const };
+      }),
+      isLocalRunCurrent: vi.fn(() => activeRun),
+      hasActiveLocalRun: vi.fn(() => activeRun),
+      finishLocalRun: vi.fn(() => { activeRun = false; }),
+    },
+    applyAndNotify: vi.fn(),
+    runDrawSequence: vi.fn(() => new Promise<never>(() => {})),
+    ...overrides,
+  };
+}
+
 describe('usePlayerNoMoveEffect local-run ownership', () => {
   it('does not start a second forced draw when the UI draw flag resets during the in-flight run', async () => {
     const match = createFixedBotHand(
@@ -22,64 +78,86 @@ describe('usePlayerNoMoveEffect local-run ownership', () => {
       },
       'you',
     );
-    const drawSequenceActiveRef = { current: false };
-    let activeRun = false;
-    const runDrawSequence = vi.fn(() => new Promise<never>(() => {}));
-    const setDrawSequenceActiveBoth = vi.fn((value: boolean) => {
-      drawSequenceActiveRef.current = value;
-    });
-    const stable = {
-      userPlayMoves: [],
-      ports: {
-        appendGhostMove: vi.fn(), appendMove: vi.fn(), pushToast: vi.fn(),
-        setIsOffAuthoredLine: vi.fn(), setLessonStepIndex: vi.fn(),
-        setAuthoringV2Events: vi.fn(), setSelectedTile: vi.fn(),
-        acceptGuidedTranscriptTurn: vi.fn(), captureGuidedMatchCandidateAction: vi.fn(),
-        recordAuthoringStep: vi.fn(), createV2Event: vi.fn(), showBoardToast: vi.fn(),
-      },
-      guided: {
-        currentTranscriptTurn: null, isGuidedTranscriptMode: false,
-        isGuidedV2Mode: false, isGuidedV2OffLine: false, isGuidedMode: false,
-        frozenLesson: null,
-      },
-      authoring: {
-        isAuthoringMode: false, isAuthoringV2Mode: false,
-        authoringV2NextEventIndexRef: { current: 0 },
-      },
-      ghost: { isGhostMode: false },
-      isDailyFritzMode: true,
-      fritzDifficulty: 'hard',
-      moveCounterRef: { current: 0 },
-      drawSequenceActiveRef,
-      setDrawSequenceActiveBoth,
-      isTransitioningRef: { current: false },
-      localRun: {
-        beginLocalRun: vi.fn(() => {
-          activeRun = true;
-          return { id: 1, lifecycleVersion: 0, kind: 'player-draw' as const };
-        }),
-        isLocalRunCurrent: vi.fn(() => activeRun),
-        hasActiveLocalRun: vi.fn(() => activeRun),
-        finishLocalRun: vi.fn(() => { activeRun = false; }),
-      },
-      applyAndNotify: vi.fn(),
-      runDrawSequence,
-    };
-
+    const stable = makeStablePorts();
     const { rerender } = renderHook(
       ({ liveMatch }) => usePlayerNoMoveEffect({ ...stable, match: liveMatch } as never),
       { initialProps: { liveMatch: match } },
     );
 
-    await waitFor(() => expect(runDrawSequence).toHaveBeenCalledOnce());
+    await waitFor(() => expect(stable.runDrawSequence).toHaveBeenCalledOnce());
     await act(async () => {
-      // Reproduce the lifecycle/UI reset that used to reopen the effect while
-      // the first draw still owned the authoritative local run.
-      drawSequenceActiveRef.current = false;
+      stable.drawSequenceActiveRef.current = false;
       rerender({ liveMatch: { ...match } });
     });
 
     expect(stable.localRun.hasActiveLocalRun).toHaveBeenCalled();
-    expect(runDrawSequence).toHaveBeenCalledOnce();
+    expect(stable.runDrawSequence).toHaveBeenCalledOnce();
+  });
+
+  it('does not re-draw after a journalled play whose applyMove already absorbed recovery draws', async () => {
+    const match = createFixedBotHand(
+      { you: 0, bot: 0 },
+      1,
+      60,
+      7,
+      {
+        player_tiles: [
+          { low: 2, high: 6 },
+          { low: 0, high: 6 },
+          { low: 0, high: 0 },
+        ],
+        fritz_tiles: [{ low: 0, high: 1 }],
+        boneyard: [
+          { low: 2, high: 2 },
+          { low: 1, high: 6 },
+        ],
+        locked: [],
+      },
+      'you',
+    );
+    // Mid-presentation race shape: journal already recorded the play, but the
+    // UI temporarily restored a drawable boneyard with no legal moves.
+    const midPresentation = {
+      ...match,
+      board: {
+        mainLine: [{ tile: { low: 1, high: 5 }, orientation: 'horizontal-normal' as const }],
+        leftEnd: 5,
+        rightEnd: 5,
+        leftEndIsDouble: false,
+        rightEndIsDouble: false,
+        hubDoubles: [],
+      },
+      handOpen: true,
+      currentPlayer: 'you' as const,
+      officialJournal: {
+        handNumber: match.handNumber,
+        actions: [
+          {
+            actor: 'player' as const,
+            kind: 'play' as const,
+            tile: { low: 1, high: 5 },
+            position: 'right' as const,
+          },
+        ],
+      },
+    };
+    expect(midPresentation.boneyard.length).toBeGreaterThan(midPresentation.deadTiles.length);
+
+    const runDrawSequence = vi.fn();
+    const stable = makeStablePorts({
+      runDrawSequence,
+      localRun: {
+        beginLocalRun: vi.fn(),
+        isLocalRunCurrent: vi.fn(() => true),
+        hasActiveLocalRun: vi.fn(() => false),
+        finishLocalRun: vi.fn(),
+      },
+    });
+
+    renderHook(() => usePlayerNoMoveEffect({ ...stable, match: midPresentation } as never));
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(runDrawSequence).not.toHaveBeenCalled();
   });
 });

--- a/client/src/modules/player-turn/usePlayerNoMoveEffect.ts
+++ b/client/src/modules/player-turn/usePlayerNoMoveEffect.ts
@@ -125,6 +125,24 @@ export function usePlayerNoMoveEffect({
     if (userPlayMoves.length > 0) return;
     if (isGuidedV2Mode && !isGuidedV2OffLine) return;
 
+    // Protocol 2: after a play command, applyMove already absorbed any forced
+    // recovery draws while the boneyard was drawable. Mid-presentation setMatch
+    // can temporarily restore a drawable boneyard with empty legal moves —
+    // never re-run drawCoreTile then or the journal gains an illegal post-play
+    // recovery draw. An empty drawable boneyard may still need an explicit pass.
+    const journal = match.officialJournal;
+    if (
+      journal
+      && journal.handNumber === match.handNumber
+      && journal.actions.length > 0
+      && match.boneyard.length > match.deadTiles.length
+    ) {
+      const last = journal.actions[journal.actions.length - 1];
+      if (last?.kind === 'play' && last.actor === 'player') {
+        return;
+      }
+    }
+
     const snapshot = collectPlayerMoveSnapshot(match, userPlayMoves);
     const boneyardBefore = match.boneyard.length;
 

--- a/server/src/dailyFritzMultiDrawVerifier.test.ts
+++ b/server/src/dailyFritzMultiDrawVerifier.test.ts
@@ -7,7 +7,7 @@ import {
   GAME_RULES_VERSION,
   type DailyFritzTranscriptAction,
 } from '@racehorse/game-core';
-import { createOfficialDailyFritzHandState, verifyDailyFritzHand } from './dailyFritzVerifier';
+import { createOfficialDailyFritzHandState, DailyFritzVerificationError, verifyDailyFritzHand } from './dailyFritzVerifier';
 
 describe('Daily Fritz multi-draw transcript verification', () => {
   it('accepts explicit draws and safely reconstructs omitted mandatory draws', () => {
@@ -243,20 +243,27 @@ describe('Daily Fritz multi-draw transcript verification', () => {
       fritzTier: 'elite',
     })).toThrow(/does not complete the hand/i);
 
-    // Protocol 2 must not silently skip obsolete recovery draws.
-    expect(() => verifyDailyFritzHand({
-      transcript: envelope([
-        { sequence: 0, actor: 'fritz', kind: 'play', tile: { low: 1, high: 6 }, position: 'left' },
-        { sequence: 1, actor: 'fritz', kind: 'draw' },
-      ], 2),
-      initialState: open,
-      expectedChallengeId: 'c',
-      expectedAttemptId: 'a',
-      expectedGameNumber: 1,
-      expectedHandIndex: 0,
-      userId: 'u',
-      fritzTier: 'elite',
-    })).toThrow(/not legal|Illegal|official policy|wrong_actor|Draw/i);
+    // Protocol 2 must not silently skip obsolete recovery draws — reject with a
+    // distinct code so incidents are distinguishable from other illegal_action.
+    try {
+      verifyDailyFritzHand({
+        transcript: envelope([
+          { sequence: 0, actor: 'fritz', kind: 'play', tile: { low: 1, high: 6 }, position: 'left' },
+          { sequence: 1, actor: 'fritz', kind: 'draw' },
+        ], 2),
+        initialState: open,
+        expectedChallengeId: 'c',
+        expectedAttemptId: 'a',
+        expectedGameNumber: 1,
+        expectedHandIndex: 0,
+        userId: 'u',
+        fritzTier: 'elite',
+      });
+      expect.fail('expected post_play_recovery_draw');
+    } catch (error) {
+      expect(error).toBeInstanceOf(DailyFritzVerificationError);
+      expect((error as DailyFritzVerificationError).code).toBe('post_play_recovery_draw');
+    }
   });
 
   it('skips obsolete post-score draw+pass after absorbed auto-pass advances the turn', () => {

--- a/server/src/dailyFritzTelemetry.ts
+++ b/server/src/dailyFritzTelemetry.ts
@@ -67,6 +67,7 @@ const TERMINAL_INTEGRITY = new Set([
   'operation_id_reused',
   'transcript_digest_mismatch',
   'illegal_action',
+  'post_play_recovery_draw',
 ]);
 
 export function isDailyFritzEventType(value: unknown): value is DailyFritzEventType {

--- a/server/src/dailyFritzVerifier.ts
+++ b/server/src/dailyFritzVerifier.ts
@@ -299,6 +299,20 @@ export function verifyDailyFritzHand(input: {
         'wrong_actor',
       );
     }
+    // Protocol 2 must not silently skip obsolete post-play recovery draws
+    // (protocol 1 still does above). Reject with a distinct code before policy
+    // comparison so Sentry can distinguish this class from other failures
+    // without a transcript reconstruction dig (aunt G2H6 / 2026-08-20).
+    if (
+      !allowLegacyRecoverySkip
+      && lastPlayActor === action.actor
+      && action.kind === 'draw'
+    ) {
+      throw new DailyFritzVerificationError(
+        `Transcript action ${action.sequence} (${action.actor} draw) is a post-play recovery draw that applyMove already embeds.`,
+        'post_play_recovery_draw',
+      );
+    }
     // Draws are deterministic and mandatory whenever `canDraw` is true. Some
     // clients can commit the resulting rack state before the presentation layer
     // appends every draw event. Reconstruct only those omitted forced draws

--- a/server/src/http/routes/dailyFritzPostPlayRecoveryDrawClientTranscript.test.ts
+++ b/server/src/http/routes/dailyFritzPostPlayRecoveryDrawClientTranscript.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Regression: aunt G2H6 (attempt e1f0a2f2-ce10-4c65-aab5-c71dc02b1be7,
+ * run_date 2026-08-20) logged a post-play recovery `draw` after `play 1|5`
+ * whose applyMove had already embedded boneyard tiles 2|2 and 1|6.
+ *
+ * Against main (no strip / no distinct code): raw transcript → illegal_action.
+ * After the fix: client strip yields a 15-action transcript that verifies;
+ * raw still fails, but with post_play_recovery_draw.
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  DAILY_FRITZ_AUTHORITY_STATE_DIGEST_VERSION,
+  GAME_RULES_VERSION,
+  getFritzPolicyContract,
+  type DailyFritzTranscriptAction,
+} from '@racehorse/game-core';
+import { stripPostPlayRecoveryTranscriptActions } from '../../../../client/src/dailyFritz/dailyFritzPostPlayRecovery.ts';
+import {
+  DailyFritzVerificationError,
+  createOfficialDailyFritzHandState,
+  verifyDailyFritzHand,
+} from '../../dailyFritzVerifier';
+
+/** Official deal: published challenge daily-fritz:2026-08-20:r2:s1, game 2 hand 6. */
+const AUNT_G2H6_DEAL = {
+  locked: [
+    { low: 2, high: 3 },
+    { low: 4, high: 5 },
+  ],
+  boneyard: [
+    { low: 2, high: 2 },
+    { low: 1, high: 6 },
+    { low: 0, high: 3 },
+    { low: 3, high: 5 },
+    { low: 6, high: 6 },
+    { low: 5, high: 5 },
+    { low: 0, high: 5 },
+    { low: 4, high: 4 },
+    { low: 3, high: 4 },
+    { low: 0, high: 1 },
+    { low: 3, high: 3 },
+    { low: 0, high: 4 },
+    { low: 2, high: 3 },
+    { low: 4, high: 5 },
+  ],
+  fritz_tiles: [
+    { low: 1, high: 2 },
+    { low: 1, high: 3 },
+    { low: 0, high: 2 },
+    { low: 2, high: 4 },
+    { low: 4, high: 6 },
+    { low: 5, high: 6 },
+    { low: 1, high: 4 },
+  ],
+  player_tiles: [
+    { low: 2, high: 5 },
+    { low: 2, high: 6 },
+    { low: 0, high: 6 },
+    { low: 1, high: 5 },
+    { low: 3, high: 6 },
+    { low: 1, high: 1 },
+    { low: 0, high: 0 },
+  ],
+} as const;
+
+/**
+ * Reconstructed from checkpoint moveLog for handNumber 7 (G2 handIndex 6).
+ * Sequence 7 is the illegal post-play recovery draw.
+ */
+const AUNT_G2H6_ACTIONS_WITH_RECOVERY_DRAW: DailyFritzTranscriptAction[] = [
+  { sequence: 0, actor: 'fritz', kind: 'play', tile: { low: 4, high: 6 }, position: 'left', preStateDigest: 'df-state-v1:c2c2df2f' },
+  { sequence: 1, actor: 'fritz', kind: 'play', tile: { low: 2, high: 4 }, position: 'left', preStateDigest: 'df-state-v1:619a56ea' },
+  { sequence: 2, actor: 'player', kind: 'play', tile: { low: 3, high: 6 }, position: 'right' },
+  { sequence: 3, actor: 'player', kind: 'play', tile: { low: 2, high: 5 }, position: 'left' },
+  { sequence: 4, actor: 'fritz', kind: 'play', tile: { low: 1, high: 3 }, position: 'right', preStateDigest: 'df-state-v1:3fb90366' },
+  { sequence: 5, actor: 'player', kind: 'play', tile: { low: 1, high: 1 }, position: 'right' },
+  { sequence: 6, actor: 'player', kind: 'play', tile: { low: 1, high: 5 }, position: 'right' },
+  { sequence: 7, actor: 'player', kind: 'draw' },
+  { sequence: 8, actor: 'player', kind: 'play', tile: { low: 1, high: 6 }, position: 'branch-0-0' },
+  { sequence: 9, actor: 'fritz', kind: 'play', tile: { low: 1, high: 4 }, position: 'branch-0-1', preStateDigest: 'df-state-v1:3f9ee75c' },
+  { sequence: 10, actor: 'fritz', kind: 'play', tile: { low: 5, high: 6 }, position: 'left', preStateDigest: 'df-state-v1:42fce2d7' },
+  { sequence: 11, actor: 'player', kind: 'play', tile: { low: 0, high: 6 }, position: 'branch-0-0' },
+  { sequence: 12, actor: 'player', kind: 'play', tile: { low: 0, high: 0 }, position: 'branch-0-0' },
+  { sequence: 13, actor: 'player', kind: 'play', tile: { low: 2, high: 6 }, position: 'left' },
+  { sequence: 14, actor: 'fritz', kind: 'play', tile: { low: 1, high: 2 }, position: 'left', preStateDigest: 'df-state-v1:6c523d68' },
+  { sequence: 15, actor: 'fritz', kind: 'play', tile: { low: 0, high: 2 }, position: 'branch-0-0', preStateDigest: 'df-state-v1:4887aadb' },
+];
+
+const CHALLENGE_ID = 'daily-fritz:2026-08-20:r2:s1';
+const ATTEMPT_ID = 'e1f0a2f2-ce10-4c65-aab5-c71dc02b1be7';
+
+function envelope(actions: DailyFritzTranscriptAction[]) {
+  return {
+    protocolVersion: 2 as const,
+    rulesVersion: GAME_RULES_VERSION,
+    fritzPolicyVersion: 2 as const,
+    fritzPolicyContract: getFritzPolicyContract(2),
+    stateDigestVersion: DAILY_FRITZ_AUTHORITY_STATE_DIGEST_VERSION,
+    clientRelease: 'test-client',
+    challengeId: CHALLENGE_ID,
+    attemptId: ATTEMPT_ID,
+    gameNumber: 2 as const,
+    handIndex: 6,
+    actions,
+  };
+}
+
+function initialState() {
+  return createOfficialDailyFritzHandState({
+    deal: AUNT_G2H6_DEAL,
+    handIndex: 6,
+    drawWinner: 'bot',
+    winningScore: 60,
+    dealSize: 7,
+    // Scores after verified G2H5 receipt.
+    playerScore: 38,
+    fritzScore: 43,
+  });
+}
+
+function verify(actions: DailyFritzTranscriptAction[]) {
+  // Aunt's checkpoint digests were captured on the polluted (post-draw) timeline;
+  // strip them so this fixture asserts action legality / strip behavior, not
+  // digest regeneration. Production clients that never emit the recovery draw
+  // keep digests aligned with authority.
+  const withoutPollutedDigests = actions.map((action) => {
+    if (action.kind !== 'play' || action.actor !== 'fritz') return action;
+    const { preStateDigest: _drop, ...rest } = action;
+    return rest;
+  });
+  return verifyDailyFritzHand({
+    transcript: envelope(withoutPollutedDigests),
+    initialState: initialState(),
+    expectedChallengeId: CHALLENGE_ID,
+    expectedAttemptId: ATTEMPT_ID,
+    expectedGameNumber: 2,
+    expectedHandIndex: 6,
+    userId: 'a7442fca-73b1-42a0-8507-1071c06505c4',
+    fritzTier: 'elite',
+  });
+}
+
+describe('Daily Fritz aunt G2H6 post-play recovery draw', () => {
+  it('raw fixture fails with post_play_recovery_draw (not generic illegal_action)', () => {
+    expect(AUNT_G2H6_ACTIONS_WITH_RECOVERY_DRAW).toHaveLength(16);
+    expect(AUNT_G2H6_ACTIONS_WITH_RECOVERY_DRAW[7]).toEqual({
+      sequence: 7,
+      actor: 'player',
+      kind: 'draw',
+    });
+
+    try {
+      verify(AUNT_G2H6_ACTIONS_WITH_RECOVERY_DRAW);
+      expect.fail('expected verification to reject the recovery draw');
+    } catch (error) {
+      expect(error).toBeInstanceOf(DailyFritzVerificationError);
+      expect((error as DailyFritzVerificationError).code).toBe('post_play_recovery_draw');
+      expect((error as DailyFritzVerificationError).message).toMatch(/action 7.*draw/i);
+    }
+  });
+
+  it('client strip removes the recovery draw and the hand verifies (15 actions)', () => {
+    const stripped = stripPostPlayRecoveryTranscriptActions(AUNT_G2H6_ACTIONS_WITH_RECOVERY_DRAW);
+    expect(stripped).toHaveLength(15);
+    expect(stripped.some((action) => action.kind === 'draw')).toBe(false);
+    expect(stripped[6]).toMatchObject({
+      sequence: 6,
+      actor: 'player',
+      kind: 'play',
+      tile: { low: 1, high: 5 },
+    });
+    expect(stripped[7]).toMatchObject({
+      sequence: 7,
+      actor: 'player',
+      kind: 'play',
+      tile: { low: 1, high: 6 },
+    });
+
+    const result = verify(stripped);
+    expect(result.result.winner).toBe('player');
+    expect(result.result.reason).toBe('domino');
+    expect(result.result.playerScoreAfter).toBe(47);
+    expect(result.result.fritzScoreAfter).toBe(52);
+  });
+});

--- a/server/src/http/routes/dailyFritzVerificationGlue.ts
+++ b/server/src/http/routes/dailyFritzVerificationGlue.ts
@@ -48,6 +48,7 @@ const CLIENT_STUCK_CODES = new Set([
   'game_mismatch',
   'hand_mismatch',
   'illegal_action',
+  'post_play_recovery_draw',
   'post_terminal_action',
   'fritz_recovery_failed',
   'fritz_policy_version_mismatch',


### PR DESCRIPTION
## Summary
- Client: do not re-run forced draws after a journalled play while the boneyard is still drawable (mid-presentation race), and strip obsolete post-play recovery draws from move-log / journal transcripts before submit.
- Server: protocol 2 rejects leftover post-play recovery draws with distinct code `post_play_recovery_draw` (instead of generic `illegal_action`).
- Regression fixture: aunt G2H6 (`e1f0a2f2-…`, 2026-08-20) — raw 16-action transcript fails with the new code; stripped 15-action transcript verifies.

## Out of scope (PR 2)
- No changes to record-game / receipt / `advance_unverified` logic.
- Receipt-before-advance (blocked/unverified game receipt) waits for this PR to merge + preview confirmation.

## Ship note
**PR 1 alone is safe to ship ahead of PR 2.** It reduces new illegal post-play draw → verification failure → empty `authority.games` → `missing_game_receipts` 409 cascades for players on current clients. It does **not** heal already-broken attempts or every missing-receipt path; PR 2 is still required to fully stop the game-boundary 409 cascade when verification fails for other reasons.

## Test plan
- [ ] `npx vitest run src/http/routes/dailyFritzPostPlayRecoveryDrawClientTranscript.test.ts` (server)
- [ ] `npx vitest run src/dailyFritzMultiDrawVerifier.test.ts src/http/routes/dailyFritzTranscriptFidelity.test.ts` (server)
- [ ] `npx vitest run src/dailyFritz/dailyFritzPostPlayRecovery.test.ts src/modules/player-turn/usePlayerNoMoveEffect.test.tsx` (client)
- [ ] Preview deploy: play a Daily Fritz hand with a scoring play that forces recovery draws; confirm hand verifies and no `post_play_recovery_draw` / `illegal_action` on draw
- [ ] No production deploy until diff + preview reviewed


Made with [Cursor](https://cursor.com)