### PR TITLE
fix(auth): require email match on timeout session fallback

### DIFF
--- a/client/src/auth/AuthModal.timeoutFallback.test.tsx
+++ b/client/src/auth/AuthModal.timeoutFallback.test.tsx
@@ -1,0 +1,65 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import AuthModal from './AuthModal';
+
+describe('AuthModal — timeout-path error vs happy-path close', () => {
+  const onClose = vi.fn();
+  const onSignIn = vi.fn();
+  const onSignUp = vi.fn();
+  const onResetPassword = vi.fn();
+
+  beforeEach(() => {
+    onClose.mockReset();
+    onSignIn.mockReset();
+    onSignUp.mockReset();
+    onResetPassword.mockReset();
+  });
+
+  function renderOpen() {
+    return render(
+      <AuthModal
+        open
+        supabaseEnabled
+        supabaseConfigError={null}
+        onClose={onClose}
+        onSignIn={onSignIn}
+        onSignUp={onSignUp}
+        onResetPassword={onResetPassword}
+      />,
+    );
+  }
+
+  async function fillAndSubmitSignIn() {
+    fireEvent.change(screen.getByPlaceholderText('you@example.com'), {
+      target: { value: 'attempt@example.com' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('Minimum 6 characters'), {
+      target: { value: 'password1' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Sign in' }));
+  }
+
+  it('1. timeout-path error (stale session) keeps modal open — no false success close', async () => {
+    onSignIn.mockResolvedValue({ error: 'Request timed out. Try again.' });
+    renderOpen();
+    await fillAndSubmitSignIn();
+
+    await waitFor(() => {
+      expect(screen.getByText('Request timed out. Try again.')).toBeTruthy();
+    });
+    expect(onClose).not.toHaveBeenCalled();
+    expect(onSignIn).toHaveBeenCalledWith('attempt@example.com', 'password1');
+  });
+
+  it('4. non-timeout happy path still closes the modal', async () => {
+    onSignIn.mockResolvedValue({ error: null });
+    renderOpen();
+    await fillAndSubmitSignIn();
+
+    await waitFor(() => {
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+    expect(screen.queryByText(/timed out/i)).toBeNull();
+  });
+});

--- a/client/src/auth/authTimeoutSessionFallback.test.ts
+++ b/client/src/auth/authTimeoutSessionFallback.test.ts
@@ -1,0 +1,125 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const captureMessage = vi.fn();
+
+vi.mock('@sentry/react', () => ({
+  captureMessage: (...args: unknown[]) => captureMessage(...args),
+}));
+
+const {
+  AUTH_TIMEOUT_FALLBACK_ERROR,
+  evaluateAuthTimeoutSessionFallback,
+  sessionEmailMatchesAttempt,
+} = await import('./authTimeoutSessionFallback');
+
+describe('sessionEmailMatchesAttempt', () => {
+  it('matches case-insensitively with trimming', () => {
+    expect(sessionEmailMatchesAttempt('  Alice@Example.COM ', 'alice@example.com')).toBe(true);
+  });
+
+  it('rejects different emails', () => {
+    expect(sessionEmailMatchesAttempt('a@example.com', 'b@example.com')).toBe(false);
+  });
+
+  it('rejects empty session email', () => {
+    expect(sessionEmailMatchesAttempt(null, 'a@example.com')).toBe(false);
+    expect(sessionEmailMatchesAttempt('', 'a@example.com')).toBe(false);
+  });
+});
+
+describe('evaluateAuthTimeoutSessionFallback — actual timeout-path decision', () => {
+  beforeEach(() => {
+    captureMessage.mockReset();
+  });
+
+  it('1. timeout + different user session → error, no false success, Sentry auth_alert', () => {
+    const result = evaluateAuthTimeoutSessionFallback({
+      flow: 'sign_in',
+      attemptedEmail: 'attempt@example.com',
+      session: {
+        user: { id: 'user-other', email: 'other@example.com' },
+      },
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      reason: 'email_mismatch',
+      error: AUTH_TIMEOUT_FALLBACK_ERROR,
+    });
+    expect(captureMessage).toHaveBeenCalledWith(
+      expect.stringContaining('session email does not match'),
+      expect.objectContaining({
+        level: 'error',
+        tags: expect.objectContaining({
+          auth_alert: 'auth_timeout_stale_session',
+          auth_flow: 'sign_in',
+        }),
+        extra: expect.objectContaining({
+          reason: 'email_mismatch',
+          session_present: true,
+          emails_match: false,
+        }),
+      }),
+    );
+    const extra = captureMessage.mock.calls[0]?.[1]?.extra as Record<string, unknown>;
+    expect(extra).not.toHaveProperty('attempted_email');
+    expect(extra).not.toHaveProperty('session_email');
+    expect(extra).not.toHaveProperty('password');
+    expect(extra).not.toHaveProperty('access_token');
+    expect(Object.keys(extra).sort()).toEqual(
+      [
+        'attempted_email_len',
+        'auth_flow',
+        'emails_match',
+        'reason',
+        'session_email_present',
+        'session_present',
+        'session_user_id_len',
+      ].sort(),
+    );
+  });
+
+  it('2. timeout + matching user session → success (legitimate fallback)', () => {
+    const result = evaluateAuthTimeoutSessionFallback({
+      flow: 'sign_up',
+      attemptedEmail: 'Same@Example.com',
+      session: {
+        user: { id: 'user-match', email: 'same@example.com' },
+      },
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      user: { id: 'user-match', email: 'same@example.com' },
+    });
+    expect(captureMessage).not.toHaveBeenCalled();
+  });
+
+  it('3. timeout + no session → error', () => {
+    const result = evaluateAuthTimeoutSessionFallback({
+      flow: 'sign_in',
+      attemptedEmail: 'attempt@example.com',
+      session: null,
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      reason: 'no_session',
+      error: AUTH_TIMEOUT_FALLBACK_ERROR,
+    });
+    // Normal timeout — console only, not a stale-session Sentry alert.
+    expect(captureMessage).not.toHaveBeenCalled();
+  });
+
+  it('3b. timeout + session without user → error', () => {
+    const result = evaluateAuthTimeoutSessionFallback({
+      flow: 'sign_in',
+      attemptedEmail: 'attempt@example.com',
+      session: { user: null },
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('no_session');
+  });
+});

--- a/client/src/auth/authTimeoutSessionFallback.ts
+++ b/client/src/auth/authTimeoutSessionFallback.ts
@@ -1,0 +1,115 @@
+import * as Sentry from '@sentry/react';
+
+export type AuthTimeoutFlow = 'sign_in' | 'sign_up';
+
+export type AuthTimeoutSessionUser = {
+  id: string;
+  email?: string | null;
+};
+
+export type AuthTimeoutFallbackOk = {
+  ok: true;
+  user: AuthTimeoutSessionUser;
+};
+
+export type AuthTimeoutFallbackErr = {
+  ok: false;
+  reason: 'no_session' | 'email_mismatch' | 'probe_failed';
+  error: string;
+};
+
+export type AuthTimeoutFallbackResult = AuthTimeoutFallbackOk | AuthTimeoutFallbackErr;
+
+export const AUTH_TIMEOUT_FALLBACK_ERROR = 'Request timed out. Try again.';
+
+/** Case-insensitive email equality for timeout-session proof. */
+export function sessionEmailMatchesAttempt(
+  sessionEmail: string | null | undefined,
+  attemptedEmail: string,
+): boolean {
+  const session = sessionEmail?.trim().toLowerCase() ?? '';
+  const attempted = attemptedEmail.trim().toLowerCase();
+  return session.length > 0 && attempted.length > 0 && session === attempted;
+}
+
+/**
+ * Decide whether a getSession() probe after AUTH_REQUEST_TIMEOUT_MS may count as
+ * success for the timed-out sign-in/up attempt.
+ *
+ * Only a session whose user email matches the submitted email is accepted.
+ * Any other session is left untouched and the attempt fails as a real timeout.
+ */
+export function evaluateAuthTimeoutSessionFallback(params: {
+  session: { user?: AuthTimeoutSessionUser | null } | null | undefined;
+  attemptedEmail: string;
+  flow: AuthTimeoutFlow;
+}): AuthTimeoutFallbackResult {
+  const user = params.session?.user ?? null;
+  if (!user) {
+    reportAuthTimeoutFallback({
+      flow: params.flow,
+      reason: 'no_session',
+      sessionPresent: false,
+      emailsMatch: false,
+      sessionUserIdLen: 0,
+      attemptedEmailLen: params.attemptedEmail.trim().length,
+    });
+    return { ok: false, reason: 'no_session', error: AUTH_TIMEOUT_FALLBACK_ERROR };
+  }
+
+  if (!sessionEmailMatchesAttempt(user.email, params.attemptedEmail)) {
+    reportAuthTimeoutFallback({
+      flow: params.flow,
+      reason: 'email_mismatch',
+      sessionPresent: true,
+      emailsMatch: false,
+      sessionUserIdLen: user.id.length,
+      attemptedEmailLen: params.attemptedEmail.trim().length,
+      sessionEmailPresent: Boolean(user.email && user.email.trim().length > 0),
+    });
+    return { ok: false, reason: 'email_mismatch', error: AUTH_TIMEOUT_FALLBACK_ERROR };
+  }
+
+  return { ok: true, user };
+}
+
+function reportAuthTimeoutFallback(extra: {
+  flow: AuthTimeoutFlow;
+  reason: 'no_session' | 'email_mismatch';
+  sessionPresent: boolean;
+  emailsMatch: boolean;
+  sessionUserIdLen: number;
+  attemptedEmailLen: number;
+  sessionEmailPresent?: boolean;
+}): void {
+  const message =
+    extra.reason === 'email_mismatch'
+      ? 'auth timeout fallback rejected: session email does not match attempt'
+      : 'auth timeout fallback rejected: no session after timeout';
+
+  // Lengths / booleans only — never emails, passwords, or tokens.
+  const safeExtra = {
+    auth_flow: extra.flow,
+    reason: extra.reason,
+    session_present: extra.sessionPresent,
+    emails_match: extra.emailsMatch,
+    session_user_id_len: extra.sessionUserIdLen,
+    attempted_email_len: extra.attemptedEmailLen,
+    session_email_present: extra.sessionEmailPresent ?? false,
+  };
+
+  console.warn(`[auth] ${message}`, safeExtra);
+
+  // Stale-session mismatch is the silent-false-success failure mode; alert it.
+  // No-session is a normal timeout outcome — warn in console only.
+  if (extra.reason === 'email_mismatch') {
+    Sentry.captureMessage(`[auth] ${message}`, {
+      level: 'error',
+      tags: {
+        auth_alert: 'auth_timeout_stale_session',
+        auth_flow: extra.flow,
+      },
+      extra: safeExtra,
+    });
+  }
+}

--- a/client/src/auth/useAuth.ts
+++ b/client/src/auth/useAuth.ts
@@ -3,6 +3,7 @@ import type { AuthChangeEvent, User } from '@supabase/supabase-js';
 import { getSupabaseConfigError, isSupabaseConfigured, supabase } from '../lib/supabase';
 import { formatAuthErrorMessage } from './authErrors';
 import { getAuthEmailRedirectTo } from './authRedirect';
+import { evaluateAuthTimeoutSessionFallback, AUTH_TIMEOUT_FALLBACK_ERROR } from './authTimeoutSessionFallback';
 import { PASSWORD_RECOVERY_PENDING_KEY } from './recoveryHash';
 import { readE2eDevAuth } from './e2eDevAuth';
 
@@ -559,12 +560,22 @@ export function useAuth() {
             const {
               data: { session },
             } = await withTimeout(supabase.auth.getSession(), 3000);
+            const fallback = evaluateAuthTimeoutSessionFallback({
+              session,
+              attemptedEmail: email,
+              flow: 'sign_up',
+            });
+            if (!fallback.ok) {
+              // Unrelated / missing session: real timeout. Do not clear that session.
+              return { error: fallback.error };
+            }
             if (session?.user) {
               void hydrateProfile(session.user);
               return { error: null };
             }
+            return { error: AUTH_TIMEOUT_FALLBACK_ERROR };
           } catch {
-            // ignore
+            // ignore probe failures; fall through to timeout error
           }
         }
         return { error: err instanceof Error ? err.message : 'Unable to sign up.' };
@@ -602,12 +613,22 @@ export function useAuth() {
             const {
               data: { session },
             } = await withTimeout(supabase.auth.getSession(), 3000);
+            const fallback = evaluateAuthTimeoutSessionFallback({
+              session,
+              attemptedEmail: email,
+              flow: 'sign_in',
+            });
+            if (!fallback.ok) {
+              // Unrelated / missing session: real timeout. Do not clear that session.
+              return { error: fallback.error };
+            }
             if (session?.user) {
               void hydrateProfile(session.user);
               return { error: null };
             }
+            return { error: AUTH_TIMEOUT_FALLBACK_ERROR };
           } catch {
-            // ignore
+            // ignore probe failures; fall through to timeout error
           }
         }
         return { error: err instanceof Error ? err.message : 'Unable to sign in.' };


### PR DESCRIPTION
## Summary
- On `AUTH_REQUEST_TIMEOUT_MS` in `signIn`/`signUp`, the `getSession()` fallback only counts as success when the session user email matches the attempted email (case-insensitive).
- Any other session is left untouched; the attempt returns a real timeout error so the auth modal stays open.
- Stale-session mismatches emit Sentry `auth_alert=auth_timeout_stale_session` with lengths/booleans only (no emails, tokens, or passwords).

## Test plan
- [x] `npm test --prefix client -- src/auth/authTimeoutSessionFallback.test.ts src/auth/AuthModal.timeoutFallback.test.tsx`
- [x] `npm run build --prefix client`
- [ ] Manual: sign in while already signed in as a different account and force a slow/auth timeout → modal stays open with timeout error; other session still intact
- [ ] Manual: normal sign-in still closes the modal on success


Made with [Cursor](https://cursor.com)