### PR TITLE
fix(mp): roll back game:action when flush is not durable (PR-MP-C)

### DIFF
--- a/client/src/match/session/actions/useDrawAction.ts
+++ b/client/src/match/session/actions/useDrawAction.ts
@@ -120,7 +120,10 @@ export function useDrawAction(params: UseDrawActionParams): () => Promise<void> 
       });
       if (!resp?.ok) {
         if (resp?.uncertain) {
-          markUncertainAndResync(requestId, resp.error ?? 'Move uncertain — resyncing.');
+          markUncertainAndResync(
+            requestId,
+            resp.error ?? "Move couldn't be saved — try again.",
+          );
         } else {
           setActionError(resp?.error ?? 'Unable to draw.');
         }

--- a/client/src/match/session/actions/useLiveMatchActions.test.ts
+++ b/client/src/match/session/actions/useLiveMatchActions.test.ts
@@ -216,7 +216,7 @@ describe('useLiveMatchActions - isGameplayActionBlocked is cosmetic/unblocked on
     vi.mocked(emitGameAction).mockResolvedValueOnce({
       ok: false,
       uncertain: true,
-      error: 'room_persistence_failed',
+      error: "Move couldn't be saved — try again.",
       sequence: 17,
     });
 
@@ -228,6 +228,6 @@ describe('useLiveMatchActions - isGameplayActionBlocked is cosmetic/unblocked on
 
     expect(logicalGameplayActionRef.current?.uncertain).toBe(true);
     expect(fetchGameState).toHaveBeenCalledWith('game_action_uncertain');
-    expect(params.showToast).toHaveBeenCalled();
+    expect(params.showToast).toHaveBeenCalledWith("Move couldn't be saved — try again.", 2500);
   });
 });

--- a/client/src/match/session/actions/usePassAction.ts
+++ b/client/src/match/session/actions/usePassAction.ts
@@ -91,7 +91,10 @@ export function usePassAction(params: UsePassActionParams): () => Promise<void> 
       mpPerfMarkAck(Boolean(resp?.ok), resp?.sequence);
       if (!resp?.ok) {
         if (resp?.uncertain) {
-          markUncertainAndResync(requestId, resp.error ?? 'Pass uncertain — resyncing.');
+          markUncertainAndResync(
+            requestId,
+            resp.error ?? "Move couldn't be saved — try again.",
+          );
         } else {
           setActionError(resp?.error ?? 'Unable to pass.');
         }

--- a/client/src/match/session/actions/usePlayAction.ts
+++ b/client/src/match/session/actions/usePlayAction.ts
@@ -183,7 +183,10 @@ export function usePlayAction(
         mpPerfMarkAck(Boolean(resp?.ok), resp?.sequence);
         if (!resp?.ok) {
           if (resp?.uncertain) {
-            markUncertainAndResync(requestId, resp.error ?? 'Play uncertain — resyncing.');
+            markUncertainAndResync(
+              requestId,
+              resp.error ?? "Move couldn't be saved — try again.",
+            );
           } else {
             setActionError(resp?.error ?? 'Unable to play tile.');
           }

--- a/server/src/multiplayer/gameActionIdempotency.test.ts
+++ b/server/src/multiplayer/gameActionIdempotency.test.ts
@@ -89,10 +89,12 @@ describe('gameActionIdempotency', () => {
     expect(execute).toHaveBeenCalledTimes(2);
   });
 
-  it('caches uncertain actions and replays the same logical request without re-executing', async () => {
+  it('does not cache uncertain acks so same requestId can re-execute after rollback', async () => {
+    // After mutate-then-persist rollback, uncertain means nothing stuck —
+    // caching would trap actor retries (client reuses requestId while uncertain).
     const execute = vi.fn(async () => ({
       ok: false,
-      error: 'room_persistence_failed',
+      error: "Move couldn't be saved — try again.",
       uncertain: true,
       sequence: 11,
     }));
@@ -102,18 +104,21 @@ describe('gameActionIdempotency', () => {
 
     expect(first).toEqual({
       ok: false,
-      error: 'room_persistence_failed',
+      error: "Move couldn't be saved — try again.",
       uncertain: true,
       sequence: 11,
     });
     expect(second).toEqual({
       ok: false,
-      error: 'room_persistence_failed',
+      error: "Move couldn't be saved — try again.",
       uncertain: true,
       sequence: 11,
-      duplicate: true,
     });
-    expect(execute).toHaveBeenCalledTimes(1);
+    expect(execute).toHaveBeenCalledTimes(2);
+    expect(persistRoomCommandReceipt).not.toHaveBeenCalledWith(
+      expect.objectContaining({ requestId: 'uncertain-req' }),
+    );
+    expect(getGameActionIdempotencyCacheSize('room1')).toBe(0);
   });
 
   it('clears cache entries after TTL and on room cleanup', async () => {

--- a/server/src/multiplayer/gameActionIdempotency.ts
+++ b/server/src/multiplayer/gameActionIdempotency.ts
@@ -106,7 +106,9 @@ function storeCachedAck(
   requestId: string,
   ack: GameActionAck,
 ): void {
-  if (!ack.ok && !ack.uncertain) return;
+  // Only durable successes are replay-blocked. Uncertain means rollback —
+  // the actor must be able to re-execute the same requestId on retry.
+  if (!ack.ok) return;
   const roomCache = getRoomCache(roomCode);
   roomCache.set(cacheKeyFor(playerSeatId, requestId), {
     ack: {
@@ -114,7 +116,6 @@ function storeCachedAck(
       sequence: ack.sequence ?? null,
       ...(ack.forcedDraw ? { forcedDraw: ack.forcedDraw } : {}),
       ...(ack.error ? { error: ack.error } : {}),
-      ...(ack.uncertain ? { uncertain: ack.uncertain } : {}),
     },
     expiresAt: Date.now() + ACTION_IDEMPOTENCY_TTL_MS,
   });
@@ -179,7 +180,8 @@ export function hydrateGameActionReceiptsForRoom(
     if (!entry.ack || typeof entry.ack !== 'object') continue;
     const ack = entry.ack as GameActionAck;
     if (typeof ack.ok !== 'boolean') continue;
-    if (!ack.ok && !ack.uncertain) continue;
+    // Skip legacy uncertain receipts — they must not block post-rollback retries.
+    if (!ack.ok) continue;
 
     const key = cacheKeyFor(entry.playerSeatId, entry.requestId);
     const existing = roomCache.get(key);
@@ -191,7 +193,6 @@ export function hydrateGameActionReceiptsForRoom(
         sequence: typeof ack.sequence === 'number' ? ack.sequence : null,
         ...(ack.forcedDraw ? { forcedDraw: ack.forcedDraw } : {}),
         ...(typeof ack.error === 'string' ? { error: ack.error } : {}),
-        ...(ack.uncertain ? { uncertain: true } : {}),
       },
       expiresAt: entry.expiresAt,
     });
@@ -203,7 +204,8 @@ export function hydrateGameActionReceiptsForRoom(
 
 /**
  * Server-authoritative idempotency for retried `game:action` submissions.
- * Successful and uncertain mutations are cached; plain failures are not replay-blocked.
+ * Only durable successes are cached/persisted. Uncertain (rolled-back) and
+ * plain failures are not replay-blocked so the actor can retry.
  */
 export async function withGameActionIdempotency(
   roomCode: string,
@@ -228,7 +230,7 @@ export async function withGameActionIdempotency(
 
   const inflight = (async () => {
     const result = await execute();
-    if (result.ok || result.uncertain) {
+    if (result.ok) {
       storeCachedAck(roomCode, playerSeatId, normalizedRequestId, result);
       const expiresAtMs = Date.now() + ACTION_IDEMPOTENCY_TTL_MS;
       void persistRoomCommandReceipt({
@@ -236,11 +238,10 @@ export async function withGameActionIdempotency(
         playerSeatId,
         requestId: normalizedRequestId,
         ack: {
-          ok: result.ok,
+          ok: true,
           sequence: result.sequence ?? null,
           ...(result.forcedDraw ? { forcedDraw: result.forcedDraw } : {}),
           ...(result.error ? { error: result.error } : {}),
-          ...(result.uncertain ? { uncertain: result.uncertain } : {}),
         },
         expiresAtMs,
       });

--- a/server/src/multiplayer/gameActionPersistRollback.integration.test.ts
+++ b/server/src/multiplayer/gameActionPersistRollback.integration.test.ts
@@ -1,0 +1,472 @@
+/**
+ * Two-client integration: live private match with real room-session handlers.
+ * Drives PR-MP-C mutate-then-persist rollback through flush-failure injection.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  getRoom,
+  getRoomCanDraw,
+  getRoomLegalMoves,
+  resetLiveRoomPersistHookForTests,
+  resetRoomRuntimeForTests,
+} from '../rooms';
+import { GAME_ACTION_PERSIST_RETRY_MESSAGE } from './registerGameplayActionHandlers';
+import { resetGameActionIdempotencyForTests } from './gameActionIdempotency';
+import { resetRoomGameplayLocksForTests } from './roomGameplayLock';
+import {
+  resetLiveRoomPersistenceForTests,
+  setForceLiveRoomFlushUnrecoverableForTests,
+} from './roomLivePersistence';
+import { initRoomSession, resetRoomSessionStoresForTests, setRoomRoster } from './roomSession';
+import { registerRoomSessionHandlers } from './registerRoomSessionHandlers';
+
+vi.mock('../supabaseUtils', () => ({
+  supabaseFetch: vi.fn(async () => []),
+}));
+
+const sessionDeps = {
+  resolveSocketIdentity: async (config: { username?: string; userId?: string | null }) => ({
+    username: typeof config.username === 'string' ? config.username : 'Guest',
+    userId: typeof config.userId === 'string' ? config.userId : null,
+  }),
+  normalizeUsername: (value: unknown) => (typeof value === 'string' ? value : 'Guest'),
+  normalizeUserId: (value: unknown) => (typeof value === 'string' ? value : null),
+  tryHydrateMatchmakingRoomShell: async () => 'skipped' as const,
+  waitUntilMatchmakingRoomSocketsReady: async () => undefined,
+  onAfterMatchStarted: async () => undefined,
+  notifyRoomPlayersInGame: () => undefined,
+  maybeFinalizeTournamentMatch: () => undefined,
+  persistRoomMatchLog: async () => undefined,
+  onGameOver: () => null,
+  finalizeTournamentMatch: () => undefined,
+};
+
+function makeSocket(label: string, userId: string) {
+  const handlers = new Map<string, (...args: any[]) => void>();
+  const socket = {
+    id: `sock-${label}`,
+    data: {
+      userId,
+      username: label,
+    } as Record<string, unknown>,
+    rooms: new Set<string>(),
+    connected: true,
+    on: (event: string, handler: (...args: any[]) => void) => {
+      handlers.set(event, handler);
+      return socket;
+    },
+    join: (roomCode: string) => {
+      socket.rooms.add(roomCode);
+    },
+    leave: (roomCode: string) => {
+      socket.rooms.delete(roomCode);
+    },
+    emit: vi.fn(),
+    disconnect: vi.fn(),
+  };
+  socket.rooms.add(socket.id);
+  return { socket: socket as any, handlers };
+}
+
+function makeIoRoomTarget() {
+  const emit = vi.fn();
+  return {
+    emit,
+    except: vi.fn(() => ({ emit: vi.fn() })),
+  };
+}
+
+function makeTwoPlayerIo(hostSocket: any, guestSocket: any, roomCode: string) {
+  const roomMembers = new Set([hostSocket.id, guestSocket.id]);
+  return {
+    sockets: {
+      sockets: new Map([
+        [hostSocket.id, hostSocket],
+        [guestSocket.id, guestSocket],
+      ]),
+      adapter: {
+        rooms: new Map<string, Set<string>>([[roomCode, roomMembers]]),
+      },
+    },
+    to: vi.fn(() => makeIoRoomTarget()),
+  } as any;
+}
+
+function stateUpdateCalls(socket: { emit: ReturnType<typeof vi.fn> }) {
+  return socket.emit.mock.calls.filter(([event]) => event === 'state:update');
+}
+
+function latestStateUpdate(socket: { emit: ReturnType<typeof vi.fn> }) {
+  const updates = stateUpdateCalls(socket);
+  return updates[updates.length - 1]?.[1] ?? null;
+}
+
+function gameplayEmitEvents(socket: { emit: ReturnType<typeof vi.fn> }) {
+  return socket.emit.mock.calls
+    .map(([event]) => event as string)
+    .filter((event) =>
+      ['state:update', 'forcedDraw:animation', 'hand:ended', 'game:over'].includes(event),
+    );
+}
+
+function boardFingerprint(state: any) {
+  return {
+    sequence: state?.sequence ?? null,
+    currentPlayerIndex: state?.currentPlayerIndex ?? null,
+    handNumber: state?.handNumber ?? null,
+    board: state?.board ?? null,
+    consecutivePasses: state?.consecutivePasses ?? null,
+    boneyardCount: Array.isArray(state?.boneyard) ? state.boneyard.length : null,
+    scores: Object.fromEntries(
+      Object.entries(state?.players ?? {}).map(([id, player]: [string, any]) => [
+        id,
+        player?.score ?? null,
+      ]),
+    ),
+    handLengths: Object.fromEntries(
+      Object.entries(state?.players ?? {}).map(([id, player]: [string, any]) => [
+        id,
+        Array.isArray(player?.hand) ? player.hand.length : null,
+      ]),
+    ),
+  };
+}
+
+async function startPrivateMatch(
+  io: any,
+  hostHandlers: Map<string, (...args: any[]) => void>,
+  guestHandlers: Map<string, (...args: any[]) => void>,
+  hostSocket: any,
+  guestSocket: any,
+) {
+  const hostAck = vi.fn();
+  await hostHandlers.get('room:create')?.(
+    { username: 'Host', userId: 'host-user', skipPregameDraw: true },
+    hostAck,
+  );
+  expect(hostAck).toHaveBeenCalledWith(expect.objectContaining({ ok: true }));
+  const roomCode = hostAck.mock.calls[0][0].roomCode as string;
+  const hostSeatId = hostAck.mock.calls[0][0].you as string;
+
+  io.sockets.adapter.rooms.set(roomCode, new Set([hostSocket.id, guestSocket.id]));
+
+  const guestJoinAck = vi.fn();
+  await guestHandlers.get('room:join')?.(
+    roomCode,
+    { username: 'Guest', userId: 'guest-user' },
+    guestJoinAck,
+  );
+  expect(guestJoinAck).toHaveBeenCalledWith(expect.objectContaining({ ok: true }));
+  const guestSeatId = guestJoinAck.mock.calls[0][0].you as string;
+
+  setRoomRoster(roomCode, [
+    { id: hostSeatId, socketId: hostSocket.id, username: 'Host', userId: 'host-user' },
+    { id: guestSeatId, socketId: guestSocket.id, username: 'Guest', userId: 'guest-user' },
+  ]);
+
+  await guestHandlers.get('player:ready')?.(roomCode, vi.fn());
+
+  hostSocket.emit.mockClear();
+  guestSocket.emit.mockClear();
+
+  const startAck = vi.fn();
+  await hostHandlers.get('game:start')?.(roomCode, startAck);
+  expect(startAck).toHaveBeenCalledWith(expect.objectContaining({ ok: true }));
+
+  return { roomCode, hostSeatId, guestSeatId };
+}
+
+async function findPlayMoveForCurrentTurn(
+  roomCode: string,
+  hostSeatId: string,
+  hostHandlers: Map<string, (...args: any[]) => void>,
+  guestHandlers: Map<string, (...args: any[]) => void>,
+) {
+  for (let step = 0; step < 24; step += 1) {
+    const room = getRoom(roomCode);
+    const currentId = room.state!.playerIds[room.state!.currentPlayerIndex];
+    const activeHandlers = currentId === hostSeatId ? hostHandlers : guestHandlers;
+    const legalMoves = getRoomLegalMoves(roomCode, currentId);
+    const playMove = legalMoves.find((move) => move.type === 'play' && move.tile);
+    if (playMove) {
+      return { currentId, activeHandlers, playMove };
+    }
+    if (getRoomCanDraw(roomCode, currentId)) {
+      const ack = vi.fn();
+      await activeHandlers.get('game:action')?.(
+        roomCode,
+        { type: 'DRAW', requestId: `setup-draw-${step}` },
+        ack,
+      );
+      expect(ack).toHaveBeenCalledWith(expect.objectContaining({ ok: true }));
+      continue;
+    }
+    if (legalMoves.some((move) => move.type === 'pass')) {
+      const ack = vi.fn();
+      await activeHandlers.get('game:action')?.(
+        roomCode,
+        { type: 'PASS', requestId: `setup-pass-${step}` },
+        ack,
+      );
+      expect(ack).toHaveBeenCalledWith(expect.objectContaining({ ok: true }));
+      continue;
+    }
+    break;
+  }
+  throw new Error('Could not reach a playable MOVE for integration test');
+}
+
+describe('PR-MP-C two-client game:action persist rollback integration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetGameActionIdempotencyForTests();
+    resetLiveRoomPersistenceForTests();
+    resetLiveRoomPersistHookForTests();
+    resetRoomGameplayLocksForTests();
+    resetRoomRuntimeForTests();
+    resetRoomSessionStoresForTests();
+  });
+
+  it('steps 1–6: happy move → forced flush fail → silent B → A retry → recover', async () => {
+    const { socket: hostSocket, handlers: hostHandlers } = makeSocket('Host', 'host-user');
+    const { socket: guestSocket, handlers: guestHandlers } = makeSocket('Guest', 'guest-user');
+
+    const io = makeTwoPlayerIo(hostSocket, guestSocket, 'PENDING');
+    initRoomSession(io, sessionDeps);
+    registerRoomSessionHandlers(io, hostSocket);
+    registerRoomSessionHandlers(io, guestSocket);
+
+    const { roomCode, hostSeatId, guestSeatId } = await startPrivateMatch(
+      io,
+      hostHandlers,
+      guestHandlers,
+      hostSocket,
+      guestSocket,
+    );
+
+    // ── Step 1: normal move; both seats get matching state:update ───────────
+    const first = await findPlayMoveForCurrentTurn(
+      roomCode,
+      hostSeatId,
+      hostHandlers,
+      guestHandlers,
+    );
+    const seatAId = first.currentId;
+    const seatBId = seatAId === hostSeatId ? guestSeatId : hostSeatId;
+    const seatAHandlers = seatAId === hostSeatId ? hostHandlers : guestHandlers;
+    const seatASocket = seatAId === hostSeatId ? hostSocket : guestSocket;
+    const seatBSocket = seatAId === hostSeatId ? guestSocket : hostSocket;
+
+    hostSocket.emit.mockClear();
+    guestSocket.emit.mockClear();
+
+    const step1SeqBefore = getRoom(roomCode).state!.sequence;
+    const step1Ack = vi.fn();
+    await seatAHandlers.get('game:action')?.(
+      roomCode,
+      {
+        type: 'MOVE',
+        requestId: 'step1-ok-move',
+        move: { tile: first.playMove!.tile, position: first.playMove!.position },
+      },
+      step1Ack,
+    );
+    expect(step1Ack, 'step1 ack').toHaveBeenCalledWith(expect.objectContaining({ ok: true }));
+    const step1Server = getRoom(roomCode).state!;
+    expect(step1Server.sequence, 'step1 sequence advanced').toBeGreaterThan(step1SeqBefore);
+
+    const step1A = latestStateUpdate(seatASocket);
+    const step1B = latestStateUpdate(seatBSocket);
+    expect(step1A?.state?.sequence, 'step1 A state:update').toBe(step1Server.sequence);
+    expect(step1B?.state?.sequence, 'step1 B state:update').toBe(step1Server.sequence);
+    expect(boardFingerprint(step1A?.state).board, 'step1 A/B board match').toEqual(
+      boardFingerprint(step1B?.state).board,
+    );
+    expect(step1A?.state?.players?.[seatBId]?.hand ?? [], 'step1 A masks B hand').toEqual([]);
+    expect(step1B?.state?.players?.[seatAId]?.hand ?? [], 'step1 B masks A hand').toEqual([]);
+
+    // Advance until Seat A again has a playable MOVE (may pass/draw through B).
+    let failMove = await findPlayMoveForCurrentTurn(
+      roomCode,
+      hostSeatId,
+      hostHandlers,
+      guestHandlers,
+    );
+    // Prefer keeping the same logical actor if possible; otherwise use whoever has the turn.
+    const actorId = failMove.currentId;
+    const actorHandlers = actorId === hostSeatId ? hostHandlers : guestHandlers;
+    const actorSocket = actorId === hostSeatId ? hostSocket : guestSocket;
+    const opponentSocket = actorId === hostSeatId ? guestSocket : hostSocket;
+    const opponentId = actorId === hostSeatId ? guestSeatId : hostSeatId;
+
+    // ── Step 2: force flush failure on next move ────────────────────────────
+    setForceLiveRoomFlushUnrecoverableForTests(true);
+
+    const baselineState = structuredClone(getRoom(roomCode).state!);
+    const baselineSequence = baselineState.sequence;
+    const baselineTurnSeat = baselineState.playerIds[baselineState.currentPlayerIndex];
+    expect(baselineTurnSeat, 'step2 baseline is actor turn').toBe(actorId);
+
+    // Capture last client snapshots before clearing emit spies for the failure window.
+    const actorClientBefore = structuredClone(latestStateUpdate(actorSocket));
+    expect(actorClientBefore?.state?.sequence, 'step2 actor has prior state:update').toBe(
+      baselineSequence,
+    );
+
+    hostSocket.emit.mockClear();
+    guestSocket.emit.mockClear();
+    const opponentEventsBefore = gameplayEmitEvents(opponentSocket).length;
+    const failPayload = {
+      type: 'MOVE' as const,
+      requestId: 'step2-fail-move',
+      move: { tile: failMove.playMove!.tile, position: failMove.playMove!.position },
+    };
+    const failAck = vi.fn();
+    await actorHandlers.get('game:action')?.(roomCode, failPayload, failAck);
+
+    // ── Step 3: Seat B receives nothing ─────────────────────────────────────
+    expect(gameplayEmitEvents(opponentSocket).length, 'step3 B no gameplay emits').toBe(
+      opponentEventsBefore,
+    );
+    expect(stateUpdateCalls(opponentSocket).length, 'step3 B no state:update').toBe(0);
+
+    // ── Step 4: Seat A uncertain + board matches rolled-back server ─────────
+    expect(failAck, 'step4 uncertain ack').toHaveBeenCalledWith(
+      expect.objectContaining({
+        ok: false,
+        uncertain: true,
+        error: GAME_ACTION_PERSIST_RETRY_MESSAGE,
+        sequence: baselineSequence,
+      }),
+    );
+    expect(stateUpdateCalls(actorSocket).length, 'step4 A no state:update on fail').toBe(0);
+
+    const rolledBack = getRoom(roomCode).state!;
+    expect(rolledBack.sequence, 'step4 server sequence rolled back').toBe(baselineSequence);
+    expect(rolledBack.playerIds[rolledBack.currentPlayerIndex], 'step4 still actor turn').toBe(
+      actorId,
+    );
+    expect(boardFingerprint(rolledBack), 'step4 server board == baseline').toEqual(
+      boardFingerprint(baselineState),
+    );
+    expect(rolledBack.players[actorId].hand, 'step4 actor hand == baseline').toEqual(
+      baselineState.players[actorId].hand,
+    );
+    expect(rolledBack.board, 'step4 board deep-equal baseline').toEqual(baselineState.board);
+
+    // Actor "client" still holds last successful snapshot; must agree with server baseline.
+    const actorClientNow = latestStateUpdate(actorSocket) ?? actorClientBefore;
+    expect(actorClientNow?.state?.sequence, 'step4 client seq == server').toBe(rolledBack.sequence);
+    expect(actorClientNow?.state?.board, 'step4 client board == server').toEqual(rolledBack.board);
+    expect(
+      actorClientNow?.state?.players?.[actorId]?.hand,
+      'step4 client hand == server',
+    ).toEqual(rolledBack.players[actorId].hand);
+    expect(
+      actorClientNow?.state?.currentPlayerIndex,
+      'step4 client turn index == server',
+    ).toBe(rolledBack.currentPlayerIndex);
+
+    // ── Step 5: rapid retries while failure forced ──────────────────────────
+    hostSocket.emit.mockClear();
+    guestSocket.emit.mockClear();
+    const rapidAcks = [vi.fn(), vi.fn(), vi.fn()];
+    for (let i = 0; i < 3; i += 1) {
+      // Re-read legal move each time (board unchanged, but keep realistic).
+      const legal = getRoomLegalMoves(roomCode, actorId);
+      const play = legal.find(
+        (m) =>
+          m.type === 'play' &&
+          m.tile &&
+          m.tile.low === failMove.playMove!.tile!.low &&
+          m.tile.high === failMove.playMove!.tile!.high &&
+          m.position === failMove.playMove!.position,
+      );
+      expect(play, `step5 legal play still available attempt ${i + 1}`).toBeTruthy();
+      await actorHandlers.get('game:action')?.(
+        roomCode,
+        {
+          type: 'MOVE',
+          requestId: `step5-retry-${i}`,
+          move: { tile: play!.tile, position: play!.position },
+        },
+        rapidAcks[i],
+      );
+    }
+
+    for (let i = 0; i < 3; i += 1) {
+      expect(rapidAcks[i], `step5 ack ${i + 1}`).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ok: false,
+          uncertain: true,
+          error: GAME_ACTION_PERSIST_RETRY_MESSAGE,
+          sequence: baselineSequence,
+        }),
+      );
+    }
+    const afterRapid = getRoom(roomCode).state!;
+    expect(afterRapid.sequence, 'step5 sequence stuck at baseline').toBe(baselineSequence);
+    expect(afterRapid.playerIds[afterRapid.currentPlayerIndex], 'step5 still actor turn').toBe(
+      actorId,
+    );
+    expect(boardFingerprint(afterRapid), 'step5 board unchanged').toEqual(
+      boardFingerprint(baselineState),
+    );
+    expect(stateUpdateCalls(opponentSocket).length, 'step5 B still silent').toBe(0);
+    expect(stateUpdateCalls(actorSocket).length, 'step5 A still no broadcast').toBe(0);
+
+    // ── Step 6: clear force; retry succeeds; B receives update ──────────────
+    setForceLiveRoomFlushUnrecoverableForTests(false);
+    hostSocket.emit.mockClear();
+    guestSocket.emit.mockClear();
+
+    const legalFinal = getRoomLegalMoves(roomCode, actorId);
+    const playFinal = legalFinal.find(
+      (m) =>
+        m.type === 'play' &&
+        m.tile &&
+        m.tile.low === failMove.playMove!.tile!.low &&
+        m.tile.high === failMove.playMove!.tile!.high &&
+        m.position === failMove.playMove!.position,
+    );
+    expect(playFinal, 'step6 same play still legal').toBeTruthy();
+
+    const successAck = vi.fn();
+    await actorHandlers.get('game:action')?.(
+      roomCode,
+      {
+        type: 'MOVE',
+        requestId: 'step6-success-move',
+        move: { tile: playFinal!.tile, position: playFinal!.position },
+      },
+      successAck,
+    );
+
+    expect(successAck, 'step6 success ack').toHaveBeenCalledWith(
+      expect.objectContaining({ ok: true }),
+    );
+    const afterSuccess = getRoom(roomCode).state!;
+    // Engine bumps sequence on play and again on turn advance (not a leftover from failed attempts).
+    expect(afterSuccess.sequence, 'step6 sequence advanced').toBeGreaterThan(baselineSequence);
+    expect(
+      afterSuccess.players[actorId].hand.length,
+      'step6 exactly one tile consumed from actor hand',
+    ).toBe(baselineState.players[actorId].hand.length - 1);
+    expect(stateUpdateCalls(opponentSocket).length, 'step6 B received state:update').toBeGreaterThan(
+      0,
+    );
+    expect(stateUpdateCalls(actorSocket).length, 'step6 A received state:update').toBeGreaterThan(0);
+
+    const finalA = latestStateUpdate(actorSocket);
+    const finalB = latestStateUpdate(opponentSocket);
+    expect(finalA?.state?.sequence, 'step6 A client seq').toBe(afterSuccess.sequence);
+    expect(finalB?.state?.sequence, 'step6 B client seq').toBe(afterSuccess.sequence);
+    expect(finalA?.state?.board, 'step6 A/B boards agree').toEqual(finalB?.state?.board);
+    expect(finalB?.state?.players?.[actorId]?.hand ?? [], 'step6 B still masks A hand').toEqual([]);
+    expect(finalA?.state?.players?.[opponentId]?.hand ?? [], 'step6 A still masks B hand').toEqual(
+      [],
+    );
+    // No leftover pending forced-draw from failed attempts.
+    expect(getRoom(roomCode).pendingForcedDrawBroadcast, 'step6 no pending forced draw').toBeUndefined();
+  });
+});

--- a/server/src/multiplayer/registerGameplayActionHandlers.test.ts
+++ b/server/src/multiplayer/registerGameplayActionHandlers.test.ts
@@ -335,7 +335,7 @@ describe('registerGameplayActionHandlers', () => {
     expect(cb).toHaveBeenCalledWith({ ok: false, error: 'new_hand_blocked' });
   });
 
-  it('returns an uncertain ack when a gameplay mutation cannot be proven durably committed', async () => {
+  it('rolls back memory and returns uncertain when flush is not durably recoverable', async () => {
     const roomCode = 'ACKUNK';
     createReservedRoom(roomCode);
     const seatId = 'seat-1';
@@ -347,6 +347,8 @@ describe('registerGameplayActionHandlers', () => {
     room.durability.persistedFence = null;
     room.durability.status = 'healthy';
     setRoomRoster(roomCode, [{ id: seatId, socketId: 'sock-1', username: 'P1', userId: 'u1' }]);
+    const sequenceBefore = room.state.sequence;
+    const passesBefore = room.state.consecutivePasses;
 
     const io = makeIo();
     const { socket, handlers } = makeSocket('sock-1', seatId);
@@ -354,11 +356,15 @@ describe('registerGameplayActionHandlers', () => {
 
     const actSpy = vi.spyOn(rooms, 'act').mockImplementation(async () => {
       room.state!.sequence += 1;
+      room.state!.consecutivePasses += 1;
       return { room, forcedDrawAnimation: undefined };
     });
+    const rollbackSpy = vi.spyOn(rooms, 'rollbackRoomGameplayCommit');
+    const broadcastSpy = vi.spyOn(roomSession, 'broadcastStateUpdate').mockImplementation(() => {});
     vi.spyOn(livePersistence, 'flushScheduledLiveRoomPersistence').mockResolvedValue({
       flushedRoomCodes: ['ACKUNK'],
     });
+    vi.spyOn(livePersistence, 'isLiveRoomDurablyRecoverable').mockReturnValue(false);
 
     registerGameplayActionHandlers(io, socket, {
       handlerDeps: {
@@ -376,26 +382,119 @@ describe('registerGameplayActionHandlers', () => {
 
     const payload = { type: 'PASS', requestId: 'uncertain-pass' };
     const ack1 = vi.fn();
-    const ack2 = vi.fn();
     await handlers.get('game:action')?.(roomCode, payload, ack1);
-    await handlers.get('game:action')?.(roomCode, payload, ack2);
 
     expect(actSpy).toHaveBeenCalledTimes(1);
+    expect(rollbackSpy).toHaveBeenCalledTimes(1);
+    expect(broadcastSpy).not.toHaveBeenCalled();
+    expect(room.state.sequence).toBe(sequenceBefore);
+    expect(room.state.consecutivePasses).toBe(passesBefore);
     expect(ack1).toHaveBeenCalledWith(
       expect.objectContaining({
         ok: false,
         uncertain: true,
-        error: expect.stringMatching(/^room_(persistence_failed|snapshot_uncommitted)$/),
+        sequence: sequenceBefore,
+        error: "Move couldn't be saved — try again.",
       }),
     );
-    expect(ack2).toHaveBeenCalledWith(
-      expect.objectContaining({
-        ok: false,
-        uncertain: true,
-        duplicate: true,
-        error: expect.stringMatching(/^room_(persistence_failed|snapshot_uncommitted)$/),
-      }),
+  });
+
+  it('consecutive flush failures: each attempt rolls back; board/turn stay at baseline', async () => {
+    const roomCode = 'ACKDBL';
+    createReservedRoom(roomCode);
+    const seatId = 'seat-1';
+    joinRoom(roomCode, seatId);
+    joinRoom(roomCode, 'seat-2');
+    const room = getRoom(roomCode);
+    room.players = [seatId, 'seat-2'];
+    room.state = mkStartedRoom(roomCode);
+    room.durability.persistedFence = null;
+    room.durability.status = 'healthy';
+    setRoomRoster(roomCode, [{ id: seatId, socketId: 'sock-1', username: 'P1', userId: 'u1' }]);
+    const sequenceBefore = room.state.sequence;
+    const turnBefore = room.state.currentPlayerIndex;
+
+    const io = makeIo();
+    const { socket, handlers } = makeSocket('sock-1', seatId);
+    ensureSocketDataSeat(socket, seatId);
+
+    const actSpy = vi.spyOn(rooms, 'act').mockImplementation(async () => {
+      room.state!.sequence += 1;
+      room.state!.currentPlayerIndex = 1;
+      return { room, forcedDrawAnimation: undefined };
+    });
+    const rollbackSpy = vi.spyOn(rooms, 'rollbackRoomGameplayCommit');
+    const broadcastSpy = vi.spyOn(roomSession, 'broadcastStateUpdate').mockImplementation(() => {});
+    vi.spyOn(livePersistence, 'flushScheduledLiveRoomPersistence').mockResolvedValue({
+      flushedRoomCodes: ['ACKDBL'],
+    });
+    const recoverableSpy = vi
+      .spyOn(livePersistence, 'isLiveRoomDurablyRecoverable')
+      .mockReturnValue(false);
+
+    registerGameplayActionHandlers(io, socket, {
+      handlerDeps: {
+        resolveSocketIdentity: async () => ({ username: 'P1', userId: 'u1' }),
+        normalizeUsername: (v) => String(v ?? 'Guest'),
+        normalizeUserId: (v) => (typeof v === 'string' ? v : null),
+        tryHydrateMatchmakingRoomShell: async () => 'skipped',
+        waitUntilMatchmakingRoomSocketsReady: async () => undefined,
+        onAfterMatchStarted: async () => undefined,
+        notifyRoomPlayersInGame: () => undefined,
+        persistRoomMatchLog: async () => undefined,
+        maybeFinalizeTournamentMatch: vi.fn(),
+      },
+    });
+
+    const ack1 = vi.fn();
+    const ack2 = vi.fn();
+    // Same requestId (client uncertain-retry) then a fresh id — both must re-act + roll back.
+    await handlers.get('game:action')?.(
+      roomCode,
+      { type: 'PASS', requestId: 'dbl-pass-1' },
+      ack1,
     );
+    await handlers.get('game:action')?.(
+      roomCode,
+      { type: 'PASS', requestId: 'dbl-pass-1' },
+      ack2,
+    );
+    const ack3 = vi.fn();
+    await handlers.get('game:action')?.(
+      roomCode,
+      { type: 'PASS', requestId: 'dbl-pass-2' },
+      ack3,
+    );
+
+    expect(actSpy).toHaveBeenCalledTimes(3);
+    expect(rollbackSpy).toHaveBeenCalledTimes(3);
+    expect(broadcastSpy).not.toHaveBeenCalled();
+    expect(room.state.sequence).toBe(sequenceBefore);
+    expect(room.state.currentPlayerIndex).toBe(turnBefore);
+    for (const ack of [ack1, ack2, ack3]) {
+      expect(ack).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ok: false,
+          uncertain: true,
+          sequence: sequenceBefore,
+          error: "Move couldn't be saved — try again.",
+        }),
+      );
+    }
+
+    // Mid-retry recovery: next attempt durably commits once.
+    recoverableSpy.mockReturnValue(true);
+    const ackOk = vi.fn();
+    await handlers.get('game:action')?.(
+      roomCode,
+      { type: 'PASS', requestId: 'dbl-pass-ok' },
+      ackOk,
+    );
+    expect(actSpy).toHaveBeenCalledTimes(4);
+    expect(rollbackSpy).toHaveBeenCalledTimes(3);
+    expect(broadcastSpy).toHaveBeenCalledWith(roomCode);
+    expect(room.state.sequence).toBe(sequenceBefore + 1);
+    expect(ackOk).toHaveBeenCalledWith(expect.objectContaining({ ok: true }));
   });
 
   it('game:action MOVE with duplicate requestId mutates only once and replays ack', async () => {

--- a/server/src/multiplayer/registerGameplayActionHandlers.ts
+++ b/server/src/multiplayer/registerGameplayActionHandlers.ts
@@ -1,5 +1,11 @@
 import type { Server, Socket } from 'socket.io';
-import { act, getRoom, readyForNextHand } from '../rooms';
+import {
+  act,
+  captureRoomGameplaySnapshot,
+  getRoom,
+  readyForNextHand,
+  rollbackRoomGameplayCommit,
+} from '../rooms';
 import { normalizeGameActionRequestId, withGameActionIdempotency } from './gameActionIdempotency';
 import { childLogger } from '../logger';
 
@@ -18,6 +24,9 @@ import {
   type RoomSessionHandlerDeps,
 } from './roomSession';
 import { emitMpAuthorityFunnel } from './mpAuthorityTelemetry';
+
+/** Actor-facing copy when a move mutates memory but cannot be proven durable (then rolled back). */
+export const GAME_ACTION_PERSIST_RETRY_MESSAGE = "Move couldn't be saved — try again.";
 
 export type RegisterGameplayActionHandlersParams = {
   handlerDeps: RoomSessionHandlerDeps;
@@ -67,6 +76,12 @@ export function registerGameplayActionHandlers(
         playerSeatId,
         requestId,
         async () => {
+          const roomBefore = getRoom(roomCode);
+          const snapshot = captureRoomGameplaySnapshot(roomBefore);
+          if (!snapshot) {
+            return { ok: false, error: 'Game not started.' };
+          }
+
           const result = await act(roomCode, playerSeatId, action, io, (code) =>
             broadcastStateUpdate(code),
           );
@@ -81,12 +96,10 @@ export function registerGameplayActionHandlers(
           const durability = getLiveRoomDurabilityState(room);
           const committed = isLiveRoomDurablyRecoverable(room);
           if (!committed) {
+            rollbackRoomGameplayCommit(room, snapshot);
             return {
               ok: false,
-              error:
-                durability.status === 'failed' || durability.status === 'degraded'
-                  ? 'room_persistence_failed'
-                  : 'room_snapshot_uncommitted',
+              error: GAME_ACTION_PERSIST_RETRY_MESSAGE,
               uncertain: true,
               sequence: room.state?.sequence ?? null,
             };
@@ -109,6 +122,7 @@ export function registerGameplayActionHandlers(
               action: action?.type,
               sequence: room.state?.sequence ?? null,
               flushedRoomCodes: flushResult.flushedRoomCodes,
+              durabilityStatus: durability.status,
             }, '');
           }
           const forcedMeta = result.forcedDrawAnimation

--- a/server/src/multiplayer/roomCommandReceiptStore.ts
+++ b/server/src/multiplayer/roomCommandReceiptStore.ts
@@ -80,7 +80,7 @@ export async function persistRoomCommandReceipt(
     return;
   }
   if (persistentRoomCommandReceiptsAvailable === false) return;
-  if (!input.ack.ok && !input.ack.uncertain) return;
+  if (!input.ack.ok) return;
 
   const row: RoomCommandReceiptRow = {
     room_code: normalizeRoomCode(input.roomCode),

--- a/server/src/multiplayer/roomLivePersistence.ts
+++ b/server/src/multiplayer/roomLivePersistence.ts
@@ -675,7 +675,21 @@ export function getLiveRoomDurabilityState(room: Room) {
   return getRoomDurabilityState(room);
 }
 
+/**
+ * Test-only: after flush, treat the room as not durably recoverable so
+ * gameplay callers exercise mutate-then-rollback. Hard-blocked in production.
+ */
+let forceLiveRoomFlushUnrecoverableForTests = false;
+
+export function setForceLiveRoomFlushUnrecoverableForTests(enabled: boolean): void {
+  if (process.env.NODE_ENV === 'production') {
+    throw new Error('setForceLiveRoomFlushUnrecoverableForTests is blocked in production');
+  }
+  forceLiveRoomFlushUnrecoverableForTests = enabled;
+}
+
 export function isLiveRoomDurablyRecoverable(room: Room): boolean {
+  if (forceLiveRoomFlushUnrecoverableForTests) return false;
   return isRoomDurablyRecoverable(room);
 }
 
@@ -1016,6 +1030,7 @@ async function runLiveRoomHydration(code: string): Promise<ActiveRoomHydrationRe
 
 /** Test-only reset for debounce timers and table-availability cache. */
 export function resetLiveRoomPersistenceForTests(): void {
+  forceLiveRoomFlushUnrecoverableForTests = false;
   for (const timer of flushTimersByRoomCode.values()) {
     clearTimeout(timer);
   }


### PR DESCRIPTION
## Summary
- **PR-MP-C** (last of the four MP hardening PRs after A/B): when `game:action` mutates memory then flush cannot be proven durable, **roll back** with the same `captureRoomGameplaySnapshot` / `rollbackRoomGameplayCommit` helpers as disconnect grace — no broadcast, opponent stays silent.
- Actor gets `uncertain` + toast: `Move couldn't be saved — try again.` (still their turn; board at pre-move baseline).
- **Do not cache/persist uncertain acks** — client reuses `requestId` while uncertain; caching would trap retries forever after rollback. Same-id retry re-executes safely.
- Tests: single rollback; **consecutive flush failures** (same + new requestId) keep sequence/turn at baseline; mid-retry recovery then commits once; idempotency no longer caches uncertain.

## Consecutive failure / resync race (manual-test note)
| Case | Behavior |
|---|---|
| Retry after toast (same `requestId`) | Re-executes (uncertain not cached); each fail rolls back independently |
| Second action while `fetchGameState` still in flight | Safe: no optimistic board apply; server already at baseline; local board already matches |
| Mid-retry recovery | Covered in test: N fails → then durable → one commit + broadcast |

Please do a **two-tab manual playtest** before merge — this path is every live move.

## Test plan
- [ ] `npx vitest run src/multiplayer/registerGameplayActionHandlers.test.ts src/multiplayer/gameActionIdempotency.test.ts` (server)
- [ ] `npx vitest run src/match/session/actions/useLiveMatchActions.test.ts` (client)
- [ ] Two-tab private match: force persist failure (or inject) on a move — actor sees retry toast, board unchanged; opponent sees no flicker
- [ ] Actor retries same move twice while failing — still same board/turn; third succeeds when persist recovers
- [ ] Happy path MOVE/DRAW/PASS still broadcasts normally


Made with [Cursor](https://cursor.com)