### PR TITLE
fix(ghost): send the recorded placement side in the ranked move log

### DIFF
--- a/client/src/modules/ghost/ghostMatchHelpers.test.ts
+++ b/client/src/modules/ghost/ghostMatchHelpers.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import { simulatePlacement } from '@racehorse/game-core';
+import { snapshotBoardState, cloneBoardState, type MoveEntry } from '../../game/moveLogger.ts';
+import type { BoardState } from '../../types.ts';
+import { moveEntriesToGhostMoveLog } from './ghostMatchHelpers.ts';
+
+/**
+ * The match runtime snapshots the board BEFORE applying the move
+ * (collectPlayerMoveSnapshot -> applyPlayMove in usePlayerPlacementHandler.ts),
+ * so MoveEntry.boardState never contains the tile that MoveEntry.position
+ * describes. moveEntriesToGhostMoveLog must therefore use MoveEntry.position.
+ */
+function buildEntry(
+  boardBefore: BoardState | null,
+  tile: [number, number],
+  position: 'left' | 'right',
+): MoveEntry {
+  return {
+    moveNumber: 2,
+    handNumber: 1,
+    player: 'you',
+    action: 'place',
+    tile,
+    position,
+    boardEnds: [boardBefore?.leftEnd ?? -1, boardBefore?.rightEnd ?? -1],
+    handBefore: [tile],
+    validMoves: [tile],
+    pipDelta: tile[0] + tile[1],
+    pointsScored: 0,
+    boardState: snapshotBoardState(boardBefore as never),
+    boardRenderState: cloneBoardState(boardBefore as never),
+    handSnapshot: [tile],
+    engineBestMove: null,
+  };
+}
+
+describe('moveEntriesToGhostMoveLog — placement side fidelity', () => {
+  it('keeps a right-end placement labelled right (non-double)', () => {
+    // Board: [2|3] opened, left=2 right=3. Player plays [1|3] on the RIGHT.
+    const board = simulatePlacement(null, { low: 2, high: 3 }, 'left') as unknown as BoardState;
+    expect([board.leftEnd, board.rightEnd]).toEqual([2, 3]);
+
+    const [entry] = moveEntriesToGhostMoveLog([buildEntry(board, [1, 3], 'right')]);
+    expect(entry.branch).toBe('right');
+  });
+
+  it('keeps a right-end double placement labelled right', () => {
+    // Board: [6|5], left=6 right=5. Player plays the double [5|5] on the RIGHT.
+    const board = simulatePlacement(null, { low: 5, high: 6 }, 'left') as unknown as BoardState;
+    const board2 = simulatePlacement(
+      board as never,
+      { low: 5, high: 6 },
+      'left',
+    ) as unknown as BoardState;
+    void board2;
+
+    const [entry] = moveEntriesToGhostMoveLog([buildEntry(board, [5, 5], 'right')]);
+    expect(entry.branch).toBe('right');
+  });
+
+  it('keeps a branch placement labelled with its branch position', () => {
+    const board = simulatePlacement(null, { low: 5, high: 5 }, 'left') as unknown as BoardState;
+    const entry = buildEntry(board, [3, 5], 'left');
+    (entry as { position: string }).position = 'branch-1-0';
+    const [converted] = moveEntriesToGhostMoveLog([entry]);
+    expect(converted.branch).toBe('branch-1-0');
+  });
+});

--- a/client/src/modules/ghost/ghostMatchHelpers.ts
+++ b/client/src/modules/ghost/ghostMatchHelpers.ts
@@ -21,13 +21,39 @@ export function formatRatingDelta(value: number): string {
   return `${value > 0 ? '+' : ''}${value}`;
 }
 
+/**
+ * The placement side a move was actually played on.
+ *
+ * `MoveEntry.position` is the authoritative value: the runtime records it from
+ * the move it hands to `applyPlayMove`. `MoveEntry.boardState` is snapshotted
+ * BEFORE the move is applied (see `collectPlayerMoveSnapshot` in
+ * usePlayerPlacementHandler.ts / useBotTurn), so it never contains the tile that
+ * was just played — reconstructing the side from it silently degraded every
+ * placement to 'left' and made the server's ranked replay reject the match with
+ * "Illegal move: [a|b] on left does not match the board (...)".
+ */
+function placementBranchForEntry(entry: MoveEntry): string | null {
+  if (entry.action === 'draw') return 'draw';
+  if (entry.action === 'pass') return 'pass';
+  if (entry.action !== 'place' || !entry.tile) return null;
+  if (entry.position) return entry.position;
+  // Legacy entries with no recorded position: keep the old lookup so their
+  // behaviour is unchanged. It resolves only if the pre-move snapshot happens
+  // to contain the tile, which is why it degraded to 'left' in the first place.
+  return (
+    entry.boardState.find(
+      (s) => s.tile[0] === entry.tile![0] && s.tile[1] === entry.tile![1],
+    )?.position ?? 'left'
+  );
+}
+
 export function moveEntriesToGhostMoveLog(entries: MoveEntry[]): GhostMoveLogEntry[] {
   return entries.map((entry) => ({
     turn: entry.moveNumber,
     actor: entry.player === 'you' ? 'you' : 'ghost',
     board_state: serializeGhostBoardState(entry.boardRenderState),
     tile_played: entry.action === 'place' && entry.tile ? `${entry.tile[0]}|${entry.tile[1]}` : null,
-    branch: entry.action === 'draw' ? 'draw' : entry.action === 'pass' ? 'pass' : entry.action === 'place' && entry.tile ? (entry.boardState.find(s => s.tile[0] === entry.tile![0] && s.tile[1] === entry.tile![1])?.position ?? 'left') : null,
+    branch: placementBranchForEntry(entry),
     hand_before: entry.handBefore.map(([low, high]) => `${low}|${high}`),
     score_delta: entry.pointsScored,
   }));


### PR DESCRIPTION
Fixes the production Sentry issue **NODE-EXPRESS-7** (high priority, first seen 2026-08-21):

```
Error: Illegal move: [5|5] on left does not match the board (left=6, right=5).
Error: Illegal move: [1|3] on left does not match the board (left=2, right=3).
```

## Root cause

`moveEntriesToGhostMoveLog` reconstructed each placement's side by looking the played tile up in `entry.boardState`:

```ts
entry.boardState.find(s => s.tile[0] === entry.tile![0] && s.tile[1] === entry.tile![1])?.position ?? 'left'
```

That snapshot is taken **before** the move is applied — `collectPlayerMoveSnapshot` at `usePlayerPlacementHandler.ts:160`, `applyPlayMove` at `:161`. The lookup therefore *never* matches the tile just played, and the `?? 'left'` fallback fires for **every** placement.

The server replays a log claiming every tile went on the left end, and the first play that actually belonged on the right throws. That is the observed signature: in both Sentry events the tile matches the board's **right** end while being submitted as **left**. It isn't a mirrored board or a convention mismatch — it's a constant collapse to `'left'`, so only plays that happen to be legal on the left survive.

Path to the 409: `routes/ghost.ts:246` → `replayRankedMoveLog` → `rankedDealAuthority.ts:306` `applyMove` → `engine.ts:607` throws → `ghost.ts:247-253` returns 409 with the raw engine string.

`[5|5]` and `[1|3]` fail through the identical line — doubles are not a separate path; their special orientation handling is downstream of the rejection.

## Fix

Use `entry.position`, which the runtime already records from the move it hands to `applyPlayMove`. The old lookup remains as a fallback for legacy entries carrying no position, so their behaviour is unchanged.

## Impact

Ratings and leaderboards are **not corrupted** — `applyGlicko` is only set after a successful replay, and the 409 returns before `completeGhostGame`. The damage is silent loss:

- the verified match is never marked `completed`,
- `bot_match_pending` is never resolved,
- the player's result and rating change are dropped,
- and the raw engine string is rendered in the results UI.

Scope is ranked/standalone Fritz completions, which send the generic log. **Daily Fritz is unaffected** — `useGhostMatchCompletion` returns early for it and uses a separate transcript path. Ghost mode proper sends `ghostMoveLog`, which records positions correctly, and only falls through when that log is empty. `moveEntriesToGhostMoveLog` has exactly one caller.

Latent, deliberately untouched: `snapshotBoardState` labels mainline tiles by array index rather than the side played (`moveLogger.ts:77-82`) — off this path once `position` is used. `hand_number` is still omitted, since setting it would newly activate `verifyPlayerMoveLog`'s hand-continuity checks.

## Verification

- **New test reproduces the bug**: 3/3 failed before the fix with `expected 'left' to be 'right'` — the exact production signature — and pass after. Cases are built the way the runtime builds a `MoveEntry` (pre-move `snapshotBoardState`, real `simulatePlacement` boards) and cover a non-double right-end play, a double (`[5|5]`), and a branch play.
- Client suite **1266/1266** (184 files), `tsc -b` clean, lint holds at **exactly 401**
- Server suite **992/992** with no Supabase credentials (CI-like)

**Not verified:** that a full real ranked Fritz match now replays clean end-to-end — that needs a live or seeded match. Once this deploys, replays will get *further* into the log than they ever have in production, so previously-masked divergences (turn ownership, draw handling, hand-2 deals) could surface as different `replayRankedMoveLog` reasons. Worth watching Sentry after release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)