### PR TITLE
fix(bot): confirm Fritz Glicko only after ghostResult

### DIFF
--- a/client/src/modules/fritz/fritzRatingDisplayState.test.ts
+++ b/client/src/modules/fritz/fritzRatingDisplayState.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import {
+  deriveFritzRatingDisplayState,
+  resolveFritzProfilePatchRating,
+} from './fritzRatingDisplayState';
+
+const PREDICTION = { glickoRating: 820, glickoDelta: 20 };
+
+describe('deriveFritzRatingDisplayState — confirm only after ghostResult', () => {
+  it('1. prediction alone → confirmed false, syncing true, no profile patch source', () => {
+    const state = deriveFritzRatingDisplayState({
+      isGhostMode: false,
+      ghostResult: null,
+      predictedFritzGlicko: PREDICTION,
+      ghostResultLoading: true,
+      matchStartGlickoRating: 800,
+    });
+
+    expect(state.hasConfirmedFritzRatingUpdate).toBe(false);
+    expect(state.showFritzRatingSyncing).toBe(true);
+    // Prediction may still be exposed for UI, but overlay uses syncing while pending.
+    expect(state.fritzNewGlickoRating).toBe(820);
+    expect(resolveFritzProfilePatchRating(null)).toBeNull();
+  });
+
+  it('2. server ghostResult matching prediction → confirmed true, profile uses server value', () => {
+    const ghostResult = { glickoRating: 820, glickoDelta: 20 };
+    const state = deriveFritzRatingDisplayState({
+      isGhostMode: false,
+      ghostResult,
+      predictedFritzGlicko: PREDICTION,
+      ghostResultLoading: false,
+      matchStartGlickoRating: 800,
+    });
+
+    expect(state.hasConfirmedFritzRatingUpdate).toBe(true);
+    expect(state.showFritzRatingSyncing).toBe(false);
+    expect(state.fritzNewGlickoRating).toBe(820);
+    expect(state.fritzGlickoDelta).toBe(20);
+    expect(resolveFritzProfilePatchRating(ghostResult)).toBe(820);
+  });
+
+  it('3. server ghostResult diverges from prediction → profile + display use server, not prediction', () => {
+    const ghostResult = { glickoRating: 805, glickoDelta: 5 };
+    const state = deriveFritzRatingDisplayState({
+      isGhostMode: false,
+      ghostResult,
+      predictedFritzGlicko: PREDICTION,
+      ghostResultLoading: false,
+      matchStartGlickoRating: 800,
+    });
+
+    expect(state.hasConfirmedFritzRatingUpdate).toBe(true);
+    expect(state.showFritzRatingSyncing).toBe(false);
+    expect(state.fritzNewGlickoRating).toBe(805);
+    expect(state.fritzGlickoDelta).toBe(5);
+    expect(state.fritzNewGlickoRating).not.toBe(PREDICTION.glickoRating);
+    expect(resolveFritzProfilePatchRating(ghostResult)).toBe(805);
+    expect(resolveFritzProfilePatchRating(ghostResult)).not.toBe(PREDICTION.glickoRating);
+  });
+
+  it('loading with no prediction yet is still syncing / unconfirmed', () => {
+    const state = deriveFritzRatingDisplayState({
+      isGhostMode: false,
+      ghostResult: null,
+      predictedFritzGlicko: null,
+      ghostResultLoading: true,
+      matchStartGlickoRating: 800,
+    });
+    expect(state.hasConfirmedFritzRatingUpdate).toBe(false);
+    expect(state.showFritzRatingSyncing).toBe(true);
+  });
+});

--- a/client/src/modules/fritz/fritzRatingDisplayState.ts
+++ b/client/src/modules/fritz/fritzRatingDisplayState.ts
@@ -1,0 +1,86 @@
+import { roundedRatingDelta } from '../ghost/ghostMatchHelpers.ts';
+
+export type FritzRatingPrediction = {
+  glickoRating: number;
+  glickoDelta: number;
+};
+
+export type FritzRatingGhostResult = {
+  glickoRating?: number | null;
+  glickoDelta?: number | null;
+};
+
+export type FritzRatingDisplayState = {
+  fritzGlickoDelta: number | null;
+  fritzNewGlickoRating: number | null;
+  hasConfirmedFritzRatingUpdate: boolean;
+  showFritzRatingSyncing: boolean;
+};
+
+/**
+ * Derive post-game Fritz rating UI fields.
+ *
+ * Prediction is display-only (pending/syncing). Confirmed + profile authority
+ * require a server `ghostResult` — never the client prediction alone.
+ */
+export function deriveFritzRatingDisplayState(input: {
+  isGhostMode: boolean;
+  ghostResult: FritzRatingGhostResult | null;
+  predictedFritzGlicko: FritzRatingPrediction | null;
+  ghostResultLoading: boolean;
+  matchStartGlickoRating: number | null;
+}): FritzRatingDisplayState {
+  const { isGhostMode, ghostResult, predictedFritzGlicko, ghostResultLoading, matchStartGlickoRating } =
+    input;
+
+  if (isGhostMode) {
+    return {
+      fritzGlickoDelta: null,
+      fritzNewGlickoRating: null,
+      hasConfirmedFritzRatingUpdate: false,
+      showFritzRatingSyncing: false,
+    };
+  }
+
+  const hasConfirmedFritzRatingUpdate =
+    ghostResult != null && (ghostResult.glickoRating != null || ghostResult.glickoDelta != null);
+
+  // Pending: waiting on server. Prediction alone never counts as confirmed.
+  const showFritzRatingSyncing =
+    ghostResult == null && (ghostResultLoading || predictedFritzGlicko != null);
+
+  const fritzGlickoDelta =
+    ghostResult?.glickoDelta != null
+      ? roundedRatingDelta(ghostResult.glickoDelta)
+      : hasConfirmedFritzRatingUpdate &&
+          ghostResult?.glickoRating != null &&
+          matchStartGlickoRating != null
+        ? roundedRatingDelta(ghostResult.glickoRating - matchStartGlickoRating)
+        : // Prediction is UI-only while syncing; overlay prefers syncing copy.
+          predictedFritzGlicko != null
+          ? roundedRatingDelta(predictedFritzGlicko.glickoDelta)
+          : null;
+
+  const fritzNewGlickoRating =
+    ghostResult?.glickoRating != null
+      ? Math.round(ghostResult.glickoRating)
+      : predictedFritzGlicko != null
+        ? predictedFritzGlicko.glickoRating
+        : null;
+
+  return {
+    fritzGlickoDelta,
+    fritzNewGlickoRating,
+    hasConfirmedFritzRatingUpdate,
+    showFritzRatingSyncing,
+  };
+}
+
+/** Profile patch rating only from server proof — never from client prediction. */
+export function resolveFritzProfilePatchRating(
+  ghostResult: FritzRatingGhostResult | null,
+): number | null {
+  if (ghostResult?.glickoRating == null) return null;
+  const rating = Number(ghostResult.glickoRating);
+  return Number.isFinite(rating) ? rating : null;
+}

--- a/client/src/modules/fritz/useFritzRatingDisplay.ts
+++ b/client/src/modules/fritz/useFritzRatingDisplay.ts
@@ -1,11 +1,14 @@
 import { useEffect, useMemo } from 'react';
 import { predictFritzGlickoUpdate } from '../../ranking/predictFritzGlickoUpdate.ts';
-import { roundedRatingDelta } from '../ghost/ghostMatchHelpers.ts';
 import { useStandaloneFritzRatingSession } from '../match/hooks/useStandaloneFritzRatingSession.ts';
 import type { BotMatchScreenProps } from '../match/types.ts';
 import type { UseBotMatchBootstrapResult } from '../match/hooks/useBotMatchBootstrap.ts';
 import type { UseGhostRuntimeResult } from '../ghost/useGhostRuntime.ts';
 import type { UseGuidedLessonBootResult } from '../guided/index.ts';
+import {
+  deriveFritzRatingDisplayState,
+  resolveFritzProfilePatchRating,
+} from './fritzRatingDisplayState.ts';
 
 export type UseFritzRatingDisplayArgs = {
   props: BotMatchScreenProps;
@@ -105,33 +108,26 @@ export function useFritzRatingDisplay({
     rankedGamesPlayed,
   ]);
 
+  // Profile patch only after server ghostResult — never from client prediction.
   useEffect(() => {
-    if (!predictedFritzGlicko || !onProfilePatch) return;
-    if (ghostResult?.glickoRating != null) return;
-    onProfilePatch({ glicko_rating: predictedFritzGlicko.glickoRating });
-  }, [ghostResult?.glickoRating, onProfilePatch, predictedFritzGlicko]);
+    if (isGhostMode || !onProfilePatch) return;
+    const rating = resolveFritzProfilePatchRating(ghostResult);
+    if (rating == null) return;
+    onProfilePatch({ glicko_rating: rating });
+  }, [ghostResult, isGhostMode, onProfilePatch]);
 
-  const fritzGlickoDelta =
-    !isGhostMode && ghostResult?.glickoDelta != null
-      ? roundedRatingDelta(ghostResult.glickoDelta)
-      : !isGhostMode && predictedFritzGlicko != null
-        ? roundedRatingDelta(predictedFritzGlicko.glickoDelta)
-      : !isGhostMode && ghostResult?.glickoRating != null && matchStartGlickoRating != null
-        ? roundedRatingDelta(ghostResult.glickoRating - matchStartGlickoRating)
-      : null;
-
-  const fritzNewGlickoRating =
-    !isGhostMode && ghostResult?.glickoRating != null
-      ? Math.round(ghostResult.glickoRating)
-      : !isGhostMode && predictedFritzGlicko != null
-        ? predictedFritzGlicko.glickoRating
-      : null;
-
-  const hasConfirmedFritzRatingUpdate =
-    fritzGlickoDelta != null || (!isGhostMode && (ghostResult != null || predictedFritzGlicko != null));
-
-  const showFritzRatingSyncing =
-    ghostResultLoading && predictedFritzGlicko == null && ghostResult?.glickoRating == null;
+  const {
+    fritzGlickoDelta,
+    fritzNewGlickoRating,
+    hasConfirmedFritzRatingUpdate,
+    showFritzRatingSyncing,
+  } = deriveFritzRatingDisplayState({
+    isGhostMode,
+    ghostResult,
+    predictedFritzGlicko,
+    ghostResultLoading,
+    matchStartGlickoRating,
+  });
 
   return {
     predictedFritzGlicko,


### PR DESCRIPTION
## Summary
- \`hasConfirmedFritzRatingUpdate\` is true only after server \`ghostResult\` (with rating fields), never from client prediction alone.
- \`onProfilePatch\` in \`useFritzRatingDisplay\` runs only with the server \`glickoRating\` — prediction is UI/pending only (\`showFritzRatingSyncing\`).
- When prediction and server diverge, display + profile use the server value.

Out of scope (unchanged): write-order and deal-seed race.

## Test plan
- [x] \`npm test --prefix client -- src/modules/fritz/fritzRatingDisplayState.test.ts\` (prediction-only / match / diverge)
- [x] \`npm test --prefix client -- src/bot src/modules/ghost src/modules/fritz src/ranking\` (62 tests)
- [x] \`npm run build --prefix client\`
- [ ] Manual: finish a ranked Play vs Fritz match → rating shows syncing until complete returns; profile matches server Glicko


Made with [Cursor](https://cursor.com)