### PR TITLE
test(mp): stub the persistence seam in the match-start lock suite

### DIFF
--- a/server/src/multiplayer/matchStartConcurrentLock.test.ts
+++ b/server/src/multiplayer/matchStartConcurrentLock.test.ts
@@ -39,6 +39,13 @@ describe('M3 concurrent match start lock', () => {
       persistRoomMatchLog: async () => undefined,
       onGameOver: () => null,
     });
+    // This suite is about the start lock, not durability. Stub the persistence
+    // seam so the cases exercise locking alone and do not need live Supabase
+    // credentials; case 2 re-spies these to simulate a failed flush.
+    vi.spyOn(livePersistence, 'flushScheduledLiveRoomPersistence').mockResolvedValue({
+      flushedRoomCodes: [],
+    });
+    vi.spyOn(livePersistence, 'isLiveRoomDurablyRecoverable').mockReturnValue(true);
   });
 
   it('1) two concurrent start signals → exactly one deal; second coalesces', async () => {


### PR DESCRIPTION
## Problem

`matchStartConcurrentLock.test.ts` cases 1 and 3 drove the **real** live-room persistence layer, so they only passed where Supabase credentials existed. CI has none, so they failed there while passing on every developer machine.

The failure never involved the locking logic. In `rooms.ts:294`:

```ts
await flushScheduledLiveRoomPersistence(room.code);
if (!isLiveRoomDurablyRecoverable(room)) {
  rollbackRoomLifecycleCommit(room, snapshot);
  throw new RoomLifecyclePersistUncertainError();
}
```

Without credentials the flush fails, the room is not durably recoverable, and `startGameUnlocked` rolls back and throws before any lock assertion runs.

## Fix

Case 2 already stubbed exactly this seam — which is why it was the one case that passed. This hoists the same two healthy stubs into `beforeEach`, so all three cases exercise the start lock they are named for.

Case 2 re-spies both functions to simulate a failed flush, so its rollback coverage is unchanged.

## Verification

With **no** Supabase credentials (a detached worktree, so the untracked `.env` does not follow — CI-like by construction):

| | before (`24822c45`) | after |
|---|---|---|
| server suite | 990 / 992 | **992 / 992** |
| lock suite | 1 / 3 | **3 / 3** |

Also re-run **with** credentials present: 3/3, so local development is unaffected.

## Scope

One file, seven lines, test-only. No production code touched.

Confirmed this was the **only** test in the suite with a live-Supabase dependency: with credentials removed, the other 174 files and 990 tests already passed on `24822c45`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)