### PR TITLE
fix(mp): fail tournament game-over when applyMatchResult does not stick (PR-MP-D)

### DIFF
--- a/docs/ops/tournament-apply-match-result-repair.md
+++ b/docs/ops/tournament-apply-match-result-repair.md
@@ -1,0 +1,52 @@
+# Ops: repair a stuck tournament match after applyMatchResult give-up
+
+**When:** Players saw game-over (and may have toasted *tournament result couldn't be saved*), but the bracket never advanced. Funnel: `private_game_over_persist_failed` with `extra.kind = "tournament_apply"`.
+
+**Player refresh does not fix this.** Persist is latched `failed` in that room process; repair is ops-side.
+
+## Confirm stuck
+
+```sql
+-- Match should still be open if apply never stuck:
+select id, tournament_id, round, match_number, status, room_code,
+       player1_id, player2_id, winner_id, player1_score, player2_score
+from public.scheduled_tournament_matches
+where id = '<matchId>';   -- from toast / funnel / room.scheduledTournamentMatchId
+-- Stuck: status in ('ready','in_progress') AND winner_id is null
+-- Already fixed: status = 'completed' AND winner_id set → stop (apply is idempotent)
+```
+
+Winner/loser user ids are `player1_id` / `player2_id` on that row. Scores: use the finished room scores if you still have them; otherwise reconstruct from player report + server logs.
+
+## Safe fix (preferred): re-run `applyMatchResult`
+
+Do **not** hand-edit only `winner_id`. Advancement (next-round slot, loser `eliminated`, final → `completeTournament`) lives in `applyMatchResult` (`server/src/scheduledTournament/engine.ts`). That function **no-ops if `status === 'completed'`**, so a second call is safe.
+
+From a one-off server context that has Socket.IO + DB (same process as production, or a small script importing the engine):
+
+```ts
+await applyMatchResult(io, {
+  matchId: '<matchId>',
+  winnerId: '<winner auth user uuid>',
+  player1Score: <number>,  // seat/player1 score on the match row orientation
+  player2Score: <number>,
+  winnerSource: 'game_over',
+});
+```
+
+That will: mark the match completed, eliminate the loser registration, emit `tournament:match_completed`, fill the next-round slot (`waiting`/`ready`), and if final, complete the tournament.
+
+## SQL-only (last resort)
+
+Only if you cannot run the engine. You must do **all** of:
+
+1. Complete the stuck row (`status`, `winner_id`, scores, `completed_at`, `winner_source`).
+2. Set loser registration to `eliminated` on `scheduled_tournament_registrations` (skip bot ids).
+3. Write the winner into the correct next-round slot (`player1_id` / `player2_id` via `advanceSlot` in `bracket.ts`) and set that match to `waiting` or `ready`.
+4. If round 3 (final): set `scheduled_tournaments.status = 'completed'` and `winner_id`.
+
+Getting slot mapping wrong bricks the bracket worse than leaving it stuck — prefer the code path.
+
+## After repair
+
+Ask affected players to refresh the bracket (or wait for `tournament:match_updated` / `match_completed` if the live server emitted them). Next-round `ready` matches still need normal attach/dispatch if players are waiting.

--- a/server/src/multiplayer/gameOverPersistPolicy.ts
+++ b/server/src/multiplayer/gameOverPersistPolicy.ts
@@ -10,6 +10,10 @@ export const GAME_OVER_PERSIST_RETRY_DELAYS_MS = [0, 400, 1200, 2800] as const;
 export const MATCH_RESULT_PERSIST_FAILED_MESSAGE =
   "Match finished, but the result couldn't be saved. Ratings may not update.";
 
+/** Tournament seats after applyMatchResult exhausts the same retry ceiling. */
+export const TOURNAMENT_RESULT_PERSIST_FAILED_MESSAGE =
+  "Match finished, but the tournament result couldn't be saved. The bracket may not advance — hang tight or contact support.";
+
 /** Rematch ack while persist is still in flight / retrying (R1). */
 export const MATCH_RESULT_STILL_SAVING_MESSAGE =
   "Result still saving — rematch isn't available yet.";

--- a/server/src/realtime/gameOverPersistence.test.ts
+++ b/server/src/realtime/gameOverPersistence.test.ts
@@ -252,50 +252,159 @@ describe('createGameOverPersistScheduler', () => {
     expect(resolvePendingFritzMatchMock).not.toHaveBeenCalled();
   });
 
-  it('returns early for scheduledTournamentMatchId without downstream persist', async () => {
-    applyTournamentGameOverFromRoomMock.mockResolvedValue(false);
-
-    await runPersist(buildInput({
+  it('tournament apply mid-retry recovery: fail then succeed — latches once, no give-up emit', async () => {
+    vi.useFakeTimers();
+    applyTournamentGameOverFromRoomMock
+      .mockRejectedValueOnce(new Error('db_blip'))
+      .mockResolvedValue(true);
+    const input = buildInput({
       room: { scheduledTournamentMatchId: 'sched-match-1' },
-    }));
+    });
+    const pending = runPersist(input);
+    await vi.runAllTimersAsync();
+    const outcome = await pending;
 
+    expect(outcome).toBe('succeeded');
+    expect(input.room.matchLogged).toBe(true);
+    expect(input.room.gameOverPersistStatus).toBe('succeeded');
+    expect(applyTournamentGameOverFromRoomMock).toHaveBeenCalledTimes(2);
     expect(appendMatchMock).not.toHaveBeenCalled();
-    expect(logWarnMock).not.toHaveBeenCalled();
+    expect(roomEmit).not.toHaveBeenCalledWith(
+      'match:result_persist_failed',
+      expect.anything(),
+    );
+    vi.useRealTimers();
   });
 
-  it('warns on scheduledTournamentMatchId when winnerUserId is missing', async () => {
-    await runPersist(buildInput({
+  it('tournament apply give-up: 4 failures → terminal failed + tournament copy, no matchLogged', async () => {
+    vi.useFakeTimers();
+    applyTournamentGameOverFromRoomMock.mockRejectedValue(new Error('db_down'));
+    const input = buildInput({
+      room: { scheduledTournamentMatchId: 'sched-match-1' },
+    });
+    const pending = runPersist(input);
+    await vi.runAllTimersAsync();
+    const outcome = await pending;
+
+    expect(outcome).toBe('failed');
+    expect(input.room.matchLogged).toBe(false);
+    expect(input.room.gameOverPersistStatus).toBe('failed');
+    expect(applyTournamentGameOverFromRoomMock.mock.calls.length).toBe(4);
+    expect(roomEmit).toHaveBeenCalledWith(
+      'match:result_persist_failed',
+      expect.objectContaining({
+        matchId: input.room.matchId,
+        message: expect.stringContaining('tournament result'),
+      }),
+    );
+    expect(emitMpAuthorityFunnelMock).toHaveBeenCalledWith(
+      'private_game_over_persist_failed',
+      expect.objectContaining({
+        roomCode: 'ROOM1',
+        extra: expect.objectContaining({
+          kind: 'tournament_apply',
+          scheduledTournamentMatchId: 'sched-match-1',
+          attempts: 4,
+        }),
+      }),
+    );
+    vi.useRealTimers();
+  });
+
+  it('tournament missing winnerUserId: does not latch success — gives up with tournament copy', async () => {
+    vi.useFakeTimers();
+    const input = buildInput({
       room: { scheduledTournamentMatchId: 'sched-match-1' },
       winnerSeatId: 'seat-unknown',
-    }));
+    });
+    const pending = runPersist(input);
+    await vi.runAllTimersAsync();
+    const outcome = await pending;
 
+    expect(outcome).toBe('failed');
+    expect(input.room.matchLogged).toBe(false);
+    expect(input.room.gameOverPersistStatus).toBe('failed');
+    expect(applyTournamentGameOverFromRoomMock).not.toHaveBeenCalled();
     expect(logWarnMock).toHaveBeenCalledWith(
       { roomCode: 'ROOM1', matchId: 'sched-match-1' },
       'missing winner user id',
     );
-    expect(appendMatchMock).not.toHaveBeenCalled();
+    expect(roomEmit).toHaveBeenCalledWith(
+      'match:result_persist_failed',
+      expect.objectContaining({
+        message: expect.stringContaining('tournament result'),
+      }),
+    );
+    vi.useRealTimers();
   });
 
-  it('returns early when findTournamentMatchByRoom finds a match', async () => {
-    findTournamentMatchByRoomMock.mockResolvedValue({ id: 'tour-match-9' });
+  it('tournament apply returns false with scheduled match id: retries then give-up', async () => {
+    vi.useFakeTimers();
+    applyTournamentGameOverFromRoomMock.mockResolvedValue(false);
+    const input = buildInput({
+      room: { scheduledTournamentMatchId: 'sched-match-1' },
+    });
+    const pending = runPersist(input);
+    await vi.runAllTimersAsync();
+    const outcome = await pending;
 
-    await runPersist(buildInput());
-
-    expect(findTournamentMatchByRoomMock).toHaveBeenCalledWith('ROOM1');
+    expect(outcome).toBe('failed');
+    expect(input.room.matchLogged).toBe(false);
+    expect(input.room.gameOverPersistStatus).toBe('failed');
+    expect(applyTournamentGameOverFromRoomMock.mock.calls.length).toBe(4);
     expect(appendMatchMock).not.toHaveBeenCalled();
-    expect(logWarnMock).not.toHaveBeenCalled();
+    expect(roomEmit).toHaveBeenCalledWith(
+      'match:result_persist_failed',
+      expect.objectContaining({
+        message: expect.stringContaining('tournament result'),
+      }),
+    );
+    vi.useRealTimers();
   });
 
-  it('warns on findTournamentMatchByRoom path when winnerUserId is missing', async () => {
+  it('private room continues when apply returns false and no tournament match by room', async () => {
+    applyTournamentGameOverFromRoomMock.mockResolvedValue(false);
+    findTournamentMatchByRoomMock.mockResolvedValue(null);
+
+    const outcome = await runPersist(buildInput());
+
+    expect(outcome).toBe('succeeded');
+    expect(appendMatchMock).toHaveBeenCalled();
+  });
+
+  it('findTournamentMatchByRoom hit with winner but apply returned false: give-up', async () => {
+    vi.useFakeTimers();
+    applyTournamentGameOverFromRoomMock.mockResolvedValue(false);
     findTournamentMatchByRoomMock.mockResolvedValue({ id: 'tour-match-9' });
+    const pending = runPersist(buildInput());
+    await vi.runAllTimersAsync();
+    const outcome = await pending;
 
-    await runPersist(buildInput({ winnerSeatId: 'seat-unknown' }));
+    expect(outcome).toBe('failed');
+    expect(appendMatchMock).not.toHaveBeenCalled();
+    expect(roomEmit).toHaveBeenCalledWith(
+      'match:result_persist_failed',
+      expect.objectContaining({
+        message: expect.stringContaining('tournament result'),
+      }),
+    );
+    vi.useRealTimers();
+  });
 
+  it('findTournamentMatchByRoom with missing winner: give-up, not silent success', async () => {
+    vi.useFakeTimers();
+    findTournamentMatchByRoomMock.mockResolvedValue({ id: 'tour-match-9' });
+    const pending = runPersist(buildInput({ winnerSeatId: 'seat-unknown' }));
+    await vi.runAllTimersAsync();
+    const outcome = await pending;
+
+    expect(outcome).toBe('failed');
     expect(logWarnMock).toHaveBeenCalledWith(
       { roomCode: 'ROOM1', matchId: 'tour-match-9' },
       'missing winner user id',
     );
     expect(appendMatchMock).not.toHaveBeenCalled();
+    vi.useRealTimers();
   });
 
   it('awaits resolvePendingFritzMatch before appendMatch when Fritz context exists', async () => {

--- a/server/src/realtime/gameOverPersistence.ts
+++ b/server/src/realtime/gameOverPersistence.ts
@@ -36,6 +36,7 @@ import {
   GAME_OVER_PERSIST_MAX_ATTEMPTS,
   GAME_OVER_PERSIST_RETRY_DELAYS_MS,
   MATCH_RESULT_PERSIST_FAILED_MESSAGE,
+  TOURNAMENT_RESULT_PERSIST_FAILED_MESSAGE,
   markGameOverPersistFailed,
   markGameOverPersistSucceeded,
   type GameOverPersistOutcome,
@@ -43,6 +44,10 @@ import {
 import type { Room } from '../rooms';
 
 const log = childLogger('realtime:game-over');
+
+/** Thrown inside persistGameOverOnce so the shared 4-attempt ceiling can give up cleanly. */
+export const TOURNAMENT_MISSING_WINNER_ERROR = 'tournament_missing_winner_user_id';
+export const TOURNAMENT_APPLY_FAILED_ERROR = 'tournament_apply_failed';
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -106,6 +111,9 @@ async function persistGameOverOnce(io: Server, input: GameOverPersistInput): Pro
   const { room, sourceMatchId, cfg, aId, bId, a, b, scoreA, scoreB, winnerSeatId } = input;
   const winnerUserId =
     winnerSeatId === a.id ? a.userId : winnerSeatId === b.id ? b.userId : null;
+
+  // Scheduled tournament: applyMatchResult must succeed or throw (retry / give-up).
+  // Never mark success when the bracket was not advanced.
   if (winnerUserId) {
     const applied = await applyTournamentGameOverFromRoom(io, room, {
       winnerUserId,
@@ -114,15 +122,18 @@ async function persistGameOverOnce(io: Server, input: GameOverPersistInput): Pro
     });
     if (applied) return;
   }
+
   if (room.scheduledTournamentMatchId) {
     if (!winnerUserId) {
       log.warn({
         roomCode: room.code,
         matchId: room.scheduledTournamentMatchId,
       }, 'missing winner user id');
+      throw new Error(TOURNAMENT_MISSING_WINNER_ERROR);
     }
-    return;
+    throw new Error(TOURNAMENT_APPLY_FAILED_ERROR);
   }
+
   const tournamentMatchByRoom = await findTournamentMatchByRoom(room.code).catch(() => null);
   if (tournamentMatchByRoom) {
     if (!winnerUserId) {
@@ -130,8 +141,9 @@ async function persistGameOverOnce(io: Server, input: GameOverPersistInput): Pro
         roomCode: room.code,
         matchId: tournamentMatchByRoom.id,
       }, 'missing winner user id');
+      throw new Error(TOURNAMENT_MISSING_WINNER_ERROR);
     }
-    return;
+    throw new Error(TOURNAMENT_APPLY_FAILED_ERROR);
   }
 
   if (getPendingFritzMatchContext(room)) {
@@ -392,6 +404,13 @@ async function persistGameOverOnce(io: Server, input: GameOverPersistInput): Pro
 function emitGameOverPersistFailed(io: Server, room: Room, sourceMatchId: string, err: unknown): void {
   const sequence = room.state?.sequence ?? null;
   const errorMessage = err instanceof Error ? err.message : String(err);
+  const isTournament =
+    Boolean(room.scheduledTournamentMatchId) ||
+    errorMessage === TOURNAMENT_MISSING_WINNER_ERROR ||
+    errorMessage === TOURNAMENT_APPLY_FAILED_ERROR;
+  const message = isTournament
+    ? TOURNAMENT_RESULT_PERSIST_FAILED_MESSAGE
+    : MATCH_RESULT_PERSIST_FAILED_MESSAGE;
   emitMpAuthorityFunnel('private_game_over_persist_failed', {
     roomCode: room.code,
     failureCode: 'room_persistence_failed',
@@ -399,8 +418,10 @@ function emitGameOverPersistFailed(io: Server, room: Room, sourceMatchId: string
     extra: {
       sourceMatchId,
       matchId: room.matchId,
+      scheduledTournamentMatchId: room.scheduledTournamentMatchId ?? null,
       attempts: GAME_OVER_PERSIST_MAX_ATTEMPTS,
       error: errorMessage,
+      kind: isTournament ? 'tournament_apply' : 'private_match',
     },
   });
   io.to(room.code).emit('match:result_persist_failed', {
@@ -408,7 +429,7 @@ function emitGameOverPersistFailed(io: Server, room: Room, sourceMatchId: string
     matchId: room.matchId,
     sourceMatchId,
     sequence,
-    message: MATCH_RESULT_PERSIST_FAILED_MESSAGE,
+    message,
   });
   log.warn(
     {
@@ -417,6 +438,7 @@ function emitGameOverPersistFailed(io: Server, room: Room, sourceMatchId: string
       sourceMatchId,
       sequence,
       error: errorMessage,
+      kind: isTournament ? 'tournament_apply' : 'private_match',
     },
     'game-over persist gave up after retries',
   );

--- a/server/src/realtime/gameOverPersistence.ts
+++ b/server/src/realtime/gameOverPersistence.ts
@@ -114,6 +114,7 @@ async function persistGameOverOnce(io: Server, input: GameOverPersistInput): Pro
 
   // Scheduled tournament: applyMatchResult must succeed or throw (retry / give-up).
   // Never mark success when the bracket was not advanced.
+  // Ops repair after give-up: docs/ops/tournament-apply-match-result-repair.md
   if (winnerUserId) {
     const applied = await applyTournamentGameOverFromRoom(io, room, {
       winnerUserId,


### PR DESCRIPTION
## Summary
- **PR-MP-D:** scheduled tournament game-over no longer treats a missed `applyMatchResult` as success.
- **Retry ceiling (same as B):** `GAME_OVER_PERSIST_MAX_ATTEMPTS = 4`, delays `[0, 400, 1200, 2800]` ms (~4.4s), then terminal `failed` + toast.
- Give-up copy: `Match finished, but the tournament result couldn't be saved. The bracket may not advance — hang tight or contact support.`
- Missing `winnerUserId` and `apply → false` now **throw** into that ceiling (previously `return` + latch success).
- Bracket announce stays gated on successful apply (`tournament:match_completed` / advance only inside `applyMatchResult`).

## Post–give-up / ops repair
- **Page refresh does not re-attempt** once `gameOverPersistStatus === 'failed'`.
- **Runbook:** `docs/ops/tournament-apply-match-result-repair.md` — confirm stuck row on `scheduled_tournament_matches`, then prefer re-running idempotent `applyMatchResult` (not SQL-only `winner_id` edits).

## Tests
- Mid-retry recovery: apply fails once then succeeds → latch once, no give-up emit
- Give-up: 4 apply failures → `failed`, no `matchLogged`, tournament message + funnel (`kind: tournament_apply`)
- Missing winner + apply-false paths → give-up, not silent success

## Test plan
- [x] `npx vitest run src/realtime/gameOverPersistence.test.ts`
- [ ] Spot-check tournament finish toast on forced apply failure (optional)