### PR TITLE
DO NOT MERGE — CI probe: does E2E fail on unmodified main?

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -27,7 +27,7 @@
     "test:smoke:sockets:stress": "SMOKE_REPEAT=10 node scripts/socketSmoke.mjs",
     "soak:mp-private-authority": "node scripts/mpPrivateAuthoritySoak.mjs",
     "ci:bot": "npm run test:bot && npm run build",
-    "lint": "ESLINT_USE_FLAT_CONFIG=false eslint src --ext .ts,.tsx --max-warnings 401",
+    "lint": "ESLINT_USE_FLAT_CONFIG=false eslint src --ext .ts,.tsx --max-warnings 408",
     "lint:css": "stylelint \"src/**/*.css\"",
     "check:deps": "depcruise src --config .dependency-cruiser.json --output-type text",
     "check:multiplayer-arch": "depcruise src/multiplayer --config .dependency-cruiser.multiplayer-arch.json --output-type err",


### PR DESCRIPTION
**Throwaway diagnostic. Do not merge. I will close and delete this branch once it reports.**

## Why

`Playwright E2E tests` only runs if `Lint TS/JS` passes. Lint has been red on main, so Playwright has been **skipped** there — it last actually executed on `775bd70f` (Aug 20), where it passed.

PR #49 fixes lint, which makes Playwright reachable again, and it fails:
`routing.spec.ts:84 › desktop nav regions keep separate hit targets at common widths`.

So the question is whether #49 *caused* that or merely *unmasked* it.

## What this is

Branched off `24822c45` with exactly one change — `--max-warnings 401` → `408`. **No source files touched.** That lets lint pass so Playwright runs against main's client completely unmodified.

- E2E fails here → pre-existing, unmasked by #49, needs its own issue.
- E2E passes here → #49 genuinely caused it and I need to fix it before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)