### PR TITLE
feat(rush): open Puzzle Rush at 2:00 instead of 1:30

### DIFF
--- a/client/src/puzzleRush/PuzzleRushScreen.tsx
+++ b/client/src/puzzleRush/PuzzleRushScreen.tsx
@@ -114,7 +114,7 @@ export function PuzzleRushScreen({ onBack, muted = false, onNavigate }: PuzzleRu
         streakDays: today?.streakDays ?? 0,
         playedToday: today?.playedToday ?? false,
         stages: FALLBACK_STAGES,
-        baseSeconds: 90,
+        baseSeconds: 120,
         startPending: phase === 'starting',
         error,
       }}

--- a/server/src/puzzleRush/config.ts
+++ b/server/src/puzzleRush/config.ts
@@ -107,10 +107,10 @@ export type PuzzleRushConfig = {
 };
 
 export const PUZZLE_RUSH_CONFIG: PuzzleRushConfig = {
-  version: 2,
+  version: 3,
 
   clock: {
-    baseSeconds: 90,
+    baseSeconds: 120,
     maxSeconds: 300,
     minBonusSeconds: 1,
     maxBonusSeconds: 5,


### PR DESCRIPTION
90 seconds reads as rushed rather than brisk. Base clock goes to **120s**.

## Changes

| value | before | after |
|---|---|---|
| `clock.baseSeconds` | 90 | **120** |
| `config.version` | 2 | **3** |
| client fallback `baseSeconds` | 90 | **120** |

The banked-time ceiling (`maxSeconds: 300`) and the bonus range (1–5s per solve) are unchanged, so a strong run still earns its way toward the cap — just from a calmer start.

## Why the version bump

`config.ts` states the rule itself:

> Bump `version` whenever a value changes: every run records the `config_version` it was played under, so a leaderboard can be filtered to comparable runs after a re-tune instead of silently mixing eras.

A third more starting time makes v2 scores incomparable with v3, so they should not share a board silently. `puzzleRushStore` already stamps `PUZZLE_RUSH_CONFIG.version` onto each run, so this flows through without further changes.

Worth knowing: **existing leaderboards will now be split by era.** If you would rather old runs stayed mixed in, say so and I will drop the bump — but the file's own policy says otherwise.

## No copy changes needed

The hub badge renders `{baseSeconds}s to start. Solve well, bank more.` dynamically, so it follows automatically. I searched for hardcoded `1:30` / `90 second` strings and found none.

## Verification

- Server suite — **992/992** (`puzzleRush`, `puzzleRushStore`, routes: 72/72)
- Client suite — **1263/1263** (`puzzleRush`: 32/32); `tsc -b` clean

Anti-cheat needs no adjustment: `durationGraceSeconds` (10) and `maxRunWallClockSeconds` (1800) both derive from or comfortably exceed the new clock, and the server test asserts against `baseSeconds + durationGraceSeconds` rather than a literal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)