### PR TITLE
Daily Fritz PR A: persist transcript evidence on verify failure paths

### DIFF
--- a/docs/daily-fritz-hardening-audit.md
+++ b/docs/daily-fritz-hardening-audit.md
@@ -1,0 +1,175 @@
+# Daily Fritz hardening audit — advance-before-proof
+
+**Date:** 2026-08-20  
+**Scope:** Client + server daily-fritz only. Find every remaining instance of the bug class fixed twice recently: **state / published write advancing before its proof is durably persisted**.  
+**Mode:** Report only — no code changes.
+
+**Reference incidents / fixes (context, not re-litigated here):**
+
+1. Advance-first `/record-game` wiped `active_game` before async verify → false `fritz_state_mismatch` (aunt / mom game-1 investigation). Mitigated by deriving hand-start scores from the authority ledger (`resolveHandStartScoresForVerification`).
+2. Async receipt backfill + record-game retry storms after cursor already moved (`0b79c9a`).
+3. Post-play recovery draw was a **transcript fidelity** bug, not this class — out of scope except where it feeds unverified advance.
+
+---
+
+## 1. Enumeration: advances & published writes
+
+Legend:
+
+- **Gated** = durable receipt / verification / authority write happens in the same commit (or transactional command) that advances the cursor / publishes, *or* the advance is refused until that proof exists.
+- **Not gated** = cursor / published blob can move (or be player-visible) while proof is missing, pending, best-effort, or fire-and-forget.
+
+### 1.1 Server — authority cursor (`currentHandIndex` / `currentGameNumber` / `revision`)
+
+| Location | What advances | Gated? | Notes |
+|---|---|---|---|
+| `server/src/http/routes/dailyFritzNextHandRoute.ts` ~388–419, 463 | `currentHandIndex += 1` after mid-game hand | **Mixed** | If verify succeeds: receipt written into `attempt.result.authority.hands` *before* upsert (or transactional `commitDailyFritzAttemptCommand` when `DAILY_FRITZ_TRANSACTIONAL_COMMANDS=true`). If verify fails but `completed_hand_scores` present: **not gated** — advances with `verification_status: 'rejected'` (~395–419). |
+| `dailyFritzNextHandRoute.ts` ~216–227 | Legacy score-only path (no transcript) | **Not gated** | Marks `legacy_unverified`, advances hand index. Modern competitive attempts should 426 before this; still a live code path. |
+| `dailyFritzNextHandRoute.ts` ~344–385 | Game-ending hand via `/next-hand` | **Gated (persist)** / **Not an index advance** | Persists verified (or unverified) hand + `active_game`, then **409** “finalize via record-game” — does **not** bump `currentHandIndex`. Score persistence is intentional; cursor stays for `/record-game`. |
+| `server/src/http/routes/dailyFritzRecordGameRoute.ts` ~252–345, 402 | `set_result.games[]` append + `currentHandIndex = 0` + `currentGameNumber++` when set not decided | **Not gated (advance-first)** | With transcript and no prior terminal receipt: sets `verificationPending`, writes published set scores, advances cursor, responds `200` + `verification_pending`, **then** `scheduleDailyFritzRecordGameVerification` (~448–462). Receipts arrive async (or never). |
+| `dailyFritzRecordGameRoute.ts` ~320–333, 347–400 | Same route when terminal hand already verified by `/next-hand`, or transactional commit | **Gated** | Sync `writeVerifiedGame` and/or `commitDailyFritzAttemptCommand` with game/hand receipts before response. Transactional path skipped when `verificationPending` (~347–348). |
+| `server/src/http/routes/dailyFritzRecordGameAsyncVerification.ts` ~86–201 | Backfills hand/game receipts after advance | **After-the-fact** | Does not reverse the earlier cursor advance. On verify failure: marks `rejected` + `unverified_hands` (~105–122). |
+| `server/src/http/routes/dailyFritzCompletionRoutes.ts` ~117–223 | `status: 'completed'`, final scores on attempt row | **Gated (eligibility)** | `canFinalizeDailyFritzAttempt` requires complete game authority **or** sticky `rejected` (~122–125). Blocks `pending_verification` / incomplete receipts with **409**. Leaderboard filter separately requires `verification_status === 'verified'` (`dailyFritzStore.ts` ~730–737). |
+| `dailyFritzCompletionRoutes.ts` ~281–349 | `status: 'abandoned'` | N/A (terminal leave) | No verification gate; abandons started attempts. |
+| `server/src/http/routes/dailyFritzCheckpointRoute.ts` ~75–76 | Writes `active_checkpoint` only | **Gated on cursor match** | `validateDailyFritzCheckpointWrite` requires matching `authorityRevision` / game / hand (`dailyFritzCheckpointPolicy.ts`). Does **not** advance authority cursor. |
+| `server/src/http/routes/dailyFritzStartRoute.ts` ~250–291 | Creates/updates attempt, pins contract, `status: 'started'` | **OK / not this class** | Starts a run; no hand/game proof required. |
+
+### 1.2 Server — player-visible / published writes
+
+| Location | What is written | Gated? | Notes |
+|---|---|---|---|
+| `dailyFritzRecordGameRoute.ts` ~318–340, 402 | `attempt.result` set blob (`games[]`, set winner, scores) | **Not gated** on advance-first path | Same write that advances cursor. Hub cards / resume read this immediately. |
+| `dailyFritzRecordGameRoute.ts` ~408–419 | `activity_feed` via `writeDailyFritzGameActivity` | **Not gated** | Fires after upsert even when `verificationPending`. Social/activity is player-visible without a receipt. |
+| `dailyFritzCompletionRoutes.ts` ~253–261 | Leaderboard preview in response | **Gated** | Rank only if `isVerified`; store builder filters `verified` only. |
+| `dailyFritzStore.ts` `buildDailyFritzLeaderboard` ~671–737 | Public leaderboard rows | **Gated** | `status === 'completed'` **and** `verification_status === 'verified'`. |
+| `dailyFritzCompletionRoutes.ts` ~134–168 | Completed attempt personal result (history / hub) | **Partially gated** | Can finalize as `legacy_unverified` when `rejected` or legacy. Personal completion is visible; leaderboard still excluded. |
+| `dailyFritzVerificationGlue.ts` `writeUnverifiedDailyFritzHand` ~86–104 | Sticky `rejected` + `unverified_hands` | Explicit unranked marker | Prevents silent leaderboard corruption; still advances play. |
+
+### 1.3 Client — cursor / local “published” state
+
+| Location | What advances | Gated? | Notes |
+|---|---|---|---|
+| `client/src/modules/match/hooks/useHandLifecycle.ts` `applyDailyFritzNextHandResponse` ~178–219 | Local session cursor (`handIndex` / `revision`) + new deal | **Gated on HTTP 200** | Applies only after `/next-hand` succeeds — including **`unverified: true`** success. Server may have advanced without a receipt. |
+| `useHandLifecycle.ts` advance path ~400–435 | Prefetch / advance request | Does not locally bump authority before response | Correct ordering relative to server. |
+| `client/src/dailyFritz/useDailyFritzRunController.ts` `submitCompletedGame` ~434–498 | Local `set_result` / between-games overlay | **Gated on `/record-game` 200** | Trusts advance-first success; may show Game N saved while async verify still pending. |
+| `client/src/modules/daily/useDailyFritzSessionPersistence.ts` ~166–251 | `localStorage` + debounced `/checkpoint` | **Not authority advance** | Checkpoint revision ≠ authority revision. Sync failure returns `null` and is ignored (`api.ts` `saveDailyFritzCheckpoint` ~526–528). |
+| `client/src/dailyFritz/dailyFritzCheckpointUnload.ts` | `fetch` beacon on unload | Best-effort | No user UI; can lose last mid-hand checkpoint. |
+
+### 1.4 Dead / misleading gate
+
+| Location | Issue |
+|---|---|
+| `dailyFritzVerificationGlue.ts` `readDailyFritzUnverifiedFallbackRequest` ~68–75 | **Never called** by `/next-hand`. Client documents a 3-attempt unverified fallback (`api.ts` ~615–621, `dailyFritzNextHandFailurePolicy.ts`), but server **already advances on first verify failure when scores are present** (`dailyFritzNeverStrand.test.ts` “advances immediately on the first request when scores are present”). |
+
+---
+
+## 2. Blast radius for every “not gated” case
+
+| Case | Blast radius |
+|---|---|
+| **Advance-first `/record-game`** (cursor + `set_result.games` before async receipt) | **Same class as 409 cascade** if `/complete` runs while `pending_verification` / missing game receipt → `Daily Fritz verification is incomplete.` Player sees “couldn’t finalize” / retry loops. If async verify later fails → sticky `rejected` → finish **unranked** (not silent LB lie). If async worker **dies** before writing status → can strand at `pending_verification` until manual ops. Hub/activity already show the game as recorded. |
+| **`/next-hand` advance-on-verify-failure with scores** | **Not 409 cascade** — returns 200 `unverified`. Blast: **silent competitive death** (run becomes `rejected`, never leaderboard-eligible) while play continues. Player may not notice until hub says unranked. Wrong scores from client legacy fields can be carried forward into `active_game`. |
+| **Legacy score-only `/next-hand`** | Same as above for non-modern attempts; modern should 426. |
+| **Activity feed on advance-first record-game** | **Social lie / premature publish** — friends can see a Daily Fritz game result that never got a receipt (or later rejected). Not LB corruption. |
+| **Checkpoint save swallow** | **Corrupted / empty resume** risk on crash mid-hand — reload falls back to last good checkpoint or official hand. Not the 409 cascade; usually recoverable via authority reload. |
+| **Client accepting `unverified: true`** | Propagates server never-strand into seamless next deal — **silent unranked**, same as server row above. |
+| **`buildRecordedDailyFritzAttemptResult` still drops `active_game`** (`dailyFritzVerificationPolicy.ts` ~197–205) | **Residual of aunt’s bug class**, largely **mitigated** for verify by ledger-based start scores. Remaining: any UI/resume path that still trusts `active_game` after record-game sees missing progress (between-games usually OK at 0–0; mid-set tooling/debug confusion). |
+
+---
+
+## 3. Client fetch error handling (daily-fritz endpoints)
+
+| Endpoint | Caller(s) | Failure UI? | Retry behavior |
+|---|---|---|---|
+| `GET /api/daily-fritz/today` | `useDailyFritzInit` | **Yes** — loading screen `failed` + Retry (`DailyFritzLoadingScreen`) | Manual retry; soft cache clear on retry |
+| `POST /api/daily-fritz/start` | `useDailyFritzRunController` begin/continue | **Yes** — hub error / start failure message | Manual re-tap start; telemetry `start_requested` |
+| `POST /api/daily-fritz/next-hand` | `useHandLifecycle` | **Yes** — hand-over modal (`handAdvanceError` + manual Continue/Retry) after silent retries | Auto retry ladder for transport/5xx; rebuild for `incomplete_transcript` / `wrong_actor`; then modal. Note: **verify-fail-with-scores is success**, not this path |
+| `POST /api/daily-fritz/record-game` | `submitCompletedGame` | **Yes** — overlay `record-error` (“Game N finished, but result has not been saved”) | Auto up to 3 attempts then hard stop; Retry on overlay; authority recovery path reloads hub |
+| `POST /api/daily-fritz/complete` | `submitSetCompletion` / embedded completion | **Yes** — `final-error` overlay / `resultError` | Manual `retryFinalSubmission` / completion retry |
+| `POST /api/daily-fritz/checkpoint` | session persistence + unload beacon | **No** | `saveDailyFritzCheckpoint` catches → `null`; unload `fetch` fire-and-forget. Debounced retries only via later edits |
+| `POST /api/daily-fritz/telemetry` | many | **No** (by design) | Swallow errors (`api.ts` ~878–880) |
+| `POST /api/daily-fritz/abandon` | exported; sparse UI use | **No dedicated DF screen** if unused | Throws to caller if used |
+| `GET /api/daily-fritz/leaderboard/:date` | `DailyFritzLeaderboardScreen` | **Yes** — inline error + try again | Manual reload |
+| `GET /api/daily-fritz/history` | `getDailyFritzHistory` in `api.ts` | **No in-product caller found** | N/A (API exists; unused by hub UI in this tree) |
+| Admin/health/events routes | admin screens | Admin-only errors | N/A for players |
+
+---
+
+## 4. Observability gaps — `verification_failed` & reconstructability
+
+### What *is* durable today
+
+- `daily_fritz_events` row (best-effort) with `event_type`, `verifier_code`, `game_number`, `hand_index`, short `payload.message`, sometimes `transcript_digest`.
+- Attempt blob: `authority.hands[]` digests/scores **only for hands that verified**; `unverified_hands[]` codes if never-strand fired.
+- Sentry warning/message for bypass / infrastructure codes (no full transcript).
+- Successful path: `daily_fritz_verified_hands` / `daily_fritz_verified_games` when transactional/async backfill succeeds.
+
+### What is **not** durable (cannot reconstruct after the fact)
+
+| Failure path | Lost artifact | Why it hurts |
+|---|---|---|
+| `/next-hand` or `/record-game` **sync** `verification_failed` catch (`dailyFritzNextHandRoute.ts` ~488–498, `dailyFritzRecordGameRoute.ts` ~466–475) | Full transcript / journal / digest often absent | Event payload is `{ operation, message }` only — **no digest, no actions**. Same gap that forced offline BFS for aunt’s game 1. |
+| `recordDailyFritzAdvanceWithoutVerification` (`dailyFritzVerificationGlue.ts` ~341–356) | Transcript + digest | Writes `verification_failed` with `outcome: advance_unverified` but **no `transcriptDigest`**, no body. |
+| Advance-first async verify (`dailyFritzRecordGameAsyncVerification.ts`) | Transcript lives **only in process memory** until verify runs | Process restart / deploy mid-flight → no replay input; may leave `pending_verification` with only earlier `game_recorded` digest (if that event landed). |
+| Async verify crash (`schedule…` `.catch` ~66–74) | May leave attempt still `pending_verification` | Sentry/log only; no transcript archive. |
+| `recordDailyFritzEventBestEffort` failure | The event itself | Metric `event_persistence_failed`; investigation has empty timeline. |
+| Client transcript build failure (competitive) | Never submitted | Sentry `transcript_build_failed`; server never sees evidence. |
+| Checkpoint not saved / silent checkpoint fail | Mid-hand journal on server | Resume evidence only local; if local wiped, gone. |
+| Sentry-only alerts | No durable transcript attachment | Ops see code + attempt id, not replayable log. |
+
+**Bottom line:** Digests on *successful* `hand_verified` / `game_recorded` help *confirm* identity but **do not store the transcript**. On the failure paths that matter most (`verification_failed` + advance_unverified + async pending), we still cannot reconstruct what the client played without an external recovery miracle.
+
+---
+
+## 5. Top 5 (ranked)
+
+Ranking axes: **(a)** how many real users can hit it, **(b)** silent data corruption vs visible error, **(c)** cheapness of fix.
+
+### 1. Advance-first `/record-game` still publishes + moves cursor before durable game receipt
+
+- **(a)** High — every competitive set that finishes a game through record-game (all multi-game / terminal paths without a prior `/next-hand` terminal receipt).
+- **(b)** Visible 409 cascade on fast `/complete`; unranked if async fails; activity feed premature; not silent LB forge (LB still gated).
+- **(c)** Medium — either verify+receipt in the same lock before cursor advance, or persist transcript+digest+pending job durably and block finalize until receipt/reject settles; keep never-strand as explicit reject only after archival.
+
+### 2. `/next-hand` never-strand advances on **first** verify failure whenever scores are sent (fallback helper unused)
+
+- **(a)** High — any transient verifier bug, transcript glitch, or fidelity regression (the class that produced post-play recovery draws) turns into an unranked run without a hard error.
+- **(b)** **Silent competitive corruption** (sticky `rejected`) with continued play — worse than a modal for trust.
+- **(c)** Cheap–medium — wire `readDailyFritzUnverifiedFallbackRequest` (or equivalent) so first failures **409** and only Nth attempt advances unranked; align client policy with server.
+
+### 3. `verification_failed` paths do not persist transcript (or even digest) durably
+
+- **(a)** Every failed verify / bypass — low daily volume, **high** cost per incident (blocks all aunt-style investigations).
+- **(b)** Observability only — does not corrupt LB by itself, but makes (1)/(2) unfixable.
+- **(c)** Cheap — on fail/bypass/async schedule: write truncated transcript JSON or content-addressed blob keyed by digest; always set `transcript_digest` on the event.
+
+### 4. Async verification is fire-and-forget in-memory (crash → stranded `pending_verification`)
+
+- **(a)** Medium — deploy/restart windows during/after game save; multi-instance without shared queue.
+- **(b)** Visible strand / 409 on complete; possible stuck “Saving…” recovery loops if client retries record-game oddly.
+- **(c)** Medium — durable outbox job + idempotent worker; or stop advancing until sync verify when transactional flag is on.
+
+### 5. Checkpoint / telemetry failures are silent; activity publishes unverified games
+
+- **(a)** Checkpoint: medium (flaky mobile networks). Activity: every advance-first game.
+- **(b)** Checkpoint → resume pain (usually recoverable). Activity → **silent social wrongness**.
+- **(c)** Cheap — gate `writeDailyFritzGameActivity` on verified game receipt (or on complete); surface a soft “progress may not resume offline” only if product wants (optional). Prefer gating activity first.
+
+---
+
+## Out of scope / explicitly not top-5
+
+- Post-play recovery draw fidelity (fixed in PR #36) — different class.
+- Transactional commands flag off by default — increases exposure of (1)/(4) but is a deployment switch, not a separate bug.
+- Unused `GET /history` client helper — cleanup only.
+- Leaderboard eligibility filter — already correct; do not “fix” by loosening it.
+
+---
+
+## Suggested next pass (when implementing)
+
+1. Persist evidence on every `verification_failed` / async schedule.  
+2. Make never-strand require explicit fallback attempts server-side.  
+3. Narrow or eliminate advance-before-receipt on `/record-game` (or make pending finalize safe + observable).  
+
+No code was changed in this audit.

--- a/server/src/dailyFritzTelemetry.test.ts
+++ b/server/src/dailyFritzTelemetry.test.ts
@@ -16,6 +16,10 @@ describe('Daily Fritz telemetry contract', () => {
     expect(isDailyFritzEventType('checkpoint_saved')).toBe(true);
   });
 
+  it('allows async_verification_scheduled in the canonical event taxonomy', () => {
+    expect(isDailyFritzEventType('async_verification_scheduled')).toBe(true);
+  });
+
   it.each([
     ['stale_revision', 'command', 'authoritative_refresh'],
     ['authority_contract_unsupported', 'challenge', 'client_update_required'],

--- a/server/src/dailyFritzTelemetry.ts
+++ b/server/src/dailyFritzTelemetry.ts
@@ -11,6 +11,7 @@ export const DAILY_FRITZ_EVENT_TYPES = [
   'next_hand_replayed',
   'game_started',
   'game_recorded',
+  'async_verification_scheduled',
   'set_continued',
   'attempt_completed',
   'attempt_abandoned',

--- a/server/src/dbIdempotencySchema.test.ts
+++ b/server/src/dbIdempotencySchema.test.ts
@@ -293,6 +293,14 @@ describe('DB idempotency schema guardrails', () => {
     expect(sql).toContain('daily_fritz_events_event_type_check');
   });
 
+  it('allows async_verification_scheduled in daily_fritz_events event taxonomy', () => {
+    const sql = compactSql(readRepoFile(
+      'supabase/migrations/2026-08-20_daily_fritz_events_async_verification_scheduled.sql',
+    ));
+    expect(sql).toContain("'async_verification_scheduled'");
+    expect(sql).toContain('daily_fritz_events_event_type_check');
+  });
+
   it('ships Fritz Challenge canonical funnel and failure metrics', () => {
     const sql = compactSql(readRepoFile(
       'supabase/migrations/2026-08-02_fritz_challenge_canonical_telemetry.sql',

--- a/server/src/http/routes/dailyFritzNextHandRoute.ts
+++ b/server/src/http/routes/dailyFritzNextHandRoute.ts
@@ -38,6 +38,7 @@ import {
   isDailyFritzGameEndingScore,
   recordDailyFritzAdvanceWithoutVerification,
   recordDailyFritzEventBestEffort,
+  dailyFritzTranscriptEvidenceFields,
   rejectModernAttemptWhenAuthorityDisabled,
   respondVerificationError,
   writeActiveGameProgress,
@@ -78,6 +79,7 @@ export function registerDailyFritzNextHandRoute(app: Application): void {
     return;
   }
 
+  let evidenceTranscript: ReturnType<typeof parseTranscriptForRequest> | null = null;
   try {
     await withDailyFritzAttemptLock(attemptId, async () => {
     const authenticatedUserId = await getAuthenticatedUserId(req);
@@ -231,6 +233,7 @@ export function registerDailyFritzNextHandRoute(app: Application): void {
     let parseError: DailyFritzVerificationError | null = null;
     try {
       parsedTranscript = parseTranscriptForRequest(transcriptInput);
+      evidenceTranscript = parsedTranscript;
     } catch (error) {
       if (error instanceof DailyFritzVerificationError && hasLegacyScores) {
         parseError = error;
@@ -364,6 +367,7 @@ export function registerDailyFritzNextHandRoute(app: Application): void {
             verifierCode: verificationError!.code,
             operation: 'next-hand',
             message: verificationError!.message,
+            transcript: parsedTranscript,
           });
           attempt.result = writeUnverifiedDailyFritzHand(attempt.result, {
             gameNumber,
@@ -403,6 +407,7 @@ export function registerDailyFritzNextHandRoute(app: Application): void {
         verifierCode: verificationError!.code,
         operation: 'next-hand',
         message: verificationError!.message,
+        transcript: parsedTranscript,
       });
       attempt.result = writeUnverifiedDailyFritzHand(attempt.result, {
         gameNumber,
@@ -487,14 +492,20 @@ export function registerDailyFritzNextHandRoute(app: Application): void {
   } catch (error) {
     if (error instanceof DailyFritzVerificationError) {
       incrementDailyFritzMetric('verification_failed', error.code);
+      const evidence = dailyFritzTranscriptEvidenceFields(evidenceTranscript);
       await recordDailyFritzEventBestEffort({
         attemptId: attemptId || null,
         requestId: diagnostics.requestId,
         eventType: 'verification_failed',
         verifierCode: error.code,
         handIndex: completedHandIndex,
+        transcriptDigest: evidence.transcriptDigest,
         idempotencyKey: `${attemptId || 'unknown'}:verification_failed:${diagnostics.requestId}`,
-        payload: { operation: 'next-hand', message: error.message },
+        payload: {
+          operation: 'next-hand',
+          message: error.message,
+          ...evidence.payload,
+        },
       });
     } else {
       incrementDailyFritzMetric('request_failed');

--- a/server/src/http/routes/dailyFritzRecordGameAdvance.test.ts
+++ b/server/src/http/routes/dailyFritzRecordGameAdvance.test.ts
@@ -50,6 +50,7 @@ vi.mock('../../social/activityWriter', () => ({
   writeDailyFritzGameActivity: vi.fn().mockResolvedValue(undefined),
 }));
 
+import { recordDailyFritzEvent } from '../stores/dailyFritzEventStore';
 import { registerDailyFritzRoutes } from './dailyFritz';
 import { getDailyFritzMetrics, resetDailyFritzMetricsForTests } from './dailyFritzMetrics';
 import {
@@ -57,7 +58,7 @@ import {
   runDailyFritzRecordGameVerification,
   setRecordGameVerificationDelayMsForTests,
 } from './dailyFritzRecordGameAsyncVerification';
-
+import { digestDailyFritzTranscript } from '../../dailyFritzVerifier';
 type Handler = (req: unknown, res: unknown) => unknown | Promise<unknown>;
 
 function makeHarness() {
@@ -243,11 +244,35 @@ describe('record-game advance-first with async verification', () => {
     expect(games[1]).toMatchObject({ gameNumber: 2, playerScore: 60, fritzScore: 34 });
     expect(response.body.next_game_number).toBe(3);
 
+    const scheduled = vi.mocked(recordDailyFritzEvent).mock.calls
+      .map((call) => call[0])
+      .find((event) => event.eventType === 'async_verification_scheduled');
+    expect(scheduled).toMatchObject({
+      eventType: 'async_verification_scheduled',
+      transcriptDigest: digestDailyFritzTranscript(recordGameBody().transcript as never),
+      payload: expect.objectContaining({
+        outcome: 'async_verification_scheduled',
+        transcript: expect.objectContaining({ gameNumber: 2, handIndex: 3 }),
+      }),
+    });
+
     await flushAsyncVerification();
     expect(getDailyFritzMetrics().verification_bypassed.total).toBeGreaterThan(0);
     expect(persistedAttempt.result?.verification_status).toBe('rejected');
     expect(persistedAttempt.result?.games).toHaveLength(2);
     expect((persistedAttempt.result as { games: Array<{ gameNumber: number }> }).games[1].gameNumber).toBe(2);
+
+    const bypassed = vi.mocked(recordDailyFritzEvent).mock.calls
+      .map((call) => call[0])
+      .find((event) => event.eventType === 'verification_failed'
+        && (event.payload as { outcome?: string } | undefined)?.outcome === 'advance_unverified');
+    expect(bypassed).toMatchObject({
+      transcriptDigest: expect.any(String),
+      payload: expect.objectContaining({
+        outcome: 'advance_unverified',
+        transcript: expect.objectContaining({ gameNumber: 2, handIndex: 3 }),
+      }),
+    });
   });
 
   it('returns before a slow async verifier finishes', async () => {

--- a/server/src/http/routes/dailyFritzRecordGameAsyncVerification.ts
+++ b/server/src/http/routes/dailyFritzRecordGameAsyncVerification.ts
@@ -113,6 +113,7 @@ export async function runDailyFritzRecordGameVerification(
         verifierCode: verification.error.code,
         operation: 'record-game',
         message: verification.error.message,
+        transcript: input.transcript,
       });
       attempt.result = writeUnverifiedDailyFritzHand(attempt.result, {
         gameNumber: input.gameNumber,
@@ -143,6 +144,7 @@ export async function runDailyFritzRecordGameVerification(
         message: !terminalComplete
           ? 'Async verification found the terminal hand was not complete.'
           : 'Async verification found recorded scores did not match the transcript.',
+        transcript: input.transcript,
       });
       attempt.result = writeUnverifiedDailyFritzHand(attempt.result, {
         gameNumber: input.gameNumber,

--- a/server/src/http/routes/dailyFritzRecordGameRoute.ts
+++ b/server/src/http/routes/dailyFritzRecordGameRoute.ts
@@ -42,7 +42,9 @@ import {
   parseTranscriptForRequest,
   readActiveGameProgress,
   isDailyFritzGameEndingScore,
+  recordDailyFritzAsyncVerificationScheduled,
   recordDailyFritzEventBestEffort,
+  dailyFritzTranscriptEvidenceFields,
   rejectModernAttemptWhenAuthorityDisabled,
   respondVerificationError,
   writeActiveGameProgress,
@@ -74,6 +76,7 @@ export function registerDailyFritzRecordGameRoute(app: Application): void {
     return;
   }
 
+  let evidenceTranscript: ReturnType<typeof parseTranscriptForRequest> | null = null;
   try {
     await withDailyFritzAttemptLock(attemptId, async () => {
     const authenticatedUserId = await getAuthenticatedUserId(req);
@@ -106,6 +109,7 @@ export function registerDailyFritzRecordGameRoute(app: Application): void {
     }
     const publishedAuthority = await loadDailyFritzPublishedAuthority({ attempt, run });
     const parsedTranscript = transcriptInput == null ? null : parseTranscriptForRequest(transcriptInput);
+    if (parsedTranscript) evidenceTranscript = parsedTranscript;
     if (!parsedTranscript && requiresVerifiedDailyFritzEvidence(attempt.result)) {
       res.status(426).json({ error: 'This attempt requires verified game evidence. Update required.' });
       return;
@@ -438,6 +442,21 @@ export function registerDailyFritzRecordGameRoute(app: Application): void {
         setWinner: setResult.setWinner ?? null,
       },
     });
+    if (asyncVerificationInput) {
+      // Persist transcript before respond + fire-and-forget verify so a process
+      // restart still leaves reconstructable evidence (observability only).
+      await recordDailyFritzAsyncVerificationScheduled({
+        attemptId,
+        runDate: attempt.runDate,
+        userId: authenticatedUserId,
+        requestId: diagnostics.requestId,
+        gameNumber,
+        handIndex: asyncVerificationInput.handIndex,
+        transcript: asyncVerificationInput.transcript,
+        expectedPlayerScore: asyncVerificationInput.expectedPlayerScore,
+        expectedFritzScore: asyncVerificationInput.expectedFritzScore,
+      });
+    }
     res.json({
       ok: true,
       authority_revision: saved.revision,
@@ -465,13 +484,19 @@ export function registerDailyFritzRecordGameRoute(app: Application): void {
   } catch (error) {
     if (error instanceof DailyFritzVerificationError) {
       incrementDailyFritzMetric('verification_failed', error.code);
+      const evidence = dailyFritzTranscriptEvidenceFields(evidenceTranscript);
       await recordDailyFritzEventBestEffort({
         attemptId: attemptId || null,
         requestId: diagnostics.requestId,
         eventType: 'verification_failed',
         verifierCode: error.code,
+        transcriptDigest: evidence.transcriptDigest,
         idempotencyKey: `${attemptId || 'unknown'}:verification_failed:record-game:${diagnostics.requestId}`,
-        payload: { operation: 'record-game', message: error.message },
+        payload: {
+          operation: 'record-game',
+          message: error.message,
+          ...evidence.payload,
+        },
       });
     } else {
       incrementDailyFritzMetric('request_failed');

--- a/server/src/http/routes/dailyFritzVerificationEvidence.test.ts
+++ b/server/src/http/routes/dailyFritzVerificationEvidence.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { DailyFritzTranscript } from '@racehorse/game-core';
+import { digestDailyFritzTranscript } from '../../dailyFritzVerifier';
+import {
+  buildDailyFritzTranscriptEvidence,
+  dailyFritzTranscriptEvidenceFields,
+  recordDailyFritzAdvanceWithoutVerification,
+  recordDailyFritzAsyncVerificationScheduled,
+} from './dailyFritzVerificationGlue';
+
+vi.mock('@sentry/node', () => ({
+  captureMessage: vi.fn(),
+  captureException: vi.fn(),
+}));
+
+const { recordEventMock } = vi.hoisted(() => ({
+  recordEventMock: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../stores/dailyFritzEventStore', async () => {
+  const actual = await vi.importActual<typeof import('../stores/dailyFritzEventStore')>(
+    '../stores/dailyFritzEventStore',
+  );
+  return {
+    ...actual,
+    recordDailyFritzEvent: recordEventMock,
+  };
+});
+
+function sampleTranscript(overrides: Partial<DailyFritzTranscript> = {}): DailyFritzTranscript {
+  return {
+    protocolVersion: 2,
+    rulesVersion: 1,
+    fritzPolicyVersion: 2,
+    fritzPolicyContract: 'fritz-policy-v2-deterministic-canonical-ties',
+    stateDigestVersion: 1,
+    clientRelease: 'test',
+    challengeId: 'daily-fritz:2026-08-20:r2:s1',
+    attemptId: 'attempt-1',
+    gameNumber: 1,
+    handIndex: 0,
+    actions: [
+      {
+        sequence: 0,
+        actor: 'player',
+        kind: 'play',
+        tile: { low: 6, high: 6 },
+        position: 'left',
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe('Daily Fritz verification transcript evidence (observability)', () => {
+  it('builds digest + transcript fields without mutating the transcript', () => {
+    const transcript = sampleTranscript();
+    const evidence = buildDailyFritzTranscriptEvidence(transcript);
+    expect(evidence.transcriptDigest).toBe(digestDailyFritzTranscript(transcript));
+    expect(evidence.actionCount).toBe(1);
+    expect(evidence.transcript).toEqual(transcript);
+    expect(dailyFritzTranscriptEvidenceFields(null)).toEqual({
+      transcriptDigest: null,
+      payload: {},
+    });
+  });
+
+  it('persists transcript + digest on advance_unverified events', async () => {
+    recordEventMock.mockClear();
+    const transcript = sampleTranscript({ handIndex: 2 });
+    await recordDailyFritzAdvanceWithoutVerification({
+      attemptId: 'attempt-1',
+      runDate: '2026-08-20',
+      userId: 'user-1',
+      requestId: 'req-1',
+      gameNumber: 1,
+      handIndex: 2,
+      verifierCode: 'wrong_actor',
+      operation: 'next-hand',
+      message: 'wrong actor',
+      transcript,
+    });
+
+    expect(recordEventMock).toHaveBeenCalledWith(expect.objectContaining({
+      eventType: 'verification_failed',
+      transcriptDigest: digestDailyFritzTranscript(transcript),
+      payload: expect.objectContaining({
+        outcome: 'advance_unverified',
+        operation: 'next-hand',
+        transcript,
+        action_count: 1,
+      }),
+    }));
+  });
+
+  it('persists transcript + digest on async_verification_scheduled events', async () => {
+    recordEventMock.mockClear();
+    const transcript = sampleTranscript({ handIndex: 4, gameNumber: 2 });
+    await recordDailyFritzAsyncVerificationScheduled({
+      attemptId: 'attempt-1',
+      runDate: '2026-08-20',
+      userId: 'user-1',
+      requestId: 'req-2',
+      gameNumber: 2,
+      handIndex: 4,
+      transcript,
+      expectedPlayerScore: 60,
+      expectedFritzScore: 34,
+    });
+
+    expect(recordEventMock).toHaveBeenCalledWith(expect.objectContaining({
+      eventType: 'async_verification_scheduled',
+      transcriptDigest: digestDailyFritzTranscript(transcript),
+      idempotencyKey: expect.stringContaining('async_verification_scheduled'),
+      payload: expect.objectContaining({
+        outcome: 'async_verification_scheduled',
+        expected_player_score: 60,
+        expected_fritz_score: 34,
+        transcript,
+        action_count: 1,
+      }),
+    }));
+  });
+});

--- a/server/src/http/routes/dailyFritzVerificationGlue.ts
+++ b/server/src/http/routes/dailyFritzVerificationGlue.ts
@@ -1,5 +1,5 @@
 import * as Sentry from '@sentry/node';
-import { parseDailyFritzTranscript } from '@racehorse/game-core';
+import { parseDailyFritzTranscript, type DailyFritzTranscript } from '@racehorse/game-core';
 import type { Response } from 'express';
 import {
   getDailyFritzSeed,
@@ -10,6 +10,7 @@ import { buildDailyFritzChallengeId } from '../../dailyFritzIdentity';
 import {
   DailyFritzVerificationError,
   createOfficialDailyFritzHandState,
+  digestDailyFritzTranscript,
   verifyDailyFritzHand,
   type VerifiedDailyFritzHandRecord,
 } from '../../dailyFritzVerifier';
@@ -117,6 +118,43 @@ export async function recordDailyFritzEventBestEffort(event: DailyFritzEventInpu
       error: error instanceof Error ? error.message : String(error),
     }, '[daily-fritz-event] persistence failed');
   }
+}
+
+/**
+ * Observability-only: digest + full transcript for reconstruction after
+ * verification_failed / advance_unverified / async-schedule. Transcripts are
+ * already capped at DAILY_FRITZ_MAX_TRANSCRIPT_BYTES at parse time.
+ */
+export type DailyFritzTranscriptEvidence = {
+  transcriptDigest: string;
+  transcript: DailyFritzTranscript;
+  actionCount: number;
+};
+
+export function buildDailyFritzTranscriptEvidence(
+  transcript: DailyFritzTranscript,
+): DailyFritzTranscriptEvidence {
+  return {
+    transcriptDigest: digestDailyFritzTranscript(transcript),
+    transcript,
+    actionCount: transcript.actions.length,
+  };
+}
+
+export function dailyFritzTranscriptEvidenceFields(
+  transcript: DailyFritzTranscript | null | undefined,
+): Pick<DailyFritzEventInput, 'transcriptDigest' | 'payload'> {
+  if (!transcript) {
+    return { transcriptDigest: null, payload: {} };
+  }
+  const evidence = buildDailyFritzTranscriptEvidence(transcript);
+  return {
+    transcriptDigest: evidence.transcriptDigest,
+    payload: {
+      transcript: evidence.transcript,
+      action_count: evidence.actionCount,
+    },
+  };
 }
 
 export type DailyFritzActiveGameProgress = { gameNumber: DailyFritzSetGameNumber; you: number; fritz: number };
@@ -328,6 +366,8 @@ export async function recordDailyFritzAdvanceWithoutVerification(input: {
   verifierCode: string;
   operation: 'next-hand' | 'record-game';
   message: string;
+  /** Observability only — does not affect advance / ranking behavior. */
+  transcript?: DailyFritzTranscript | null;
 }): Promise<void> {
   incrementDailyFritzMetric('verification_bypassed', input.verifierCode);
   log.error({
@@ -339,6 +379,7 @@ export async function recordDailyFritzAdvanceWithoutVerification(input: {
     verifierCode: input.verifierCode,
     message: input.message,
   }, '[daily-fritz] advancing without verification receipt — run is now unranked');
+  const evidence = dailyFritzTranscriptEvidenceFields(input.transcript ?? null);
   await recordDailyFritzEventBestEffort({
     attemptId: input.attemptId,
     runDate: input.runDate,
@@ -348,11 +389,13 @@ export async function recordDailyFritzAdvanceWithoutVerification(input: {
     verifierCode: input.verifierCode,
     gameNumber: input.gameNumber,
     handIndex: input.handIndex,
+    transcriptDigest: evidence.transcriptDigest,
     idempotencyKey: `${input.attemptId}:verification_bypassed:${input.operation}:${input.gameNumber}:${input.handIndex}`,
     payload: {
       operation: input.operation,
       outcome: 'advance_unverified',
       message: input.message,
+      ...evidence.payload,
     },
   });
   const infrastructureFailure = DAILY_FRITZ_INFRASTRUCTURE_VERIFIER_CODES.has(input.verifierCode);
@@ -374,9 +417,47 @@ export async function recordDailyFritzAdvanceWithoutVerification(input: {
         gameNumber: input.gameNumber,
         handIndex: input.handIndex,
         message: input.message,
+        transcriptDigest: evidence.transcriptDigest,
       },
     });
   }
+}
+
+/**
+ * Observability only: durable transcript archive before fire-and-forget async
+ * verification. Does not gate advance or finalize.
+ */
+export async function recordDailyFritzAsyncVerificationScheduled(input: {
+  attemptId: string;
+  runDate: string;
+  userId: string;
+  requestId: string;
+  gameNumber: DailyFritzSetGameNumber;
+  handIndex: number;
+  transcript: DailyFritzTranscript;
+  expectedPlayerScore: number;
+  expectedFritzScore: number;
+}): Promise<void> {
+  const evidence = buildDailyFritzTranscriptEvidence(input.transcript);
+  await recordDailyFritzEventBestEffort({
+    attemptId: input.attemptId,
+    runDate: input.runDate,
+    userId: input.userId,
+    requestId: input.requestId,
+    eventType: 'async_verification_scheduled',
+    gameNumber: input.gameNumber,
+    handIndex: input.handIndex,
+    transcriptDigest: evidence.transcriptDigest,
+    idempotencyKey: `${input.attemptId}:async_verification_scheduled:${input.gameNumber}:${input.handIndex}:${evidence.transcriptDigest}`,
+    payload: {
+      operation: 'record-game',
+      outcome: 'async_verification_scheduled',
+      expected_player_score: input.expectedPlayerScore,
+      expected_fritz_score: input.expectedFritzScore,
+      transcript: evidence.transcript,
+      action_count: evidence.actionCount,
+    },
+  });
 }
 
 export function verifyAttemptHand(input: {

--- a/supabase/migrations/2026-08-20_daily_fritz_events_async_verification_scheduled.sql
+++ b/supabase/migrations/2026-08-20_daily_fritz_events_async_verification_scheduled.sql
@@ -1,0 +1,18 @@
+-- Allow async_verification_scheduled observability events.
+-- Persists transcript evidence when advance-first /record-game schedules
+-- fire-and-forget verification so ops can reconstruct after process death.
+
+alter table public.daily_fritz_events
+  drop constraint if exists daily_fritz_events_event_type_check;
+
+alter table public.daily_fritz_events
+  add constraint daily_fritz_events_event_type_check check (event_type in (
+    'mode_impression', 'start_requested', 'attempt_started', 'attempt_resumed',
+    'first_move', 'hand_started', 'hand_verified', 'next_hand_replayed',
+    'game_started', 'game_recorded', 'async_verification_scheduled',
+    'set_continued', 'attempt_completed',
+    'attempt_abandoned', 'verification_failed', 'command_conflict',
+    'recovery_started', 'recovery_succeeded', 'recovery_failed',
+    'request_failed', 'retry_request', 'review_opened', 'leaderboard_opened',
+    'share_requested', 'share_completed', 'checkpoint_saved'
+  ));


### PR DESCRIPTION
## Summary
- Persist `transcript_digest` + full transcript on every `verification_failed` catch, `advance_unverified` bypass, and new `async_verification_scheduled` event (advance-first `/record-game`).
- Purely additive observability — **no changes to verification, cursor advance, never-strand, finalize, or leaderboard gating**.
- Ships first so future debugging of PR B/C has reconstructable evidence (closes the aunt-style reconstructability hole from the hardening audit #3).

## Low-risk proof
| Path | Behavior change? |
|---|---|
| `/next-hand` verify success / fail-with-scores advance | No — same upsert + response; only event payload gains evidence |
| `/next-hand` verification_failed catch (409/422) | No — same status/body; event now includes digest+transcript when parse succeeded |
| `/record-game` advance-first | No — still advances then schedules async verify; evidence event is awaited best-effort before respond |
| Async verify success/reject | No — same receipt/reject writes; bypass events now include transcript |
| Leaderboard / complete / checkpoint | Untouched |

Requires migration `2026-08-20_daily_fritz_events_async_verification_scheduled.sql` (adds event type to CHECK). Deploy migration before or with this server release.

## Test plan
- [x] `dailyFritzVerificationEvidence.test.ts`
- [x] `dailyFritzRecordGameAdvance.test.ts` (asserts schedule + bypass evidence)
- [x] `dailyFritzNeverStrand.test.ts`, async verification, hand-start scores, telemetry + schema tests
- [x] `npm run build --prefix server`
- [ ] Apply Supabase migration in preview/staging
- [ ] Manually trigger a failed verify / advance-first record-game and confirm `daily_fritz_events` rows include `transcript_digest` + `payload.transcript`


Made with [Cursor](https://cursor.com)