### PR TITLE
fix(mp): durability-gate disconnect auto-act with rollback (PR-MP-A)

### DIFF
--- a/client/src/multiplayer/socketEventRegistry.ts
+++ b/client/src/multiplayer/socketEventRegistry.ts
@@ -386,6 +386,15 @@ export const SOCKET_EVENT_REGISTRY: readonly SocketEventRegistryEntry[] = [
     description: 'Opponent reconnect grace expired message',
   },
   {
+    socketEvent: 'player:disconnect_stall',
+    owner: 'connection.presence',
+    registrar: 'multiplayer/useRoomSocketSync.ts',
+    boundedContext: 'connection',
+    registrationKind: 'raw',
+    enforced: true,
+    description: 'Disconnect auto-act deferred/paused when live-session durability cannot commit',
+  },
+  {
     socketEvent: 'room:match_abandoned',
     owner: 'tournament.session.abandoned',
     registrar: 'tournament/registerTournamentSocketHandlers.ts',
@@ -570,6 +579,7 @@ export const SOCKET_EVENTS = {
   PLAYER_DISCONNECTED: 'player:disconnected',
   PLAYER_RECONNECTED: 'player:reconnected',
   PLAYER_RECONNECT_TIMEOUT: 'player:reconnect_timeout',
+  PLAYER_DISCONNECT_STALL: 'player:disconnect_stall',
   ROOM_MATCH_ABANDONED: 'room:match_abandoned',
 } as const;
 

--- a/client/src/multiplayer/useRoomSocketSync.ts
+++ b/client/src/multiplayer/useRoomSocketSync.ts
@@ -647,6 +647,24 @@ export function useRoomSocketSync(inputParams: UseRoomSocketSyncParams) {
       scope.ui.showToast('Opponent forfeited.', 3000);
     });
 
+    const onPlayerDisconnectStall = wrapSocketHandler(
+      'player:disconnect_stall',
+      (payload: { playerId?: string; phase?: 'retry' | 'paused'; message?: string }) => {
+        if (!payload?.playerId || payload.playerId === scope.dom.youRef.current) return;
+        scope.ui.setOpponentDisconnected(true);
+        const message =
+          typeof payload.message === 'string' && payload.message.trim().length > 0
+            ? payload.message
+            : payload.phase === 'paused'
+              ? "We're having technical issues saving this match. The game is paused — hang tight."
+              : "Opponent still disconnected. Auto-move couldn't be saved — waiting for server recovery…";
+        scope.ui.setOpponentDisconnectMessage(message);
+        if (payload.phase === 'paused') {
+          scope.ui.showToast(message, 4500);
+        }
+      },
+    );
+
     const unregisterNormalized = registerNormalizedSocketRouter({
       stateUpdate: handleStateUpdate,
     });
@@ -663,6 +681,7 @@ export function useRoomSocketSync(inputParams: UseRoomSocketSyncParams) {
       registerRawSocketEventHandler(SOCKET_EVENTS.PLAYER_DISCONNECTED, asRawHandler(onPlayerDisconnected)),
       registerRawSocketEventHandler(SOCKET_EVENTS.PLAYER_RECONNECTED, asRawHandler(onPlayerReconnected)),
       registerRawSocketEventHandler(SOCKET_EVENTS.PLAYER_RECONNECT_TIMEOUT, asRawHandler(onPlayerReconnectTimeout)),
+      registerRawSocketEventHandler(SOCKET_EVENTS.PLAYER_DISCONNECT_STALL, asRawHandler(onPlayerDisconnectStall)),
     ];
 
     return () => {

--- a/server/src/multiplayer/disconnectGrace.test.ts
+++ b/server/src/multiplayer/disconnectGrace.test.ts
@@ -3,10 +3,16 @@ import type { GameState } from '../game/types';
 import * as engine from '../game/engine';
 import * as rooms from '../rooms';
 import { createReservedRoom, joinRoom, resetRoomRuntimeForTests } from '../rooms';
+import { createHydratedRoomDurabilityState, captureRoomDurabilityFence } from './roomDurability';
+import * as livePersistence from './roomLivePersistence';
 import { initRoomSession, resetRoomSessionStoresForTests, clearRoomMetadata } from './roomSession';
 import {
   configureDisconnectGraceSeatResolver,
+  DISCONNECT_DURABILITY_MAX_RETRIES,
+  DISCONNECT_DURABILITY_RETRY_MS,
   DISCONNECT_GRACE_MS,
+  DISCONNECT_STALL_PAUSED_MESSAGE,
+  DISCONNECT_STALL_RETRY_MESSAGE,
   getActiveDisconnectGracePlayerId,
   hasActiveDisconnectGrace,
   hasActiveDisconnectGraceForSeat,
@@ -54,6 +60,7 @@ function seedLiveRoom(roomCode: string, currentPlayerIndex: number) {
   room.players = ['seat-a', 'seat-b'];
   room.state = mkGameState(currentPlayerIndex);
   room.disconnectExpiries = {};
+  room.durability = createHydratedRoomDurabilityState(room, captureRoomDurabilityFence(room));
   return room;
 }
 
@@ -82,17 +89,31 @@ describe('disconnectGrace', () => {
   let actSpy: ReturnType<typeof vi.spyOn>;
   let getLegalMovesSpy: ReturnType<typeof vi.spyOn>;
   let canDrawSpy: ReturnType<typeof vi.spyOn>;
+  let flushSpy: ReturnType<typeof vi.spyOn>;
+  let recoverableSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
     vi.useFakeTimers();
     resetRoomRuntimeForTests();
     resetDisconnectGraceForTests();
-    actSpy = vi.spyOn(rooms, 'act').mockResolvedValue({
-      room: {} as any,
-      forcedDrawAnimation: undefined,
+    resetRoomSessionStoresForTests();
+    rooms.resetLiveRoomPersistHookForTests();
+    actSpy = vi.spyOn(rooms, 'act').mockImplementation(async (code) => {
+      const room = rooms.getRoom(code);
+      if (room.state) {
+        room.state = { ...room.state, sequence: room.state.sequence + 1 };
+      }
+      return {
+        room,
+        forcedDrawAnimation: undefined,
+      };
     });
     getLegalMovesSpy = vi.spyOn(engine, 'getLegalMoves').mockReturnValue([{ type: 'pass' } as any]);
     canDrawSpy = vi.spyOn(engine, 'canDraw').mockReturnValue(false);
+    flushSpy = vi.spyOn(livePersistence, 'flushScheduledLiveRoomPersistence').mockResolvedValue({
+      flushedRoomCodes: ['TEST'],
+    } as any);
+    recoverableSpy = vi.spyOn(livePersistence, 'isLiveRoomDurablyRecoverable').mockReturnValue(true);
     configureDisconnectGraceSeatResolver(() => null);
   });
 
@@ -144,6 +165,8 @@ describe('disconnectGrace', () => {
       io,
       broadcast,
     );
+    expect(flushSpy).toHaveBeenCalled();
+    expect(broadcast).toHaveBeenCalledWith('GRACE3');
     expect(hasActiveDisconnectGrace('GRACE3')).toBe(false);
   });
 
@@ -241,22 +264,17 @@ describe('disconnectGrace', () => {
     const { io, roomEmit } = makeIo(false);
     initRoomSession(io, sessionDeps);
 
-    // 1. Current player disconnects
     onActivePlayerSocketDisconnect(roomCode, 'seat-a', io, vi.fn());
     expect(hasActiveDisconnectGrace(roomCode)).toBe(true);
 
-    // 2. First timer expires, auto-pass/draw behavior occurs
     await vi.advanceTimersByTimeAsync(DISCONNECT_GRACE_MS);
     expect(actSpy).toHaveBeenCalledTimes(1);
     expect(room.disconnectExpiries?.['seat-a']).toBe(1);
     expect(hasActiveDisconnectGrace(roomCode)).toBe(false);
 
-    // 3. Player remains disconnected, and it becomes their turn again
-    // We simulate another disconnect event for the active player
     onActivePlayerSocketDisconnect(roomCode, 'seat-a', io, vi.fn());
     expect(hasActiveDisconnectGrace(roomCode)).toBe(true);
 
-    // 4. Second timer expires, forfeit path executes
     await vi.advanceTimersByTimeAsync(DISCONNECT_GRACE_MS);
     await vi.waitFor(() => {
       expect(room.disconnectExpiries?.['seat-a']).toBe(2);
@@ -265,6 +283,7 @@ describe('disconnectGrace', () => {
     }, { timeout: 1000, interval: 20 });
 
     resetRoomSessionStoresForTests();
+    rooms.resetLiveRoomPersistHookForTests();
   });
 
   it('handles reconnect after first expiry but before room cleanup', async () => {
@@ -273,13 +292,10 @@ describe('disconnectGrace', () => {
 
     const { io } = makeIo(false);
 
-    // Disconnect
     onActivePlayerSocketDisconnect(roomCode, 'seat-a', io, vi.fn());
-    // Advance to expire first timer
     await vi.advanceTimersByTimeAsync(DISCONNECT_GRACE_MS);
     expect(room.disconnectExpiries?.['seat-a']).toBe(1);
 
-    // Reconnect
     onPlayerSocketRejoined(roomCode, io, 'seat-a');
     expect(room.disconnectExpiries?.['seat-a']).toBe(0);
     expect(hasActiveDisconnectGrace(roomCode)).toBe(false);
@@ -296,5 +312,81 @@ describe('disconnectGrace', () => {
     clearRoomMetadata(roomCode);
 
     expect(hasActiveDisconnectGrace(roomCode)).toBe(false);
+  });
+
+  it('rolls back auto-act and emits stall retry when flush is not durably recoverable', async () => {
+    const room = seedLiveRoom('GRACE_FLUSH_FAIL', 0);
+    const sequenceBefore = room.state!.sequence;
+    const broadcast = vi.fn();
+    const rollbackSpy = vi.spyOn(rooms, 'rollbackRoomGameplayCommit');
+    recoverableSpy.mockReturnValue(false);
+    const { io, roomEmit } = makeIo(false);
+
+    onActivePlayerSocketDisconnect('GRACE_FLUSH_FAIL', 'seat-a', io, broadcast);
+    await vi.advanceTimersByTimeAsync(DISCONNECT_GRACE_MS);
+
+    expect(actSpy).toHaveBeenCalledTimes(1);
+    expect(rollbackSpy).toHaveBeenCalled();
+    expect(broadcast).not.toHaveBeenCalled();
+    expect(room.disconnectExpiries?.['seat-a'] ?? 0).toBe(0);
+    expect(roomEmit).toHaveBeenCalledWith('player:disconnect_stall', {
+      playerId: 'seat-a',
+      phase: 'retry',
+      message: DISCONNECT_STALL_RETRY_MESSAGE,
+    });
+    expect(hasActiveDisconnectGrace('GRACE_FLUSH_FAIL')).toBe(true);
+    expect(room.state!.sequence).toBe(sequenceBefore);
+  });
+
+  it('skips act and emits stall when durability already blocks gameplay', async () => {
+    const room = seedLiveRoom('GRACE_PRE_FAIL', 0);
+    room.durability = {
+      ...room.durability,
+      status: 'failed',
+    };
+    const broadcast = vi.fn();
+    const { io, roomEmit } = makeIo(false);
+
+    onActivePlayerSocketDisconnect('GRACE_PRE_FAIL', 'seat-a', io, broadcast);
+    await vi.advanceTimersByTimeAsync(DISCONNECT_GRACE_MS);
+
+    expect(actSpy).not.toHaveBeenCalled();
+    expect(broadcast).not.toHaveBeenCalled();
+    expect(roomEmit).toHaveBeenCalledWith('player:disconnect_stall', {
+      playerId: 'seat-a',
+      phase: 'retry',
+      message: DISCONNECT_STALL_RETRY_MESSAGE,
+    });
+    expect(hasActiveDisconnectGrace('GRACE_PRE_FAIL')).toBe(true);
+  });
+
+  it('pauses after durability retry ceiling with no further timers or forfeit', async () => {
+    const room = seedLiveRoom('GRACE_CEILING', 0);
+    room.durability = {
+      ...room.durability,
+      status: 'failed',
+    };
+    const broadcast = vi.fn();
+    const { io, roomEmit } = makeIo(false);
+
+    onActivePlayerSocketDisconnect('GRACE_CEILING', 'seat-a', io, broadcast);
+    await vi.advanceTimersByTimeAsync(DISCONNECT_GRACE_MS);
+
+    for (let i = 0; i < DISCONNECT_DURABILITY_MAX_RETRIES; i += 1) {
+      await vi.advanceTimersByTimeAsync(DISCONNECT_DURABILITY_RETRY_MS);
+    }
+
+    expect(actSpy).not.toHaveBeenCalled();
+    expect(room.abandonedAt).toBeUndefined();
+    expect(room.disconnectExpiries?.['seat-a'] ?? 0).toBe(0);
+    expect(roomEmit).toHaveBeenCalledWith('player:disconnect_stall', {
+      playerId: 'seat-a',
+      phase: 'paused',
+      message: DISCONNECT_STALL_PAUSED_MESSAGE,
+    });
+    expect(hasActiveDisconnectGrace('GRACE_CEILING')).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(DISCONNECT_DURABILITY_RETRY_MS * 3);
+    expect(actSpy).not.toHaveBeenCalled();
   });
 });

--- a/server/src/multiplayer/disconnectGrace.test.ts
+++ b/server/src/multiplayer/disconnectGrace.test.ts
@@ -338,6 +338,62 @@ describe('disconnectGrace', () => {
     expect(room.state!.sequence).toBe(sequenceBefore);
   });
 
+  it('recovers mid-retry: flush fails once then succeeds — commits once, no forfeit from failed attempt', async () => {
+    const room = seedLiveRoom('GRACE_RECOVER', 0);
+    const sequenceBefore = room.state!.sequence;
+    const broadcast = vi.fn();
+    const rollbackSpy = vi.spyOn(rooms, 'rollbackRoomGameplayCommit');
+    recoverableSpy.mockReturnValueOnce(false).mockReturnValue(true);
+    const { io, roomEmit } = makeIo(false);
+
+    onActivePlayerSocketDisconnect('GRACE_RECOVER', 'seat-a', io, broadcast);
+    await vi.advanceTimersByTimeAsync(DISCONNECT_GRACE_MS);
+
+    // First expiry: act attempted, flush not durable → rollback + stall retry.
+    expect(actSpy).toHaveBeenCalledTimes(1);
+    expect(rollbackSpy).toHaveBeenCalledTimes(1);
+    expect(broadcast).not.toHaveBeenCalled();
+    expect(room.disconnectExpiries?.['seat-a'] ?? 0).toBe(0);
+    expect(room.state!.sequence).toBe(sequenceBefore);
+    expect(roomEmit).toHaveBeenCalledWith('player:disconnect_stall', {
+      playerId: 'seat-a',
+      phase: 'retry',
+      message: DISCONNECT_STALL_RETRY_MESSAGE,
+    });
+    expect(hasActiveDisconnectGrace('GRACE_RECOVER')).toBe(true);
+
+    roomEmit.mockClear();
+    await vi.advanceTimersByTimeAsync(DISCONNECT_DURABILITY_RETRY_MS);
+
+    // Second attempt (within retry window): durability recovered → commit + broadcast.
+    expect(actSpy).toHaveBeenCalledTimes(2);
+    expect(rollbackSpy).toHaveBeenCalledTimes(1);
+    expect(flushSpy).toHaveBeenCalledTimes(2);
+    expect(broadcast).toHaveBeenCalledWith('GRACE_RECOVER');
+    expect(room.disconnectExpiries?.['seat-a']).toBe(1);
+    expect(room.abandonedAt).toBeUndefined();
+    expect(hasActiveDisconnectGrace('GRACE_RECOVER')).toBe(false);
+
+    // Stall UI path ends: no further retry/paused stall; normal timeout + board update path.
+    expect(roomEmit).not.toHaveBeenCalledWith(
+      'player:disconnect_stall',
+      expect.objectContaining({ phase: 'retry' }),
+    );
+    expect(roomEmit).not.toHaveBeenCalledWith(
+      'player:disconnect_stall',
+      expect.objectContaining({ phase: 'paused' }),
+    );
+    expect(roomEmit).not.toHaveBeenCalledWith(
+      'player:disconnect_stall',
+      expect.objectContaining({ message: DISCONNECT_STALL_RETRY_MESSAGE }),
+    );
+    expect(roomEmit).not.toHaveBeenCalledWith(
+      'player:disconnect_stall',
+      expect.objectContaining({ message: DISCONNECT_STALL_PAUSED_MESSAGE }),
+    );
+    expect(roomEmit).toHaveBeenCalledWith('player:reconnect_timeout', { playerId: 'seat-a' });
+  });
+
   it('skips act and emits stall when durability already blocks gameplay', async () => {
     const room = seedLiveRoom('GRACE_PRE_FAIL', 0);
     room.durability = {

--- a/server/src/multiplayer/disconnectGrace.ts
+++ b/server/src/multiplayer/disconnectGrace.ts
@@ -1,16 +1,42 @@
 import type { Server, Socket } from 'socket.io';
-import { act, getRoom } from '../rooms';
+import {
+  act,
+  captureRoomGameplaySnapshot,
+  getRoom,
+  rollbackRoomGameplayCommit,
+  type RoomGameplaySnapshot,
+} from '../rooms';
 import { canDraw, getLegalMoves } from '../game/engine';
 import { childLogger } from '../logger';
 import type { RoomPlayer } from './roomSession';
+import { evaluateRoomDurabilityOperation } from './roomDurabilityPolicy';
+import {
+  flushScheduledLiveRoomPersistence,
+  getLiveRoomDurabilityState,
+  isLiveRoomDurablyRecoverable,
+} from './roomLivePersistence';
+import { emitMpAuthorityFunnel } from './mpAuthorityTelemetry';
 
 const log = childLogger('disconnect-grace');
 
 export const DISCONNECT_GRACE_MS = 30_000;
+/** Retry spacing after a durability-blocked or flush-failed auto-act. */
+export const DISCONNECT_DURABILITY_RETRY_MS = 10_000;
+/** Max durability retries after the initial grace expiry (6 × 10s = 60s). Then pause. */
+export const DISCONNECT_DURABILITY_MAX_RETRIES = 6;
+
+/** Seat B banner while durability retries are still scheduled (Path 1 and Path 2). */
+export const DISCONNECT_STALL_RETRY_MESSAGE =
+  "Opponent still disconnected. Auto-move couldn't be saved — waiting for server recovery…";
+
+/** Seat B banner after retry ceiling — match paused, no forfeit, no more auto-act timers. */
+export const DISCONNECT_STALL_PAUSED_MESSAGE =
+  "We're having technical issues saving this match. The game is paused — hang tight.";
 
 type GraceEntry = {
   timer: ReturnType<typeof setTimeout>;
   playerId: string;
+  durabilityRetryCount: number;
 };
 
 const graceTimersByRoomSeat = new Map<string, GraceEntry>();
@@ -88,6 +114,112 @@ export function resetDisconnectGraceForTests(): void {
   resolveSeatSocket = () => null;
 }
 
+function emitDisconnectStall(
+  io: Server,
+  roomCode: string,
+  playerSeatId: string,
+  phase: 'retry' | 'paused',
+  message: string,
+): void {
+  io.to(roomCode).emit('player:disconnect_stall', {
+    playerId: playerSeatId,
+    phase,
+    message,
+  });
+}
+
+function scheduleDisconnectGraceTimer(
+  roomCode: string,
+  playerSeatId: string,
+  io: Server,
+  broadcast: (roomCode: string) => void,
+  delayMs: number,
+  durabilityRetryCount: number,
+): void {
+  const code = normalizeRoomCode(roomCode);
+  clearDisconnectGraceForSeat(code, playerSeatId);
+  const timer = setTimeout(() => {
+    void handleDisconnectGraceExpired(code, playerSeatId, io, broadcast, durabilityRetryCount);
+  }, delayMs);
+  graceTimersByRoomSeat.set(graceKey(code, playerSeatId), {
+    timer,
+    playerId: playerSeatId,
+    durabilityRetryCount,
+  });
+}
+
+function handleDurabilityStall(
+  roomCode: string,
+  disconnectedPlayerSeatId: string,
+  io: Server,
+  broadcast: (roomCode: string) => void,
+  durabilityRetryCount: number,
+  failureCode: 'room_persistence_failed' | 'room_degraded' | 'room_failed',
+  extra?: Record<string, unknown>,
+): void {
+  const nextRetry = durabilityRetryCount + 1;
+  if (nextRetry > DISCONNECT_DURABILITY_MAX_RETRIES) {
+    emitMpAuthorityFunnel('private_disconnect_auto_act_paused', {
+      roomCode,
+      seatId: disconnectedPlayerSeatId,
+      failureCode,
+      extra: {
+        durabilityRetryCount,
+        ...extra,
+      },
+    });
+    emitDisconnectStall(
+      io,
+      roomCode,
+      disconnectedPlayerSeatId,
+      'paused',
+      DISCONNECT_STALL_PAUSED_MESSAGE,
+    );
+    log.warn(
+      { roomCode, disconnectedPlayerSeatId, durabilityRetryCount, failureCode, ...extra },
+      'disconnect auto-act paused after durability retry ceiling',
+    );
+    return;
+  }
+
+  emitMpAuthorityFunnel('private_disconnect_auto_act_deferred', {
+    roomCode,
+    seatId: disconnectedPlayerSeatId,
+    failureCode,
+    extra: {
+      durabilityRetryCount: nextRetry,
+      maxRetries: DISCONNECT_DURABILITY_MAX_RETRIES,
+      retryMs: DISCONNECT_DURABILITY_RETRY_MS,
+      ...extra,
+    },
+  });
+  emitDisconnectStall(
+    io,
+    roomCode,
+    disconnectedPlayerSeatId,
+    'retry',
+    DISCONNECT_STALL_RETRY_MESSAGE,
+  );
+  scheduleDisconnectGraceTimer(
+    roomCode,
+    disconnectedPlayerSeatId,
+    io,
+    broadcast,
+    DISCONNECT_DURABILITY_RETRY_MS,
+    nextRetry,
+  );
+  log.warn(
+    {
+      roomCode,
+      disconnectedPlayerSeatId,
+      durabilityRetryCount: nextRetry,
+      failureCode,
+      ...extra,
+    },
+    'disconnect auto-act deferred; scheduled durability retry',
+  );
+}
+
 export function onActivePlayerSocketDisconnect(
   roomCode: string,
   playerSeatId: string,
@@ -103,18 +235,12 @@ export function onActivePlayerSocketDisconnect(
   if (!room.state || room.state.gameOver || room.state.handOver) return;
   if (!room.players.includes(playerSeatId)) return;
 
-  clearDisconnectGraceForSeat(roomCode, playerSeatId);
-
   io.to(roomCode).emit('player:disconnected', {
     playerId: playerSeatId,
     graceMs: DISCONNECT_GRACE_MS,
   });
 
-  const timer = setTimeout(() => {
-    void handleDisconnectGraceExpired(roomCode, playerSeatId, io, broadcast);
-  }, DISCONNECT_GRACE_MS);
-
-  graceTimersByRoomSeat.set(graceKey(roomCode, playerSeatId), { timer, playerId: playerSeatId });
+  scheduleDisconnectGraceTimer(roomCode, playerSeatId, io, broadcast, DISCONNECT_GRACE_MS, 0);
 }
 
 export function onPlayerSocketRejoined(roomCode: string, io: Server, playerSeatId: string): void {
@@ -135,6 +261,7 @@ async function handleDisconnectGraceExpired(
   disconnectedPlayerSeatId: string,
   io: Server,
   broadcast: (roomCode: string) => void,
+  durabilityRetryCount: number,
 ): Promise<void> {
   const code = normalizeRoomCode(roomCode);
   graceTimersByRoomSeat.delete(graceKey(code, disconnectedPlayerSeatId));
@@ -151,16 +278,62 @@ async function handleDisconnectGraceExpired(
       : false;
     if (stillConnected) return;
 
+    const durabilityDecision = evaluateRoomDurabilityOperation(room, 'gameplay_action');
+    if (!durabilityDecision.allowed) {
+      handleDurabilityStall(
+        code,
+        disconnectedPlayerSeatId,
+        io,
+        broadcast,
+        durabilityRetryCount,
+        durabilityDecision.error === 'room_degraded' ? 'room_degraded' : 'room_persistence_failed',
+        { phase: 'pre_act', reason: durabilityDecision.reason },
+      );
+      return;
+    }
+
     const legalMoves = getLegalMoves(room.state, disconnectedPlayerSeatId);
     const canPass = legalMoves.some((move) => move.type === 'pass');
     const canDrawNow = canDraw(room.state, disconnectedPlayerSeatId);
+
+    const snapshot: RoomGameplaySnapshot | null = captureRoomGameplaySnapshot(room);
+    if (!snapshot) return;
 
     if (canPass) {
       await act(code, disconnectedPlayerSeatId, { type: 'PASS' }, io, broadcast);
     } else if (canDrawNow) {
       await act(code, disconnectedPlayerSeatId, { type: 'DRAW' }, io, broadcast);
     } else {
-      log.warn({ roomCode: code, disconnectedPlayerSeatId, legalMoveTypes: legalMoves.map((m) => m.type) }, 'no legal auto-action for disconnected turn');
+      log.warn(
+        {
+          roomCode: code,
+          disconnectedPlayerSeatId,
+          legalMoveTypes: legalMoves.map((m) => m.type),
+        },
+        'no legal auto-action for disconnected turn',
+      );
+      return;
+    }
+
+    await flushScheduledLiveRoomPersistence(code);
+    const durability = getLiveRoomDurabilityState(room);
+    const committed = isLiveRoomDurablyRecoverable(room);
+    if (!committed) {
+      rollbackRoomGameplayCommit(room, snapshot);
+      handleDurabilityStall(
+        code,
+        disconnectedPlayerSeatId,
+        io,
+        broadcast,
+        durabilityRetryCount,
+        durability.status === 'degraded' ? 'room_degraded' : 'room_persistence_failed',
+        {
+          phase: 'post_flush',
+          durabilityStatus: durability.status,
+          sequence: room.state?.sequence ?? null,
+        },
+      );
+      return;
     }
 
     if (!room.disconnectExpiries) {
@@ -200,5 +373,24 @@ async function handleDisconnectGraceExpired(
     broadcast(code);
   } catch (error) {
     log.error({ err: error, roomCode: code, disconnectedPlayerSeatId }, 'grace expiry failed');
+    try {
+      handleDurabilityStall(
+        code,
+        disconnectedPlayerSeatId,
+        io,
+        broadcast,
+        durabilityRetryCount,
+        'room_persistence_failed',
+        {
+          phase: 'exception',
+          error: error instanceof Error ? error.message : String(error),
+        },
+      );
+    } catch (stallError) {
+      log.error(
+        { err: stallError, roomCode: code, disconnectedPlayerSeatId },
+        'disconnect stall emit failed after grace expiry error',
+      );
+    }
   }
 }

--- a/server/src/multiplayer/mpAuthorityTelemetry.ts
+++ b/server/src/multiplayer/mpAuthorityTelemetry.ts
@@ -22,7 +22,9 @@ export type MpAuthorityFunnelEvent =
   | 'private_durability_degraded'
   | 'private_durability_failed'
   | 'private_move_log_verification_failed'
-  | 'private_terminal_recovery';
+  | 'private_terminal_recovery'
+  | 'private_disconnect_auto_act_deferred'
+  | 'private_disconnect_auto_act_paused';
 
 export type MpAuthorityFailureCode =
   | 'missing_request_id'

--- a/server/src/rooms.ts
+++ b/server/src/rooms.ts
@@ -131,6 +131,17 @@ export type ActResult = {
   };
 };
 
+/** In-memory gameplay fields restored after a failed durable commit (disconnect auto-act). */
+export type RoomGameplaySnapshot = {
+  state: GameState;
+  ghostMoveLogs: Record<string, GhostMoveLogEntry[]>;
+  ghostTurnIndex: number;
+  eventSequence: number;
+  events: RoomMatchEvent[];
+  pendingAutoPassNotice?: string[];
+  pendingForcedDrawBroadcast?: { playerId: string; count: number };
+};
+
 const rooms = new Map<RoomCode, Room>();
 const nextHandStartsByRoom = new Map<RoomCode, Promise<Room>>();
 
@@ -148,6 +159,39 @@ export function resetLiveRoomPersistHookForTests(): void {
 
 function notifyLiveRoomStateCommitted(room: Room): void {
   liveRoomPersistHook?.(room);
+}
+
+export function captureRoomGameplaySnapshot(room: Room): RoomGameplaySnapshot | null {
+  if (!room.state) return null;
+  return {
+    state: structuredClone(room.state) as GameState,
+    ghostMoveLogs: structuredClone(room.ghostMoveLogs),
+    ghostTurnIndex: room.ghostTurnIndex,
+    eventSequence: room.eventSequence,
+    events: structuredClone(room.events),
+    pendingAutoPassNotice: room.pendingAutoPassNotice
+      ? [...room.pendingAutoPassNotice]
+      : undefined,
+    pendingForcedDrawBroadcast: room.pendingForcedDrawBroadcast
+      ? { ...room.pendingForcedDrawBroadcast }
+      : undefined,
+  };
+}
+
+/** Restore pre-act memory and re-notify the live-session persist hook with the rolled-back room. */
+export function rollbackRoomGameplayCommit(room: Room, snapshot: RoomGameplaySnapshot): void {
+  room.state = structuredClone(snapshot.state) as GameState;
+  room.ghostMoveLogs = structuredClone(snapshot.ghostMoveLogs);
+  room.ghostTurnIndex = snapshot.ghostTurnIndex;
+  room.eventSequence = snapshot.eventSequence;
+  room.events = structuredClone(snapshot.events);
+  room.pendingAutoPassNotice = snapshot.pendingAutoPassNotice
+    ? [...snapshot.pendingAutoPassNotice]
+    : undefined;
+  room.pendingForcedDrawBroadcast = snapshot.pendingForcedDrawBroadcast
+    ? { ...snapshot.pendingForcedDrawBroadcast }
+    : undefined;
+  notifyLiveRoomStateCommitted(room);
 }
 
 async function flushCommittedRoomStateOrThrow(room: Room): Promise<void> {


### PR DESCRIPTION
## Summary
- Disconnect-grace auto PASS/DRAW now uses the same flush + `isLiveRoomDurablyRecoverable` gate as `game:action`.
- On flush failure: **narrow rollback** of the auto-act (no skip-broadcast-with-dirty-memory), no forfeit counter bump, no board broadcast.
- Seat B always gets an explicit `player:disconnect_stall` message (never a frozen “Waiting up to 30s…” with silence).
- Durability retries are **bounded**: 6 × 10s after the initial 30s grace, then a clean technical pause (no infinite retry, no unfair forfeit).

### Seat B copy (literal)
| Phase | Message |
|---|---|
| Path 1 / Path 2 retry | `Opponent still disconnected. Auto-move couldn't be saved — waiting for server recovery…` |
| Retry ceiling (paused) | `We're having technical issues saving this match. The game is paused — hang tight.` |

### Retry ceiling
- Initial grace: 30s
- Then up to **6** retries at **10s** (60s)
- After that: emit `phase: 'paused'`, clear timers, **do not forfeit**. Match stays paused until opponent reconnects or someone abandons.

## Test plan
- [x] `npx vitest run src/multiplayer/disconnectGrace.test.ts` (server) — 13 passed
- [x] Socket event registry validation
- [ ] Preview: disconnect on your turn → opponent sees 30s wait → (healthy) auto-pass advances board
- [ ] Preview / forced durability fail: Seat B banner updates to retry copy (not frozen); board does not advance; no forfeit
- [ ] After 6 durability retries: paused copy + toast; no further auto-acts


Made with [Cursor](https://cursor.com)