### PR TITLE
Daily Fritz PR B: sync verify before record-game advance

### DIFF
--- a/server/src/http/routes/dailyFritzRecordGameAdvance.test.ts
+++ b/server/src/http/routes/dailyFritzRecordGameAdvance.test.ts
@@ -53,12 +53,8 @@ vi.mock('../../social/activityWriter', () => ({
 import { recordDailyFritzEvent } from '../stores/dailyFritzEventStore';
 import { registerDailyFritzRoutes } from './dailyFritz';
 import { getDailyFritzMetrics, resetDailyFritzMetricsForTests } from './dailyFritzMetrics';
-import {
-  resetRecordGameVerificationDelayMsForTests,
-  runDailyFritzRecordGameVerification,
-  setRecordGameVerificationDelayMsForTests,
-} from './dailyFritzRecordGameAsyncVerification';
 import { digestDailyFritzTranscript } from '../../dailyFritzVerifier';
+
 type Handler = (req: unknown, res: unknown) => unknown | Promise<unknown>;
 
 function makeHarness() {
@@ -79,7 +75,15 @@ function makeHarness() {
       setHeader() { return res; },
       once() { return res; },
     };
-    await handler({ headers: {}, params: {}, query: {}, body: input.body ?? {}, method, path, get() { return undefined; } }, res);
+    await handler({
+      headers: {},
+      params: {},
+      query: {},
+      body: input.body ?? {},
+      method,
+      path,
+      get() { return undefined; },
+    }, res);
     return { status, body: body as Record<string, unknown> };
   };
 }
@@ -197,22 +201,12 @@ function recordGameBody(overrides: Record<string, unknown> = {}) {
   };
 }
 
-async function flushAsyncVerification() {
-  await new Promise((resolve) => {
-    setImmediate(resolve);
-  });
-  await new Promise((resolve) => {
-    setTimeout(resolve, 0);
-  });
-}
-
-describe('record-game advance-first with async verification', () => {
+describe('record-game sync verify before advance', () => {
   const request = makeHarness();
   let persistedAttempt: DailyFritzAttemptRecord;
 
   beforeEach(() => {
     resetDailyFritzMetricsForTests();
-    resetRecordGameVerificationDelayMsForTests();
     authUserMock.mockResolvedValue(USER_ID);
     process.env.DAILY_FRITZ_TEST_FIXTURES_ENABLED = 'true';
     persistedAttempt = buildAttempt();
@@ -227,47 +221,38 @@ describe('record-game advance-first with async verification', () => {
 
   afterEach(() => {
     vi.clearAllMocks();
-    resetRecordGameVerificationDelayMsForTests();
     delete process.env.DAILY_FRITZ_TEST_FIXTURES_ENABLED;
   });
 
-  it('records game 2 from legacy scores when async verification fails', async () => {
+  it('advances with sticky rejected in the same request when sync verify fails', async () => {
     const response = await request('POST', '/api/daily-fritz/record-game', {
       body: recordGameBody(),
     });
 
     expect(response.status).toBe(200);
     expect(response.body.ok).toBe(true);
-    expect(response.body.verification_pending).toBe(true);
+    expect(response.body.verification_pending).toBeUndefined();
+    expect(response.body.unverified).toBe(true);
     const games = (response.body.set_result as { games: Array<{ gameNumber: number; playerScore: number; fritzScore: number }> }).games;
     expect(games).toHaveLength(2);
     expect(games[1]).toMatchObject({ gameNumber: 2, playerScore: 60, fritzScore: 34 });
     expect(response.body.next_game_number).toBe(3);
 
-    const scheduled = vi.mocked(recordDailyFritzEvent).mock.calls
-      .map((call) => call[0])
-      .find((event) => event.eventType === 'async_verification_scheduled');
-    expect(scheduled).toMatchObject({
-      eventType: 'async_verification_scheduled',
-      transcriptDigest: digestDailyFritzTranscript(recordGameBody().transcript as never),
-      payload: expect.objectContaining({
-        outcome: 'async_verification_scheduled',
-        transcript: expect.objectContaining({ gameNumber: 2, handIndex: 3 }),
-      }),
-    });
-
-    await flushAsyncVerification();
-    expect(getDailyFritzMetrics().verification_bypassed.total).toBeGreaterThan(0);
+    // Settled synchronously — no pending_verification, no async schedule event.
     expect(persistedAttempt.result?.verification_status).toBe('rejected');
-    expect(persistedAttempt.result?.games).toHaveLength(2);
-    expect((persistedAttempt.result as { games: Array<{ gameNumber: number }> }).games[1].gameNumber).toBe(2);
+    expect(persistedAttempt.currentGameNumber).toBe(3);
+    expect(persistedAttempt.currentHandIndex).toBe(0);
+    expect(getDailyFritzMetrics().verification_bypassed.total).toBeGreaterThan(0);
+
+    const eventTypes = vi.mocked(recordDailyFritzEvent).mock.calls.map((call) => call[0].eventType);
+    expect(eventTypes).not.toContain('async_verification_scheduled');
 
     const bypassed = vi.mocked(recordDailyFritzEvent).mock.calls
       .map((call) => call[0])
       .find((event) => event.eventType === 'verification_failed'
         && (event.payload as { outcome?: string } | undefined)?.outcome === 'advance_unverified');
     expect(bypassed).toMatchObject({
-      transcriptDigest: expect.any(String),
+      transcriptDigest: digestDailyFritzTranscript(recordGameBody().transcript as never),
       payload: expect.objectContaining({
         outcome: 'advance_unverified',
         transcript: expect.objectContaining({ gameNumber: 2, handIndex: 3 }),
@@ -275,28 +260,16 @@ describe('record-game advance-first with async verification', () => {
     });
   });
 
-  it('returns before a slow async verifier finishes', async () => {
-    setRecordGameVerificationDelayMsForTests(400);
-
-    const startedAt = Date.now();
-    const responsePromise = request('POST', '/api/daily-fritz/record-game', {
+  it('does not leave pending_verification after a failed sync verify', async () => {
+    const response = await request('POST', '/api/daily-fritz/record-game', {
       body: recordGameBody(),
     });
-    const response = await responsePromise;
-    const elapsedMs = Date.now() - startedAt;
-
     expect(response.status).toBe(200);
-    expect(response.body.verification_pending).toBe(true);
-    expect(elapsedMs).toBeLessThan(200);
-
-    await flushAsyncVerification();
-    await new Promise((resolve) => {
-      setTimeout(resolve, 450);
-    });
     expect(persistedAttempt.result?.verification_status).toBe('rejected');
+    expect(persistedAttempt.result?.verification_status).not.toBe('pending_verification');
   });
 
-  it('keeps the recorded game result when async verification rejects the attempt', async () => {
+  it('keeps the recorded game result when sync verify rejects the attempt', async () => {
     const response = await request('POST', '/api/daily-fritz/record-game', {
       body: recordGameBody(),
     });
@@ -304,8 +277,6 @@ describe('record-game advance-first with async verification', () => {
     const shownGame = (response.body.set_result as {
       games: Array<{ gameNumber: number; playerScore: number; fritzScore: number }>;
     }).games[1];
-
-    await flushAsyncVerification();
 
     expect(persistedAttempt.result?.verification_status).toBe('rejected');
     const persistedGame = (persistedAttempt.result as {
@@ -343,10 +314,8 @@ describe('record-game advance-first with async verification', () => {
 
     expect(response.status).toBe(200);
     expect(response.body.ok).toBe(true);
-    expect(response.body.verification_pending).toBe(true);
-  });
-
-  it('runDailyFritzRecordGameVerification is exported for deterministic async tests', async () => {
-    expect(typeof runDailyFritzRecordGameVerification).toBe('function');
+    expect(response.body.verification_pending).toBeUndefined();
+    expect(response.body.unverified).toBe(true);
+    expect(persistedAttempt.result?.verification_status).toBe('rejected');
   });
 });

--- a/server/src/http/routes/dailyFritzRecordGameRoute.ts
+++ b/server/src/http/routes/dailyFritzRecordGameRoute.ts
@@ -37,20 +37,23 @@ import {
 import { commitDailyFritzAttemptCommand } from '../stores/dailyFritzCommandStore';
 import {
   DAILY_FRITZ_TRANSACTIONAL_COMMANDS_ENABLED,
+  attemptVerifyHand,
   findVerifiedHand,
   isRecoverableDailyFritzCommandConflict,
   parseTranscriptForRequest,
+  pinAuthorityContractFromVerifiedTranscript,
   readActiveGameProgress,
   isDailyFritzGameEndingScore,
-  recordDailyFritzAsyncVerificationScheduled,
+  recordDailyFritzAdvanceWithoutVerification,
   recordDailyFritzEventBestEffort,
   dailyFritzTranscriptEvidenceFields,
   rejectModernAttemptWhenAuthorityDisabled,
   respondVerificationError,
   writeActiveGameProgress,
+  writeUnverifiedDailyFritzHand,
   writeVerifiedGame,
+  writeVerifiedHand,
 } from './dailyFritzVerificationGlue';
-import { scheduleDailyFritzRecordGameVerification } from './dailyFritzRecordGameAsyncVerification';
 import { capture500, log, prodSafeError } from './dailyFritzRouteErrors';
 import { DAILY_FRITZ_VERIFIER_VERSION } from '@racehorse/game-core';
 
@@ -202,13 +205,7 @@ export function registerDailyFritzRecordGameRoute(app: Application): void {
     let movesUsed = Math.round(legacyMovesUsed);
     let handsPlayed = Math.round(legacyHandsPlayed);
     let terminalHandReceipt: VerifiedDailyFritzHandRecord | null = null;
-    let verificationPending = false;
-    let asyncVerificationInput: {
-      transcript: NonNullable<ReturnType<typeof parseTranscriptForRequest>>;
-      expectedPlayerScore: number;
-      expectedFritzScore: number;
-      handIndex: number;
-    } | null = null;
+    let advancedUnverified = false;
     const terminalHandIndex = attempt.currentHandIndex;
     const winningScore = publishedAuthority?.winningScore ?? run.winningScore;
     if (parsedTranscript) {
@@ -253,7 +250,8 @@ export function registerDailyFritzRecordGameRoute(app: Application): void {
         }
         verifiedHandResult = existingTerminalHand;
       } else {
-        // Advance-first: record the game now, verify the terminal hand async.
+        // Sync verify + receipt under lock before publishing / advancing.
+        // Forward-only: attempts already advance-first published are not rewritten.
         const progress = readActiveGameProgress(attempt.result, gameNumber);
         const resolvedPlayerScore = hasLegacyResult ? playerScore : progress.you;
         const resolvedFritzScore = hasLegacyResult ? fritzScore : progress.fritz;
@@ -262,7 +260,6 @@ export function registerDailyFritzRecordGameRoute(app: Application): void {
             res.status(409).json({ error: 'Daily Fritz game is not complete.' });
             return;
           }
-          // Legacy score fallback when transcript evidence is unusable.
           if (playerScore === fritzScore) {
             res.status(400).json({ error: 'Daily Fritz games cannot be recorded with tied scores.' });
             return;
@@ -271,9 +268,81 @@ export function registerDailyFritzRecordGameRoute(app: Application): void {
           playerScore = resolvedPlayerScore;
           fritzScore = resolvedFritzScore;
         }
+
+        const verification = attemptVerifyHand({
+          transcript: parsedTranscript,
+          attempt,
+          run,
+          userId: authenticatedUserId,
+          gameNumber,
+          handIndex: terminalHandIndex,
+          publishedChallenge: publishedAuthority,
+        });
+
+        const verified = verification.ok ? verification.verified : null;
+        const terminalComplete = Boolean(
+          verified
+          && verified.terminalState.gameOver
+          && verified.result.playerScoreAfter !== verified.result.fritzScoreAfter,
+        );
+        const scoresMatch = Boolean(
+          verified
+          && verified.result.playerScoreAfter === playerScore
+          && verified.result.fritzScoreAfter === fritzScore,
+        );
+
+        if (verified && terminalComplete && scoresMatch) {
+          attempt.result = pinAuthorityContractFromVerifiedTranscript({
+            result: attempt.result,
+            run,
+            transcript: verified.transcript,
+          });
+          attempt.result = writeVerifiedHand(attempt.result, verified.result);
+          verifiedHandResult = verified.result;
+          playerScore = verified.result.playerScoreAfter;
+          fritzScore = verified.result.fritzScoreAfter;
+        } else {
+          // Never-strand: publish with sticky rejected only after evidence is archived.
+          // Do not leave pending_verification / fire-and-forget async verify.
+          const verifierCode = !verification.ok
+            ? verification.error.code
+            : !terminalComplete
+              ? 'game_not_complete'
+              : 'score_mismatch';
+          const message = !verification.ok
+            ? verification.error.message
+            : !terminalComplete
+              ? 'Terminal hand verification found the game was not complete.'
+              : 'Recorded scores did not match the verified transcript.';
+          await recordDailyFritzAdvanceWithoutVerification({
+            attemptId,
+            runDate: attempt.runDate,
+            userId: authenticatedUserId,
+            requestId: diagnostics.requestId,
+            gameNumber,
+            handIndex: terminalHandIndex,
+            verifierCode,
+            operation: 'record-game',
+            message,
+            transcript: parsedTranscript,
+          });
+          attempt.result = writeUnverifiedDailyFritzHand(attempt.result, {
+            gameNumber,
+            handIndex: terminalHandIndex,
+            verifierCode,
+          });
+          advancedUnverified = true;
+        }
+
         if (hasLegacyResult) {
           movesUsed = Math.round(legacyMovesUsed);
           handsPlayed = Math.round(legacyHandsPlayed);
+        } else if (verifiedHandResult) {
+          const gameHands = readAuthorityLedger(attempt.result).hands.filter(
+            (hand) => hand.gameNumber === gameNumber,
+          );
+          movesUsed = gameHands.reduce((sum, hand) => sum + hand.actionCount, 0);
+          handsPlayed = gameHands.length;
         } else {
           const priorHands = readAuthorityLedger(attempt.result).hands.filter(
             (hand) => hand.gameNumber === gameNumber,
@@ -286,13 +355,6 @@ export function registerDailyFritzRecordGameRoute(app: Application): void {
           you: playerScore,
           fritz: fritzScore,
         });
-        verificationPending = true;
-        asyncVerificationInput = {
-          transcript: parsedTranscript,
-          expectedPlayerScore: playerScore,
-          expectedFritzScore: fritzScore,
-          handIndex: terminalHandIndex,
-        };
       }
       if (verifiedHandResult) {
         playerScore = verifiedHandResult.playerScoreAfter;
@@ -321,7 +383,7 @@ export function registerDailyFritzRecordGameRoute(app: Application): void {
     };
     const setResult = appendDailyFritzGameToSet(currentSetResult, gameResult);
 
-    if (parsedTranscript && !verificationPending) {
+    if (parsedTranscript && !advancedUnverified) {
       const gameHands = readAuthorityLedger(attempt.result).hands.filter((hand) => hand.gameNumber === gameNumber);
       const resultDigest = createHash('sha256')
         .update(`${attempt.id}:${gameNumber}:${playerScore}:${fritzScore}:${gameHands.map((hand) => hand.transcriptDigest).join(':')}`)
@@ -340,7 +402,7 @@ export function registerDailyFritzRecordGameRoute(app: Application): void {
       previousResult: attempt.result,
       setResult,
       hasTranscript: Boolean(parsedTranscript),
-      verificationPending,
+      verificationPending: false,
     });
     attempt.result = clearDailyFritzActiveCheckpoint(attempt.result);
     if (!setResult.setWinner) {
@@ -349,7 +411,7 @@ export function registerDailyFritzRecordGameRoute(app: Application): void {
     }
     let saved: DailyFritzAttemptRecord;
     const transactionalGame = Boolean(
-      attempt.challengeId && DAILY_FRITZ_TRANSACTIONAL_COMMANDS_ENABLED && !verificationPending,
+      attempt.challengeId && DAILY_FRITZ_TRANSACTIONAL_COMMANDS_ENABLED && !advancedUnverified,
     );
     if (transactionalGame) {
       const authorityGame = readAuthorityLedger(attempt.result).games.find(
@@ -440,46 +502,16 @@ export function registerDailyFritzRecordGameRoute(app: Application): void {
         movesUsed,
         handsPlayed,
         setWinner: setResult.setWinner ?? null,
+        ...(advancedUnverified ? { unverified: true } : {}),
       },
     });
-    if (asyncVerificationInput) {
-      // Persist transcript before respond + fire-and-forget verify so a process
-      // restart still leaves reconstructable evidence (observability only).
-      await recordDailyFritzAsyncVerificationScheduled({
-        attemptId,
-        runDate: attempt.runDate,
-        userId: authenticatedUserId,
-        requestId: diagnostics.requestId,
-        gameNumber,
-        handIndex: asyncVerificationInput.handIndex,
-        transcript: asyncVerificationInput.transcript,
-        expectedPlayerScore: asyncVerificationInput.expectedPlayerScore,
-        expectedFritzScore: asyncVerificationInput.expectedFritzScore,
-      });
-    }
     res.json({
       ok: true,
       authority_revision: saved.revision,
       set_result: savedSetResult ?? setResult,
       next_game_number: setResult.setWinner ? null : Math.min(setResult.games.length + 1, 3),
-      ...(verificationPending ? { verification_pending: true } : {}),
+      ...(advancedUnverified ? { unverified: true } : {}),
     });
-    if (asyncVerificationInput) {
-      scheduleDailyFritzRecordGameVerification({
-        attemptId,
-        userId: authenticatedUserId,
-        runDate: attempt.runDate,
-        requestId: diagnostics.requestId,
-        gameNumber,
-        handIndex: asyncVerificationInput.handIndex,
-        transcript: asyncVerificationInput.transcript,
-        run,
-        publishedChallenge: publishedAuthority,
-        expectedPlayerScore: asyncVerificationInput.expectedPlayerScore,
-        expectedFritzScore: asyncVerificationInput.expectedFritzScore,
-        challengeId: attempt.challengeId,
-      });
-    }
     });
   } catch (error) {
     if (error instanceof DailyFritzVerificationError) {

--- a/server/src/http/routes/dailyFritzVerificationPolicy.ts
+++ b/server/src/http/routes/dailyFritzVerificationPolicy.ts
@@ -174,7 +174,7 @@ export function buildRecordedDailyFritzAttemptResult(input: {
   previousResult: Record<string, unknown> | null;
   setResult: object;
   hasTranscript: boolean;
-  /** Advance-first path: game is recorded before async verification finishes. */
+  /** @deprecated Advance-first pending path removed; kept for call-site compatibility. */
   verificationPending?: boolean;
 }): Record<string, unknown> {
   const previous = input.previousResult ?? {};


### PR DESCRIPTION
## Summary
- `/record-game` now **sync-verifies under the attempt lock and writes hand/game receipts before** publishing `set_result` / advancing the cursor.
- Verify failure with usable scores still **never-strands** as sticky `rejected` in the **same request** (with PR A transcript evidence) — no more `pending_verification` + fire-and-forget async.
- **Forward-only:** attempts already advance-first published are not rewritten. Replay path unchanged.

## In-flight / backward compat (confirmed before impl)
- New gate applies only to **future** `/record-game` advances.
- Mid-flight `pending_verification` rows (if any) are **not** healed by this PR — separate remediation (your planned follow-up after preview).

## Prod snapshot before this PR (read-only, 2026-08-20)
- `status=started` + `verification_status=pending_verification`: **0**
- Broader “published games, missing authority receipt” among started `run_date>=2026-07-01`: **7** (5 legacy `vs=null` from July, 1 July `in_progress`, 1 Aug 20 already `rejected`)
- Oldest of those 7: **~46 days** (`2026-07-05`) — not a large active pending queue from this week

## Test plan
- [x] `dailyFritzRecordGameAdvance.test.ts` rewritten for sync gate
- [x] Related DF verification / never-strand / evidence / finalize tests
- [x] `npm run build --prefix server`
- [ ] Preview: finish a multi-game Daily Fritz set; confirm no `verification_pending` on record-game; `/complete` succeeds when receipts present
- [ ] Preview: force a bad transcript with legacy scores; confirm same-response `unverified: true` + sticky `rejected`, play continues


Made with [Cursor](https://cursor.com)