### PR TITLE
Daily Fritz: infra fallback gate + stranded-row remediation

### DIFF
--- a/server/scripts/remediateDailyFritzStrandedAttempts.ts
+++ b/server/scripts/remediateDailyFritzStrandedAttempts.ts
@@ -1,0 +1,254 @@
+/**
+ * Case-by-case remediation for the 7 stranded Daily Fritz attempts identified
+ * in the 2026-08-20 hardening follow-up. Attempt #7 (live Aug 20 rejected run)
+ * is intentionally excluded.
+ *
+ * Default: dry-run (no writes).
+ * Apply:    REMEDIATE_APPLY=1 npx tsx scripts/remediateDailyFritzStrandedAttempts.ts
+ *
+ * Abandon leaves `result` (including any orphan authority hands) untouched —
+ * only status + completedAt change.
+ */
+import { createHash } from 'crypto';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+type AttemptRow = {
+  id: string;
+  run_date: string;
+  user_id: string;
+  status: string;
+  started_at: string;
+  revision: number;
+  result: Record<string, unknown> | null;
+};
+
+const TARGETS: Array<{
+  id: string;
+  runDate: string;
+  kind: 'legacy_orphan' | 'corrupt_ledger';
+  note: string;
+}> = [
+  {
+    id: '52ba55c0-442a-442d-b797-5eb379416c94',
+    runDate: '2026-07-05',
+    kind: 'legacy_orphan',
+    note: 'Pre-modern started row: game 1 published, no authority, no events.',
+  },
+  {
+    id: '2ba392c2-5780-4878-a98e-60d85f884580',
+    runDate: '2026-07-06',
+    kind: 'legacy_orphan',
+    note: 'Pre-modern started row: game 1 published, no authority, no events.',
+  },
+  {
+    id: '39816586-d07d-40bb-8122-e42f52ed1981',
+    runDate: '2026-07-10',
+    kind: 'legacy_orphan',
+    note: 'Pre-modern started row: game 1 published, no authority, no events.',
+  },
+  {
+    id: 'f3ac0758-736c-4b2a-99ae-968b27857415',
+    runDate: '2026-07-11',
+    kind: 'legacy_orphan',
+    note: 'Pre-modern started row: game 1 published, no authority, no events.',
+  },
+  {
+    id: '0df1400a-914c-4d4a-8875-a034deb5c261',
+    runDate: '2026-07-17',
+    kind: 'legacy_orphan',
+    note: 'Pre-modern started row: game 1 published, no authority, no events.',
+  },
+  {
+    id: '0b6fe2f8-89a9-4847-8a7d-767bbd46fae2',
+    runDate: '2026-07-22',
+    kind: 'corrupt_ledger',
+    note: 'Corrupt ledger: published game 1 missing receipt; orphan authority hand game 2 / hand 0 left inert.',
+  },
+];
+
+const EXCLUDED = {
+  id: 'e1f0a2f2-ce10-4c65-aab5-c71dc02b1be7',
+  reason: 'Live Aug 20 started+rejected run — leave as-is (already unranked).',
+};
+
+function loadEnv(): { url: string; key: string } {
+  const envPath = resolve(__dirname, '../.env');
+  const text = readFileSync(envPath, 'utf8');
+  const env: Record<string, string> = {};
+  for (const line of text.split('\n')) {
+    if (!line || line.startsWith('#') || !line.includes('=')) continue;
+    const [k, ...rest] = line.split('=');
+    env[k!] = rest.join('=').trim().replace(/^['"]|['"]$/g, '');
+  }
+  const url = env.SUPABASE_URL?.replace(/\/$/, '');
+  const key = env.SUPABASE_SERVICE_KEY;
+  if (!url || !key) throw new Error('SUPABASE_URL / SUPABASE_SERVICE_KEY missing from server/.env');
+  return { url, key };
+}
+
+async function supabaseFetch<T>(
+  url: string,
+  key: string,
+  path: string,
+  init: RequestInit = {},
+): Promise<T> {
+  const response = await fetch(`${url}${path}`, {
+    ...init,
+    headers: {
+      apikey: key,
+      Authorization: `Bearer ${key}`,
+      'Content-Type': 'application/json',
+      Prefer: 'return=representation',
+      ...(init.headers ?? {}),
+    },
+  });
+  if (!response.ok) {
+    throw new Error(`${init.method ?? 'GET'} ${path} → ${response.status}: ${await response.text()}`);
+  }
+  if (response.status === 204) return undefined as T;
+  return response.json() as Promise<T>;
+}
+
+function summarizeResult(result: Record<string, unknown> | null) {
+  const games = Array.isArray(result?.games) ? result!.games as Array<Record<string, unknown>> : [];
+  const authority = result?.authority && typeof result.authority === 'object'
+    ? result.authority as Record<string, unknown>
+    : {};
+  const hands = Array.isArray(authority.hands) ? authority.hands : [];
+  const authGames = Array.isArray(authority.games) ? authority.games : [];
+  return {
+    verification_status: result?.verification_status ?? null,
+    published_games: games.map((g) => g.gameNumber),
+    authority_games: authGames.map((g) => (g as { gameNumber?: number }).gameNumber),
+    authority_hand_pairs: hands.map((h) => {
+      const row = h as { gameNumber?: number; handIndex?: number };
+      return `${row.gameNumber}/${row.handIndex}`;
+    }),
+  };
+}
+
+function nextResult(kind: 'legacy_orphan' | 'corrupt_ledger', previous: Record<string, unknown> | null) {
+  const base = { ...(previous ?? {}) };
+  if (kind === 'legacy_orphan') {
+    return {
+      ...base,
+      verification_status: 'legacy_unverified',
+      remediation_note: 'abandoned_legacy_orphan_2026-08-20',
+    };
+  }
+  return {
+    ...base,
+    verification_status: 'rejected',
+    remediation_note: 'abandoned_corrupt_ledger_2026-08-20',
+    // Intentionally do not touch authority.hands — orphan game-2/hand-0 stays inert.
+  };
+}
+
+async function main() {
+  const apply = process.env.REMEDIATE_APPLY === '1';
+  const { url, key } = loadEnv();
+  const ids = TARGETS.map((t) => t.id);
+  const rows = await supabaseFetch<AttemptRow[]>(
+    url,
+    key,
+    `/rest/v1/daily_fritz_attempts?select=id,run_date,user_id,status,started_at,revision,result&id=in.(${ids.join(',')})&order=started_at.asc`,
+  );
+
+  console.log(JSON.stringify({
+    mode: apply ? 'APPLY' : 'DRY_RUN',
+    excluded: EXCLUDED,
+    targets: TARGETS.length,
+    fetched: rows.length,
+  }, null, 2));
+
+  const byId = new Map(rows.map((r) => [r.id, r]));
+  const plan = [];
+  for (const target of TARGETS) {
+    const row = byId.get(target.id);
+    if (!row) {
+      plan.push({ id: target.id, action: 'skip_missing', note: target.note });
+      continue;
+    }
+    if (row.status !== 'started') {
+      plan.push({
+        id: target.id,
+        action: 'skip_not_started',
+        status: row.status,
+        note: target.note,
+      });
+      continue;
+    }
+    const before = summarizeResult(row.result);
+    const patchedResult = nextResult(target.kind, row.result);
+    const after = summarizeResult(patchedResult);
+    plan.push({
+      id: target.id,
+      run_date: row.run_date,
+      user_id: row.user_id,
+      kind: target.kind,
+      note: target.note,
+      action: 'abandon',
+      revision: row.revision,
+      before,
+      after,
+      authority_hands_unchanged:
+        JSON.stringify(before.authority_hand_pairs) === JSON.stringify(after.authority_hand_pairs),
+    });
+
+    if (apply) {
+      const completedAt = new Date().toISOString();
+      const updated = await supabaseFetch<AttemptRow[]>(
+        url,
+        key,
+        `/rest/v1/daily_fritz_attempts?id=eq.${target.id}`,
+        {
+          method: 'PATCH',
+          body: JSON.stringify({
+            status: 'abandoned',
+            completed_at: completedAt,
+            result: patchedResult,
+            // bump revision for observability; abandon API does the same via upsert
+            revision: row.revision + 1,
+          }),
+        },
+      );
+      const eventKey = createHash('sha256')
+        .update(`remediate:${target.id}:abandoned:${completedAt}`)
+        .digest('hex');
+      await supabaseFetch(
+        url,
+        key,
+        '/rest/v1/daily_fritz_events?on_conflict=idempotency_key',
+        {
+          method: 'POST',
+          headers: { Prefer: 'resolution=ignore-duplicates,return=minimal' },
+          body: JSON.stringify([{
+            attempt_id: target.id,
+            run_date: row.run_date,
+            user_id: row.user_id,
+            event_type: 'attempt_abandoned',
+            idempotency_key: `remediate:${target.id}:${eventKey.slice(0, 24)}`,
+            payload: {
+              remediation: true,
+              kind: target.kind,
+              note: target.note,
+              previous_status: 'started',
+            },
+          }]),
+        },
+      );
+      console.log(JSON.stringify({ applied: target.id, updated: updated?.[0]?.status ?? null }, null, 2));
+    }
+  }
+
+  console.log(JSON.stringify({ plan }, null, 2));
+  if (!apply) {
+    console.log('\nDry-run only. Re-run with REMEDIATE_APPLY=1 after human confirm.');
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/server/src/http/routes/dailyFritzInfrastructureFallback.test.ts
+++ b/server/src/http/routes/dailyFritzInfrastructureFallback.test.ts
@@ -1,0 +1,295 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { Application } from 'express';
+import { buildDailyFritzChallengeId } from '../../dailyFritzIdentity';
+import { getDailyFritzSeed } from '../../dailyFritz';
+import { isDailyFritzAttemptLeaderboardEligible } from '../stores/dailyFritzStore';
+import type { DailyFritzAttemptRecord, DailyFritzRunRecord } from '../stores/dailyFritzStore';
+import { DailyFritzVerificationError } from '../../dailyFritzVerifier';
+import {
+  DAILY_FRITZ_UNVERIFIED_FALLBACK_MIN_ATTEMPTS,
+  canNeverStrandDailyFritzVerification,
+} from './dailyFritzVerificationGlue';
+import {
+  DAILY_FRITZ_UNVERIFIED_FALLBACK_AFTER_ATTEMPTS,
+  resolveDailyFritzCompletedHandNextHandFailure,
+} from '../../../../client/src/dailyFritz/dailyFritzNextHandFailurePolicy';
+
+const {
+  authUserMock,
+  getAttemptByIdMock,
+  getAttemptMock,
+  upsertAttemptMock,
+  getRunMock,
+  attemptVerifyHandMock,
+} = vi.hoisted(() => ({
+  authUserMock: vi.fn(),
+  getAttemptByIdMock: vi.fn(),
+  getAttemptMock: vi.fn(),
+  upsertAttemptMock: vi.fn(),
+  getRunMock: vi.fn(),
+  attemptVerifyHandMock: vi.fn(),
+}));
+
+vi.mock('../../platform/auth/supabaseAuth', () => ({
+  getAuthenticatedUserId: authUserMock,
+}));
+
+vi.mock('../stores/dailyFritzStore', async () => {
+  const actual = await vi.importActual<typeof import('../stores/dailyFritzStore')>(
+    '../stores/dailyFritzStore',
+  );
+  return {
+    ...actual,
+    getDailyFritzAttemptById: getAttemptByIdMock,
+    getDailyFritzAttempt: getAttemptMock,
+    upsertDailyFritzAttempt: upsertAttemptMock,
+    getDailyFritzRun: getRunMock,
+    ensureDailyFritzRunForDate: getRunMock,
+  };
+});
+
+vi.mock('../stores/dailyFritzEventStore', async () => {
+  const actual = await vi.importActual<typeof import('../stores/dailyFritzEventStore')>(
+    '../stores/dailyFritzEventStore',
+  );
+  return {
+    ...actual,
+    recordDailyFritzEvent: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+vi.mock('./dailyFritzVerificationGlue', async () => {
+  const actual = await vi.importActual<typeof import('./dailyFritzVerificationGlue')>(
+    './dailyFritzVerificationGlue',
+  );
+  return {
+    ...actual,
+    attemptVerifyHand: attemptVerifyHandMock,
+  };
+});
+
+vi.mock('../../social/activityWriter', () => ({
+  writeDailyFritzGameActivity: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { registerDailyFritzRoutes } from './dailyFritz';
+
+type Handler = (req: any, res: any) => unknown | Promise<unknown>;
+
+function makeHarness() {
+  const routes = new Map<string, Handler>();
+  const app = {
+    get(path: string, handler: Handler) { routes.set(`GET ${path}`, handler); },
+    post(path: string, handler: Handler) { routes.set(`POST ${path}`, handler); },
+  };
+  registerDailyFritzRoutes(app as unknown as Application);
+
+  return async function request(
+    method: 'GET' | 'POST',
+    path: string,
+    input: { body?: Record<string, unknown> } = {},
+  ) {
+    const handler = routes.get(`${method} ${path}`);
+    if (!handler) throw new Error(`Missing route ${method} ${path}`);
+    let status = 200;
+    let body: unknown;
+    const res = {
+      status(code: number) { status = code; return res; },
+      json(value: unknown) { body = value; return res; },
+      setHeader() { return res; },
+      once() { return res; },
+    };
+    await handler({
+      headers: {},
+      params: {},
+      query: {},
+      body: input.body ?? {},
+      method,
+      path,
+      get() { return undefined; },
+    }, res);
+    return { status, body: body as any };
+  };
+}
+
+const RUN_DATE = '2026-08-10';
+const USER_ID = 'user-1';
+const ATTEMPT_ID = 'attempt-1';
+const VERIFIED_MATCH_ID = 'verified-match-1';
+
+const DEAL = {
+  player_tiles: [{ low: 4, high: 4 }, { low: 1, high: 2 }],
+  fritz_tiles: [{ low: 6, high: 6 }],
+  boneyard: [{ low: 1, high: 3 }, { low: 2, high: 6 }],
+  locked: [],
+};
+
+function sampleTranscript() {
+  return {
+    protocolVersion: 2 as const,
+    rulesVersion: 1 as never,
+    fritzPolicyVersion: 2 as const,
+    challengeId: buildDailyFritzChallengeId(RUN_DATE),
+    attemptId: ATTEMPT_ID,
+    gameNumber: 1 as const,
+    handIndex: 0,
+    actions: [
+      { sequence: 0, actor: 'player' as const, kind: 'play' as const, tile: { low: 4, high: 4 }, position: 'left' as const },
+    ],
+  };
+}
+
+function buildRun(): DailyFritzRunRecord {
+  return {
+    runDate: RUN_DATE,
+    seed: getDailyFritzSeed(RUN_DATE),
+    fritzTier: 'standard',
+    dealSize: 7,
+    winningScore: 500,
+    status: 'live',
+    handDeals: [DEAL, DEAL],
+    generatedAt: '2026-08-10T00:00:00.000Z',
+    invalidatedAt: null,
+    metadata: { draw_winners_by_game: { '1': 'you' } },
+  } as DailyFritzRunRecord;
+}
+
+function buildAttempt(): DailyFritzAttemptRecord {
+  return {
+    id: ATTEMPT_ID,
+    runDate: RUN_DATE,
+    userId: USER_ID,
+    status: 'started',
+    currentHandIndex: 0,
+    currentGameNumber: 1,
+    revision: 1,
+    challengeId: null,
+    challengeContractVersion: null,
+    generationVersion: null,
+    gameRulesVersion: null,
+    transcriptProtocolVersion: null,
+    fritzPolicyVersion: null,
+    rankingVersion: null,
+    authoritySchemaVersion: 1,
+    startedAt: '2026-08-10T00:00:00.000Z',
+    completedAt: null,
+    verifiedMatchId: VERIFIED_MATCH_ID,
+    completionHash: null,
+    result: null,
+    finalScore: null,
+    opponentScore: null,
+    pointDiff: null,
+    won: null,
+    movesUsed: null,
+    handsPlayed: null,
+  } as DailyFritzAttemptRecord;
+}
+
+function wireStore(run: DailyFritzRunRecord) {
+  let stored = buildAttempt();
+  getAttemptByIdMock.mockImplementation(async (id: string, userId: string) =>
+    (id === stored.id && userId === stored.userId ? { ...stored } : null));
+  getAttemptMock.mockImplementation(async () => ({ ...stored }));
+  upsertAttemptMock.mockImplementation(async (record: DailyFritzAttemptRecord) => {
+    stored = { ...record, revision: record.revision + 1 };
+    return { ...stored };
+  });
+  getRunMock.mockImplementation(async (date: string) => (date === run.runDate ? run : null));
+  return { current: () => stored };
+}
+
+function nextHandBody(extra: Record<string, unknown> = {}) {
+  return {
+    attempt_id: ATTEMPT_ID,
+    verified_match_id: VERIFIED_MATCH_ID,
+    run_date: RUN_DATE,
+    game_number: 1,
+    completed_hand_index: 0,
+    transcript: sampleTranscript(),
+    completed_hand_scores: { you: 12, fritz: 0 },
+    ...extra,
+  };
+}
+
+describe('Daily Fritz infrastructure verify failures on /next-hand', () => {
+  afterEach(() => {
+    authUserMock.mockReset();
+    getAttemptByIdMock.mockReset();
+    getAttemptMock.mockReset();
+    upsertAttemptMock.mockReset();
+    getRunMock.mockReset();
+    attemptVerifyHandMock.mockReset();
+  });
+
+  it('aligns server fallback floor with the client ladder', () => {
+    expect(DAILY_FRITZ_UNVERIFIED_FALLBACK_MIN_ATTEMPTS)
+      .toBe(DAILY_FRITZ_UNVERIFIED_FALLBACK_AFTER_ATTEMPTS);
+    expect(canNeverStrandDailyFritzVerification({
+      verifierCode: 'missing_hand_start_progress',
+      unverifiedFallbackAttempts: null,
+    })).toBe(false);
+    expect(canNeverStrandDailyFritzVerification({
+      verifierCode: 'missing_hand_start_progress',
+      unverifiedFallbackAttempts: 2,
+    })).toBe(true);
+    expect(canNeverStrandDailyFritzVerification({
+      verifierCode: 'illegal_action',
+      unverifiedFallbackAttempts: null,
+    })).toBe(true);
+  });
+
+  it('client policy requests unverified_fallback after the first infra 409', () => {
+    expect(resolveDailyFritzCompletedHandNextHandFailure({
+      verifierCode: 'missing_hand_start_progress',
+      status: 409,
+      failureAttempt: 1,
+    }).kind).toBe('continue');
+    expect(resolveDailyFritzCompletedHandNextHandFailure({
+      verifierCode: 'missing_hand_start_progress',
+      status: 409,
+      failureAttempt: 2,
+    }).kind).toBe('unverified_fallback');
+  });
+
+  it('persistent infra failure refuses advance until unverified_fallback, then never-strands playable', async () => {
+    authUserMock.mockResolvedValue(USER_ID);
+    const store = wireStore(buildRun());
+    const request = makeHarness();
+    attemptVerifyHandMock.mockReturnValue({
+      ok: false,
+      error: new DailyFritzVerificationError(
+        'Daily Fritz hand verification is missing authoritative hand-start scores while prior verified hands exist.',
+        'missing_hand_start_progress',
+      ),
+    });
+
+    // Attempt 1 (and any pre-fallback retries): 409, cursor unchanged.
+    const first = await request('POST', '/api/daily-fritz/next-hand', { body: nextHandBody() });
+    expect(first.status).toBe(409);
+    expect(first.body.code).toBe('missing_hand_start_progress');
+    expect(first.body.recoverable).toBe(true);
+    expect(store.current().currentHandIndex).toBe(0);
+    expect(store.current().result?.verification_status).not.toBe('rejected');
+    expect(upsertAttemptMock).not.toHaveBeenCalled();
+
+    // Client ladder reaches unverified_fallback at failureAttempt >= 2.
+    const fallback = await request('POST', '/api/daily-fritz/next-hand', {
+      body: nextHandBody({
+        unverified_fallback: true,
+        verification_attempts: 2,
+      }),
+    });
+    expect(fallback.status).toBe(200);
+    expect(fallback.body.ok).toBe(true);
+    expect(fallback.body.unverified).toBe(true);
+    expect(fallback.body.hand).toBeTruthy();
+
+    const attempt = store.current();
+    expect(attempt.currentHandIndex).toBe(1);
+    expect(attempt.result?.verification_status).toBe('rejected');
+    expect(isDailyFritzAttemptLeaderboardEligible({
+      ...attempt,
+      status: 'completed',
+    })).toBe(false);
+  });
+});

--- a/server/src/http/routes/dailyFritzNextHandRoute.ts
+++ b/server/src/http/routes/dailyFritzNextHandRoute.ts
@@ -36,6 +36,8 @@ import {
   readActiveGameProgress,
   attemptVerifyHand,
   isDailyFritzGameEndingScore,
+  canNeverStrandDailyFritzVerification,
+  readDailyFritzUnverifiedFallbackRequest,
   recordDailyFritzAdvanceWithoutVerification,
   recordDailyFritzEventBestEffort,
   dailyFritzTranscriptEvidenceFields,
@@ -317,6 +319,7 @@ export function registerDailyFritzNextHandRoute(app: Application): void {
     // covers the common case; any hand beyond it is generated on-demand from
     // the same deterministic seed so all players still get identical tiles.
     const winningScore = publishedAuthority?.winningScore ?? run.winningScore;
+    const unverifiedFallbackAttempts = readDailyFritzUnverifiedFallbackRequest(req.body);
     const verification = parsedTranscript
       ? attemptVerifyHand({
           transcript: parsedTranscript,
@@ -339,6 +342,44 @@ export function registerDailyFritzNextHandRoute(app: Application): void {
     if (!progressScores) {
       if (verificationError) throw verificationError;
       res.status(400).json({ error: 'completed_hand_scores are required when verification evidence is unusable.' });
+      return;
+    }
+
+    if (
+      verificationError
+      && !canNeverStrandDailyFritzVerification({
+        verifierCode: verificationError.code,
+        unverifiedFallbackAttempts,
+      })
+    ) {
+      // Infrastructure failure without an explicit client fallback request:
+      // refuse advance so a transient server blip does not sticky-reject the run.
+      const evidence = dailyFritzTranscriptEvidenceFields(parsedTranscript);
+      await recordDailyFritzEventBestEffort({
+        attemptId,
+        runDate: attempt.runDate,
+        userId: authenticatedUserId,
+        requestId: diagnostics.requestId,
+        eventType: 'verification_failed',
+        verifierCode: verificationError.code,
+        gameNumber,
+        handIndex: completedHandIndex,
+        statusCode: 409,
+        transcriptDigest: evidence.transcriptDigest,
+        idempotencyKey: `${attemptId}:verification_failed:infra:${diagnostics.requestId}`,
+        payload: {
+          operation: 'next-hand',
+          outcome: 'refused_advance_infrastructure',
+          message: verificationError.message,
+          ...evidence.payload,
+        },
+      });
+      res.status(409).json({
+        error: 'Daily Fritz could not verify this hand due to a temporary server issue. Retry to continue.',
+        code: verificationError.code,
+        recoverable: true,
+        recovery_action: 'retry',
+      });
       return;
     }
 

--- a/server/src/http/routes/dailyFritzRecordGameAdvance.test.ts
+++ b/server/src/http/routes/dailyFritzRecordGameAdvance.test.ts
@@ -318,4 +318,21 @@ describe('record-game sync verify before advance', () => {
     expect(response.body.unverified).toBe(true);
     expect(persistedAttempt.result?.verification_status).toBe('rejected');
   });
+
+  it('still never-strands on first sync verify failure for infrastructure codes (no unverified_fallback on record-game)', async () => {
+    // /record-game has no client unverified_fallback ladder; capped transport
+    // retries then hard-stop is the escape hatch. Infra codes therefore still
+    // sticky-reject in the same request so the game can be saved unranked.
+    const response = await request('POST', '/api/daily-fritz/record-game', {
+      body: recordGameBody(),
+    });
+    expect(response.status).toBe(200);
+    expect(response.body.unverified).toBe(true);
+    expect(persistedAttempt.result?.verification_status).toBe('rejected');
+    const bypassed = vi.mocked(recordDailyFritzEvent).mock.calls
+      .map((call) => call[0])
+      .find((event) => event.eventType === 'verification_failed'
+        && (event.payload as { outcome?: string } | undefined)?.outcome === 'advance_unverified');
+    expect(bypassed?.verifierCode).toBe('missing_hand_start_progress');
+  });
 });

--- a/server/src/http/routes/dailyFritzVerificationGlue.ts
+++ b/server/src/http/routes/dailyFritzVerificationGlue.ts
@@ -60,12 +60,11 @@ const CLIENT_STUCK_CODES = new Set([
  * How many times a client must have failed to get a hand verified before the
  * server will let the run continue without a verification receipt.
  *
- * The client rebuilds and retries on its own for the recoverable codes; by the
- * time it asks for this, the player has been sitting on a Hand Over screen
- * unable to advance. Continuing unranked is strictly better than trapping
- * them — a stranded player loses the whole run either way.
+ * Keep in sync with client
+ * `DAILY_FRITZ_UNVERIFIED_FALLBACK_AFTER_ATTEMPTS` (currently 2): the client
+ * starts sending `unverified_fallback` once failureAttempt reaches that floor.
  */
-export const DAILY_FRITZ_UNVERIFIED_FALLBACK_MIN_ATTEMPTS = 3;
+export const DAILY_FRITZ_UNVERIFIED_FALLBACK_MIN_ATTEMPTS = 2;
 
 export function readDailyFritzUnverifiedFallbackRequest(body: unknown): number | null {
   const record = (body ?? {}) as Record<string, unknown>;
@@ -74,6 +73,20 @@ export function readDailyFritzUnverifiedFallbackRequest(body: unknown): number |
   if (!Number.isFinite(attempts)) return null;
   const rounded = Math.floor(attempts);
   return rounded >= DAILY_FRITZ_UNVERIFIED_FALLBACK_MIN_ATTEMPTS ? rounded : null;
+}
+
+/**
+ * Infrastructure verifier codes must not burn a competitive run on the first
+ * failure. The client retries, then explicitly sends unverified_fallback; only
+ * then may we never-strand. Genuine transcript failures still never-strand
+ * without that flag (existing /next-hand behavior).
+ */
+export function canNeverStrandDailyFritzVerification(input: {
+  verifierCode: string;
+  unverifiedFallbackAttempts: number | null;
+}): boolean {
+  if (!DAILY_FRITZ_INFRASTRUCTURE_VERIFIER_CODES.has(input.verifierCode)) return true;
+  return input.unverifiedFallbackAttempts != null;
 }
 
 /**


### PR DESCRIPTION
## Summary
- **Option A:** `/next-hand` returns **409-without-advance** for `DAILY_FRITZ_INFRASTRUCTURE_VERIFIER_CODES` unless the client sends `unverified_fallback: true` (then never-strand / sticky `rejected` as today).
- Aligns server fallback floor with client (`MIN_ATTEMPTS = 2`).
- **`/record-game`:** no behavior change — still never-strands on first sync verify failure (including infra); client already caps retries then hard-stops.
- **Remediation:** dry-run script for attempts 1–6; **#7 excluded**. Apply only with `REMEDIATE_APPLY=1` after human confirm. Orphan authority hands stay inert.

## Test coverage (persistent infra → playable)
- `dailyFritzInfrastructureFallback.test.ts`: persistent `missing_hand_start_progress` → first request 409 + cursor unchanged → `unverified_fallback` request → 200 `unverified` + playable next hand + sticky rejected.
- Asserts client policy emits `unverified_fallback` at attempt 2 for that code, and server/client floors match.
- `dailyFritzRecordGameAdvance.test.ts`: confirms record-game still never-strands infra on first failure.

## Remediation dry-run (executed, not applied)
- 5× legacy orphan → abandon + `legacy_unverified`
- 1× corrupt ledger (`0b6fe2f8…`) → abandon + `rejected`; **authority hand `2/0` unchanged** (`authority_hands_unchanged: true`)
- `e1f0a2f2…` excluded

## Test plan
- [x] Infra fallback + never-strand + record-game tests
- [x] `npm run build --prefix server`
- [x] Remediation dry-run against prod (no writes)
- [ ] Preview: force infra failure on next-hand; confirm Hand Over → Continue → unranked advance
- [ ] After merge + confirm: `REMEDIATE_APPLY=1 npx tsx scripts/remediateDailyFritzStrandedAttempts.ts`


Made with [Cursor](https://cursor.com)