### PR TITLE
lint(client): clear the seven warnings over the budget

### DIFF
--- a/client/src/components/OfflineBanner.tsx
+++ b/client/src/components/OfflineBanner.tsx
@@ -33,7 +33,7 @@ export function OfflineBanner({ online }: { online: boolean }) {
         boxShadow: '0 2px 12px rgba(0,0,0,0.4)',
       }}
     >
-      <span>You're offline — reconnect to continue playing.</span>
+      <span>You&apos;re offline — reconnect to continue playing.</span>
       <button
         type="button"
         onClick={() => setDismissed(true)}

--- a/client/src/dailyFritz/DailyFritzLeaderboardScreen.tsx
+++ b/client/src/dailyFritz/DailyFritzLeaderboardScreen.tsx
@@ -336,6 +336,9 @@ export default function DailyFritzLeaderboardScreen({
 
   const resetLabel = useMemo(
     () => formatCountdownHms(secondsUntilNextPacificMidnight(new Date())),
+    // countdownTick is not read here: it is the 1s interval that re-runs this
+    // memo so the impure new Date() is re-read. Dropping it freezes the label.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [countdownTick],
   );
 

--- a/client/src/dailyPuzzle/DailyPuzzleLadderLeaderboardScreen.tsx
+++ b/client/src/dailyPuzzle/DailyPuzzleLadderLeaderboardScreen.tsx
@@ -338,6 +338,9 @@ export default function DailyPuzzleLadderLeaderboardScreen({
 
   const resetLabel = useMemo(
     () => formatCountdownHms(secondsUntilNextPacificMidnight(new Date())),
+    // countdownTick is not read here: it is the 1s interval that re-runs this
+    // memo so the impure new Date() is re-read. Dropping it freezes the label.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [countdownTick],
   );
 
@@ -476,7 +479,7 @@ export default function DailyPuzzleLadderLeaderboardScreen({
                   <span className="rh-hub-tag dflb-eyebrow dflb-eyebrow--ladder">Daily Puzzle Ladder</span>
                   <h1 className="dflb-command__title">Leaderboard</h1>
                   <p className="dflb-command__sub">
-                    Global ranking · Climb five puzzles for today's ladder total.
+                    Global ranking · Climb five puzzles for today&apos;s ladder total.
                   </p>
                 </div>
                 <div className="dflb-command__aside">

--- a/client/src/home/useHomeCommandCenter.ts
+++ b/client/src/home/useHomeCommandCenter.ts
@@ -101,7 +101,7 @@ export function useHomeCommandCenter(tournament: TournamentHookState): HomeComma
     kind: user ? 'authenticated' : 'guest',
     userId: user?.id ?? null,
     displayName: profile?.username ?? user?.email?.split('@')[0] ?? null,
-  }), [profile?.username, user, user?.email]);
+  }), [profile?.username, user]);
   const [model, setModel] = useState(() => createInitialModel(identity, tournament));
 
   useEffect(() => {
@@ -282,6 +282,9 @@ export function useHomeCommandCenter(tournament: TournamentHookState): HomeComma
           });
         });
     } else {
+      // Mirrors the tournament status straight from props; there is nothing to
+      // await, so the update is intentionally synchronous.
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setModel((current) => {
         const updated = {
           ...current,

--- a/client/src/tournament/TournamentHubScreen.tsx
+++ b/client/src/tournament/TournamentHubScreen.tsx
@@ -116,6 +116,9 @@ const TournamentCardStatus = memo(function TournamentCardStatus({
     tickWhileRegistrationOpen ||
     (tickWhileStartSoon && now < startSoonAtMs);
   void needsStatusTick;
+  // now is not read here: statusFor() calls Date.now() internally, so this
+  // dep is what advances the card to "Starting Soon". Dropping it pins status.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   const status = useMemo(() => statusFor(tournament), [tournament, now]);
 
   return <span className={`th-card__status ${status.cls}`}>{status.label}</span>;


### PR DESCRIPTION
## Problem

Client lint reports **zero errors**. It failed only on a budget: `eslint src --max-warnings 401`, with main at **408** warnings. This clears exactly the overage of 7.

## Triage

Three of these looked like one-line dep removals and are **actively dangerous to "fix"**. Each is a `useMemo` dep ESLint reports as unnecessary because the value is not read in the memo body — but each body is impure, and the dep is precisely what re-runs it:

| site | what removing the dep would break |
|---|---|
| `DailyFritzLeaderboardScreen.tsx:339` | `countdownTick` is a 1s interval whose only consumer is this memo (`new Date()`). Removing → the reset countdown freezes. |
| `DailyPuzzleLadderLeaderboardScreen.tsx:341` | identical pattern |
| `TournamentHubScreen.tsx:119` | `statusFor()` calls `Date.now()` internally (line 65). Removing `now` → a card never advances to "Starting Soon". |

These get a **scoped disable with a stated reason**, not a removal.

Genuine fixes:

- `OfflineBanner.tsx` — escape `You're`
- `DailyPuzzleLadderLeaderboardScreen.tsx` — escape `today's`
- `useHomeCommandCenter.ts` — drop `user?.email`; the deps already include the whole `user` object, so it is genuinely subsumed

Plus one deliberate case re-applied: the tournament-sync effect's synchronous `setModel` (originally `719e8ef2`, which never landed with #47).

## Result

408 → **401**, with per-file deltas confined to those five files. 401 does not exceed the existing `--max-warnings 401`, so **`package.json` is unchanged** and the budget is now exact — the next new warning fails CI rather than hiding in slack.

## Verification

- `npm run lint --prefix client` — **exit 0**, `✖ 401 problems (0 errors, 401 warnings)`
- `tsc -b` — clean
- `npx vitest run` from `client/` — **1263/1263** across 183 files

## Not addressed

The remaining 401 are pre-existing debt, untouched here: 130 `no-console`, 89 `react-hooks/refs`, 45 `max-lines`, and 8 `react-hooks/immutability` (render-phase mutation in `useHandLifecycle`, `MultiplayerGameShell`, `useLiveMatchActions`) — that last group needs a design decision, not a quick fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)