### PR TITLE
fix(nav): stop the desktop nav regions overlapping below 1280px

### DIFF
--- a/client/src/components/GlobalNav.tsx
+++ b/client/src/components/GlobalNav.tsx
@@ -168,7 +168,7 @@ export function GlobalNav({
   return (
     <>
     <nav 
-      className={`rh-global-nav relative shrink-0 w-full z-50 h-[56px] ${compactChrome ? 'desk:h-[66px]' : 'desk:h-[78px]'}`}
+      className={`rh-global-nav relative shrink-0 w-full z-50 h-[56px] ${compactChrome ? 'rh-nav--compact desk:h-[66px]' : 'desk:h-[78px]'}`}
       style={{
         boxSizing: 'border-box',
         overflow: 'visible',
@@ -253,12 +253,11 @@ export function GlobalNav({
                   <button
                     key={tab.label}
                     onClick={() => onNavigate?.(tab.mode)}
-                    className="relative py-2 transition-all"
+                    className="rh-nav-tab relative py-2 transition-all"
                     style={{
-                      // Sized against the nav's other display type (the
-                      // wordmark is 900, the date 800) — at 600/17px the tabs
-                      // read as secondary chrome rather than primary nav.
-                      fontSize: compactChrome ? '18px' : '20px',
+                      // font-size lives in rh-mobile-chrome.css (.rh-nav-tab):
+                      // an inline value cannot be narrowed by a media query,
+                      // and the tabs must shrink on a narrow desktop row.
                       fontWeight: 700,
                       letterSpacing: '0.01em',
                       color: textColor,

--- a/client/src/styles/rh-mobile-chrome.css
+++ b/client/src/styles/rh-mobile-chrome.css
@@ -261,3 +261,103 @@
     padding-bottom: 0;
   }
 }
+
+/* Tab type. Lives here, not inline, so the narrow-desktop bands below can
+ * shrink it — sized against the nav's other display type (wordmark 900,
+ * date 800) so the tabs read as secondary chrome, not primary nav. */
+.rh-nav-tab {
+  font-size: 20px;
+}
+
+.rh-nav--compact .rh-nav-tab {
+  font-size: 18px;
+}
+
+/* ── Narrow desktop: 769px–1279px ───────────────────────────────────
+ *
+ * The desktop nav is a 3-column grid, `minmax(0,1fr) auto minmax(0,1fr)`,
+ * which centers the tabs by forcing both side columns to equal width. The
+ * brand needs ~220px and the stats ~327px, so below 1280px the symmetry
+ * sizes both columns under what the stats require. `.rh-nav-stats` cannot
+ * shrink (fixed icons, values, avatar) and `justify-self: end` pins its
+ * right edge, so the overflow spilled leftward across the center column and
+ * swallowed the tab hit targets — at 769px stats ran 434→745 while the tabs
+ * ended at 654.
+ *
+ * Below 1280px there is not enough room for symmetric columns, so use the
+ * flex row the phone layer already uses: items sit in sequence and cannot
+ * overlap. Spacing is then tightened until the row genuinely fits, because
+ * a row that merely stops overlapping while running off-screen is not fixed.
+ *
+ * The `.rh-global-nav` prefixes are load-bearing: Tailwind's px-5/pl-5/gap-4
+ * utilities carry the same specificity as a bare class here and are emitted
+ * later, so an unprefixed rule silently loses.
+ */
+@media (min-width: 769px) and (max-width: 1279px) and (min-height: 600px) {
+  .rh-global-nav .rh-nav-inner {
+    display: flex;
+    justify-content: space-between;
+  }
+
+  .rh-global-nav .rh-nav-center-desktop {
+    width: auto;
+    flex: 0 1 auto;
+    min-width: 0;
+  }
+
+  .rh-global-nav .rh-nav-brand {
+    flex: 0 1 auto;
+    min-width: 0;
+  }
+
+  .rh-global-nav .rh-nav-center-desktop > div {
+    gap: 18px;
+  }
+
+  .rh-global-nav .rh-nav-stat-block {
+    padding: 10px 8px;
+    gap: 8px;
+  }
+
+  .rh-global-nav .rh-nav-user-block {
+    padding-left: 8px;
+    gap: 10px;
+  }
+}
+
+/* Below 1024px the tabs and stats alone need the whole row: the wordmark
+ * yields to the logo mark, and the tabs drop to their secondary size. */
+@media (min-width: 769px) and (max-width: 1023px) and (min-height: 600px) {
+  .rh-global-nav .rh-nav-inner {
+    padding-left: 10px;
+    padding-right: 10px;
+  }
+
+  .rh-nav-wordmark {
+    display: none;
+  }
+
+  /* Never let the row's deficit collapse the logo itself. */
+  .rh-global-nav .rh-nav-brand {
+    flex: 0 0 auto;
+  }
+
+  .rh-global-nav .rh-nav-center-desktop > div {
+    gap: 10px;
+  }
+
+  .rh-nav-tab,
+  .rh-nav--compact .rh-nav-tab {
+    font-size: 14px;
+  }
+
+  .rh-global-nav .rh-nav-stat-block {
+    padding: 8px 6px;
+    gap: 6px;
+  }
+
+  .rh-global-nav .rh-nav-user-block {
+    padding-left: 6px;
+    gap: 8px;
+  }
+}


### PR DESCRIPTION
Fixes the `routing.spec.ts` failure that has been blocking `Client Validation` since the lint budget was cleared. That E2E step only runs when lint passes, so it had been `skipped` on main since Aug 20 — PR #49 made it reachable again and this is the bug it exposed. Confirmed pre-existing via a control run on unmodified main (closed PR #50).

## Root cause

The desktop nav is a 3-column grid:

```
minmax(0,1fr) auto minmax(0,1fr)
```

The tabs are centered by forcing both side columns to equal width. But the brand needs ~220px and the stats ~327px, so below 1280px the symmetry sizes **both** columns under what the stats require. `.rh-nav-stats` cannot shrink — fixed icons, values, avatar — and `justify-self: end` pins its right edge, so the excess spills **leftward** across the center column and swallows the tab hit targets.

Measured at 769px before the fix:

| region | column | element |
|---|---|---|
| brand | 75px | 24→99 (fits, truncates) |
| center | 540px | 115→654 (fits) |
| **stats** | **75px** | **434→745** — 312px of content, spilling 237px left |

Failed at 769 and 1024; 1280 and 1440 genuinely fit.

## Fix

Below 1280px, use the flex row the phone layer already uses — items sit in sequence and cannot overlap — then tighten spacing until the row genuinely fits. A row that stops overlapping while running off-screen is not fixed, so the pass also checks nothing exceeds the viewport and the brand never collapses. Below 1024px the wordmark yields to the logo mark and the tabs drop to their secondary size.

Two things worth calling out for review:

- **Tab `font-size` moved from an inline style to `.rh-nav-tab`.** An inline value cannot be narrowed by a media query, and the tabs must shrink on a narrow row. A `rh-nav--compact` modifier preserves the existing 18/20px split.
- **The `.rh-global-nav` prefixes are load-bearing.** Tailwind's `px-5`/`pl-5`/`gap-4` carry the same specificity as a bare class and are emitted later, so unprefixed rules silently lose — the pre-existing `.rh-nav-stat-block { padding: 10px 20px }` in the desktop layer has never actually applied.

## Verification

Geometry measured at 769 / 900 / 1024 / 1100 / 1280 / 1440 — no overlap, brand visible, nothing past the viewport:

```
769:  brand 10-70   center 92-451   stats 474-759   ok
900:  brand 10-70   center 158-517  stats 605-890   ok
1024: brand 24-213  center 228-683  stats 699-1000  ok
1100: brand 24-235  center 251-759  stats 775-1076  ok
1280: brand 24-243  center 370-910  stats 929-1256  ok
1440: brand 24-243  center 450-990  stats 1089-1416 ok
```

- `routing.spec.ts` — **21/21**, including the previously failing nav test
- Client tests — **1263/1263**; `tsc -b` clean; stylelint clean
- Lint holds at **exactly 401**, so the budget from #49 stays exact

## Note on the remaining E2E failures

A full local E2E run also fails `daily-fritz-server-restore`, `journey-premium-open-end-discipline` and `multiplayer-in-match-reconnect`. I ran those three **without** this change as a control and they fail identically (one on a different test in the same spec, so it is flaky). They are environmental to a local run — my client was pointed at an already-running backend rather than a fresh build — and unrelated to nav CSS. CI will be the real check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)