### PR TITLE
fix(auth): clear recovery hash only after setSession succeeds

### DIFF
--- a/client/src/auth/recoveryHash.test.ts
+++ b/client/src/auth/recoveryHash.test.ts
@@ -1,0 +1,103 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const setSession = vi.fn();
+const captureMessage = vi.fn();
+
+vi.mock('../lib/supabase', () => ({
+  supabase: {
+    auth: {
+      setSession: (...args: unknown[]) => setSession(...args),
+    },
+  },
+}));
+
+vi.mock('@sentry/react', () => ({
+  captureMessage: (...args: unknown[]) => captureMessage(...args),
+}));
+
+const { parseSupabaseAuthHash, consumeSupabaseRecoveryHash, PASSWORD_RECOVERY_PENDING_KEY } =
+  await import('./recoveryHash');
+
+function recoveryHash(overrides: { access?: string; refresh?: string; type?: string } = {}): string {
+  const access = overrides.access ?? 'access-token-value';
+  const refresh = overrides.refresh ?? 'refresh-token-value';
+  const type = overrides.type ?? 'recovery';
+  return `#access_token=${access}&refresh_token=${refresh}&type=${type}`;
+}
+
+describe('parseSupabaseAuthHash', () => {
+  it('parses recovery callback hashes', () => {
+    expect(parseSupabaseAuthHash(recoveryHash())).toEqual({
+      access_token: 'access-token-value',
+      refresh_token: 'refresh-token-value',
+      type: 'recovery',
+    });
+  });
+
+  it('ignores legacy HashRouter paths', () => {
+    expect(parseSupabaseAuthHash('#/play')).toBeNull();
+  });
+});
+
+describe('consumeSupabaseRecoveryHash', () => {
+  beforeEach(() => {
+    setSession.mockReset();
+    captureMessage.mockReset();
+    window.sessionStorage.clear();
+    window.history.replaceState(null, '', '/reset-password');
+  });
+
+  it('clears the hash only after setSession succeeds', async () => {
+    window.location.hash = recoveryHash();
+    setSession.mockResolvedValue({ error: null });
+
+    const ok = await consumeSupabaseRecoveryHash();
+
+    expect(ok).toBe(true);
+    expect(setSession).toHaveBeenCalledWith({
+      access_token: 'access-token-value',
+      refresh_token: 'refresh-token-value',
+    });
+    expect(window.location.hash).toBe('');
+    expect(window.sessionStorage.getItem(PASSWORD_RECOVERY_PENDING_KEY)).toBe('1');
+  });
+
+  it('leaves the hash in place and reports when setSession fails', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    window.location.hash = recoveryHash({ access: 'access-abc', refresh: 'refresh-xyz' });
+    setSession.mockResolvedValue({
+      error: { message: 'Invalid Refresh Token', name: 'AuthApiError', status: 400 },
+    });
+
+    const ok = await consumeSupabaseRecoveryHash();
+
+    expect(ok).toBe(false);
+    expect(window.location.hash).toContain('access_token=access-abc');
+    expect(window.sessionStorage.getItem(PASSWORD_RECOVERY_PENDING_KEY)).toBeNull();
+    expect(captureMessage).toHaveBeenCalledWith(
+      expect.stringContaining('recovery hash setSession failed'),
+      expect.objectContaining({
+        level: 'error',
+        tags: expect.objectContaining({ auth_alert: 'recovery_set_session_failed' }),
+        extra: expect.objectContaining({
+          auth_flow: 'password_recovery',
+          hash_still_present: true,
+          access_token_len: 'access-abc'.length,
+          refresh_token_len: 'refresh-xyz'.length,
+          error_status: 400,
+        }),
+      }),
+    );
+    expect(JSON.stringify(captureMessage.mock.calls[0])).not.toContain('access-abc');
+    expect(JSON.stringify(captureMessage.mock.calls[0])).not.toContain('refresh-xyz');
+    warn.mockRestore();
+  });
+
+  it('does not call setSession for non-recovery hashes', async () => {
+    window.location.hash = recoveryHash({ type: 'signup' });
+    const ok = await consumeSupabaseRecoveryHash();
+    expect(ok).toBe(false);
+    expect(setSession).not.toHaveBeenCalled();
+  });
+});

--- a/client/src/auth/recoveryHash.ts
+++ b/client/src/auth/recoveryHash.ts
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/react';
 import { supabase } from '../lib/supabase';
 
 export const PASSWORD_RECOVERY_PENDING_KEY = 'racehorse_password_recovery_pending';
@@ -15,7 +16,9 @@ export type SupabaseAuthHashPayload = {
  * bare query string hash:
  *   #access_token=…&refresh_token=…&type=recovery
  *
- * We must read and clear that hash before the router starts.
+ * Callers must read the hash before the router starts (see `main.tsx` bootstrap).
+ * Tokens are cleared from the URL only after `setSession` succeeds — clearing
+ * first burned one-shot recovery links on transient setSession failures.
  */
 export function parseSupabaseAuthHash(rawHash: string): SupabaseAuthHashPayload | null {
   const hash = rawHash.startsWith('#') ? rawHash.slice(1) : rawHash;
@@ -36,10 +39,42 @@ function clearRecoveryHash(): void {
   window.history.replaceState(window.history.state, '', next);
 }
 
+function reportRecoverySetSessionFailure(
+  error: { message?: string; status?: number; name?: string },
+  tokenMeta: { accessTokenLen: number; refreshTokenLen: number },
+): void {
+  const message = error.message ?? 'unknown';
+  const extra = {
+    auth_flow: 'password_recovery',
+    hash_type: 'recovery',
+    pathname: typeof window !== 'undefined' ? window.location.pathname : null,
+    // Lengths only — never token material.
+    access_token_len: tokenMeta.accessTokenLen,
+    refresh_token_len: tokenMeta.refreshTokenLen,
+    error_name: error.name ?? null,
+    error_status: error.status ?? null,
+    hash_still_present: typeof window !== 'undefined' && window.location.hash.includes('access_token='),
+  };
+
+  // Always visible in prod consoles / log drains; Sentry for alerting.
+  console.warn('[auth] recovery hash setSession failed', { message, ...extra });
+  Sentry.captureMessage(`[auth] recovery hash setSession failed: ${message}`, {
+    level: 'error',
+    tags: {
+      auth_alert: 'recovery_set_session_failed',
+      auth_flow: 'password_recovery',
+    },
+    extra: { message, ...extra },
+  });
+}
+
 /**
  * If the current URL carries a Supabase password-recovery hash, exchange it for a
  * session and remove the sensitive hash. Returns true when a recovery session was
  * established (PASSWORD_RECOVERY will fire via onAuthStateChange).
+ *
+ * On setSession failure the hash is left in place so a refresh can retry; tokens
+ * are never cleared before proof of a durable session.
  */
 export async function consumeSupabaseRecoveryHash(): Promise<boolean> {
   if (typeof window === 'undefined' || !supabase) return false;
@@ -49,14 +84,19 @@ export async function consumeSupabaseRecoveryHash(): Promise<boolean> {
 
   const { access_token, refresh_token } = parsed;
 
-  // Strip auth tokens from the hash before App's navigate() effect can run.
-  clearRecoveryHash();
-
   const { error } = await supabase.auth.setSession({ access_token, refresh_token });
   if (error) {
-    console.warn('[auth] recovery hash setSession failed:', error.message);
+    reportRecoverySetSessionFailure(error, {
+      accessTokenLen: access_token.length,
+      refreshTokenLen: refresh_token.length,
+    });
     return false;
   }
+
+  // Strip auth tokens from the URL only after the session is established.
+  // Bootstrap awaits this before mounting the router, so App navigate effects
+  // never see the recovery hash on the success path.
+  clearRecoveryHash();
 
   try {
     window.sessionStorage.setItem(PASSWORD_RECOVERY_PENDING_KEY, '1');


### PR DESCRIPTION
## Summary
- Stop clearing the Supabase password-recovery URL hash before `setSession` succeeds — that burned one-shot reset links on transient failures.
- On failure, leave the hash in place so a refresh can retry, and emit a Sentry + console signal with safe context (pathname, error status/name, token lengths only — never token material).
- Add unit coverage for success clear-after, failure retain + telemetry, and non-recovery no-op.

## Test plan
- [x] `npm test --prefix client -- src/auth/recoveryHash.test.ts`
- [ ] Click a password-reset email link → change-password modal opens; URL hash cleared after session established
- [ ] Simulate setSession failure (invalid/expired link) → hash remains; Sentry event `auth_alert=recovery_set_session_failed` appears; refresh can retry while tokens still in URL


Made with [Cursor](https://cursor.com)