### PR TITLE
fix(daily-fritz): stop one unverified hand poisoning the rest of the run

### DIFF
--- a/server/src/http/routes/dailyFritzNextHandRoute.ts
+++ b/server/src/http/routes/dailyFritzNextHandRoute.ts
@@ -414,6 +414,8 @@ export function registerDailyFritzNextHandRoute(app: Application): void {
             gameNumber,
             handIndex: completedHandIndex,
             verifierCode: verificationError!.code,
+            playerScoreAfter: progressScores.you,
+            fritzScoreAfter: progressScores.fritz,
           });
         }
         attempt.result = writeActiveGameProgress(attempt.result, {
@@ -454,6 +456,8 @@ export function registerDailyFritzNextHandRoute(app: Application): void {
         gameNumber,
         handIndex: completedHandIndex,
         verifierCode: verificationError!.code,
+        playerScoreAfter: progressScores.you,
+        fritzScoreAfter: progressScores.fritz,
       });
     }
     attempt.result = writeActiveGameProgress(attempt.result, {

--- a/server/src/http/routes/dailyFritzUnverifiedHandCascade.test.ts
+++ b/server/src/http/routes/dailyFritzUnverifiedHandCascade.test.ts
@@ -1,0 +1,134 @@
+/**
+ * One unverified hand used to poison every later hand of the run.
+ *
+ * writeUnverifiedDailyFritzHand deliberately leaves the authority ledger
+ * untouched, and resolveHandStartScoresForVerification required every prior
+ * hand to be IN that ledger. So after any hand advanced without a receipt,
+ * the next hand threw missing_hand_start_progress — an infrastructure code,
+ * which does not never-strand, so the player saw an error at the End of Hand
+ * modal, retried, advanced unverified again, and created the next gap.
+ * The run failed at every remaining hand boundary.
+ *
+ * The attempt is already `verification_status: 'rejected'` at that point and
+ * that is sticky, so refusing later hands bought no integrity at all.
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@sentry/node', () => ({
+  captureMessage: vi.fn(),
+  captureException: vi.fn(),
+}));
+
+import {
+  findUnverifiedHand,
+  resolveHandStartScoresForVerification,
+  writeUnverifiedDailyFritzHand,
+} from './dailyFritzVerificationGlue';
+
+/** A ledger holding one verified hand, without needing a real transcript. */
+function ledgerWithVerifiedHand(handIndex: number, you: number, fritz: number) {
+  return {
+    authority: {
+      version: 1,
+      hands: [
+        {
+          gameNumber: 1,
+          handIndex,
+          playerScoreAfter: you,
+          fritzScoreAfter: fritz,
+        },
+      ],
+      games: [],
+    },
+  } as Record<string, unknown>;
+}
+
+describe('unverified hand does not poison the rest of the run', () => {
+  it('records the post-hand scores alongside the unverified hand', () => {
+    const result = writeUnverifiedDailyFritzHand(null, {
+      gameNumber: 1,
+      handIndex: 0,
+      verifierCode: 'incomplete_transcript',
+      playerScoreAfter: 7,
+      fritzScoreAfter: 3,
+    });
+
+    expect(result.verification_status).toBe('rejected');
+    const found = findUnverifiedHand(result, 1, 0);
+    expect(found).toMatchObject({ playerScoreAfter: 7, fritzScoreAfter: 3 });
+  });
+
+  it('keeps it OUT of the authority ledger, so nothing reads it as verified', () => {
+    const result = writeUnverifiedDailyFritzHand(null, {
+      gameNumber: 1,
+      handIndex: 0,
+      verifierCode: 'incomplete_transcript',
+      playerScoreAfter: 7,
+      fritzScoreAfter: 3,
+    });
+    expect(result.authority).toBeUndefined();
+  });
+
+  it('the NEXT hand still resolves, using the recorded scores', () => {
+    // Hand 0 advanced without a receipt — the exact production shape.
+    const result = writeUnverifiedDailyFritzHand(null, {
+      gameNumber: 1,
+      handIndex: 0,
+      verifierCode: 'incomplete_transcript',
+      playerScoreAfter: 7,
+      fritzScoreAfter: 3,
+    });
+
+    // Before the fix this threw missing_hand_start_progress.
+    const scores = resolveHandStartScoresForVerification({ result, gameNumber: 1, handIndex: 1 });
+    expect(scores).toEqual({ gameNumber: 1, you: 7, fritz: 3 });
+  });
+
+  it('a verified hand is still preferred over an unverified one', () => {
+    const base = ledgerWithVerifiedHand(0, 11, 4);
+    const result = writeUnverifiedDailyFritzHand(base, {
+      gameNumber: 1,
+      handIndex: 0,
+      verifierCode: 'incomplete_transcript',
+      playerScoreAfter: 999,
+      fritzScoreAfter: 999,
+    });
+
+    const scores = resolveHandStartScoresForVerification({ result, gameNumber: 1, handIndex: 1 });
+    expect(scores).toEqual({ gameNumber: 1, you: 11, fritz: 4 });
+  });
+
+  it('mixed chain: verified hand 0, unverified hand 1, hand 2 still resolves', () => {
+    const base = ledgerWithVerifiedHand(0, 5, 2);
+    const result = writeUnverifiedDailyFritzHand(base, {
+      gameNumber: 1,
+      handIndex: 1,
+      verifierCode: 'fritz_state_mismatch',
+      playerScoreAfter: 9,
+      fritzScoreAfter: 6,
+    });
+
+    const scores = resolveHandStartScoresForVerification({ result, gameNumber: 1, handIndex: 2 });
+    expect(scores).toEqual({ gameNumber: 1, you: 9, fritz: 6 });
+  });
+
+  it('a genuinely absent hand still fails closed', () => {
+    // Nothing recorded for hand 0 at all — a real gap, not a known one.
+    expect(() =>
+      resolveHandStartScoresForVerification({ result: {}, gameNumber: 1, handIndex: 1 }),
+    ).toThrow(/hand-start scores/i);
+  });
+
+  it('an unverified record without scores still fails closed', () => {
+    // Pre-existing rows carry no scores and cannot seed the chain.
+    const result = {
+      unverified_hands: [
+        { game_number: 1, hand_index: 0, verifier_code: 'incomplete_transcript' },
+      ],
+    } as Record<string, unknown>;
+
+    expect(() =>
+      resolveHandStartScoresForVerification({ result, gameNumber: 1, handIndex: 1 }),
+    ).toThrow(/hand-start scores/i);
+  });
+});

--- a/server/src/http/routes/dailyFritzVerificationGlue.ts
+++ b/server/src/http/routes/dailyFritzVerificationGlue.ts
@@ -100,7 +100,19 @@ export function canNeverStrandDailyFritzVerification(input: {
  */
 export function writeUnverifiedDailyFritzHand(
   result: Record<string, unknown> | null,
-  input: { gameNumber: DailyFritzSetGameNumber; handIndex: number; verifierCode: string },
+  input: {
+    gameNumber: DailyFritzSetGameNumber;
+    handIndex: number;
+    verifierCode: string;
+    /**
+     * Scores after this hand, as reported. NOT authoritative — the attempt is
+     * already `rejected` — but they keep the hand-start chain continuous for
+     * every later hand. Without them, one unverified hand made every
+     * subsequent hand fail with missing_hand_start_progress.
+     */
+    playerScoreAfter?: number;
+    fritzScoreAfter?: number;
+  },
 ): Record<string, unknown> {
   const previous = result ?? {};
   const existing = Array.isArray(previous.unverified_hands) ? previous.unverified_hands : [];
@@ -114,9 +126,50 @@ export function writeUnverifiedDailyFritzHand(
         hand_index: input.handIndex,
         verifier_code: input.verifierCode,
         recorded_at: new Date().toISOString(),
+        ...(Number.isFinite(input.playerScoreAfter) && Number.isFinite(input.fritzScoreAfter)
+          ? { player_score_after: input.playerScoreAfter, fritz_score_after: input.fritzScoreAfter }
+          : {}),
       },
     ],
   };
+}
+
+/**
+ * A hand recorded as advanced-without-receipt. Deliberately NOT in the
+ * authority ledger: `readAuthorityLedger().hands` is typed as verified
+ * records, and anything reading it must keep treating every entry as
+ * authoritative. This is the parallel, explicitly-unverified record.
+ */
+export type UnverifiedDailyFritzHandRecord = {
+  gameNumber: number;
+  handIndex: number;
+  verifierCode: string;
+  playerScoreAfter: number | null;
+  fritzScoreAfter: number | null;
+};
+
+export function findUnverifiedHand(
+  result: Record<string, unknown> | null,
+  gameNumber: DailyFritzSetGameNumber,
+  handIndex: number,
+): UnverifiedDailyFritzHandRecord | null {
+  const rows = result?.unverified_hands;
+  if (!Array.isArray(rows)) return null;
+  for (const row of rows) {
+    if (!row || typeof row !== 'object') continue;
+    const rec = row as Record<string, unknown>;
+    if (Number(rec.game_number) !== gameNumber || Number(rec.hand_index) !== handIndex) continue;
+    const you = Number(rec.player_score_after);
+    const fritz = Number(rec.fritz_score_after);
+    return {
+      gameNumber,
+      handIndex,
+      verifierCode: String(rec.verifier_code ?? 'unknown'),
+      playerScoreAfter: Number.isFinite(you) ? Math.round(you) : null,
+      fritzScoreAfter: Number.isFinite(fritz) ? Math.round(fritz) : null,
+    };
+  }
+  return null;
 }
 
 export async function recordDailyFritzEventBestEffort(event: DailyFritzEventInput): Promise<void> {
@@ -280,8 +333,13 @@ export const DAILY_FRITZ_INFRASTRUCTURE_VERIFIER_CODES = new Set([
  * source of truth; `active_game` is UI/progress bookkeeping and can be wiped
  * (e.g. by `buildRecordedDailyFritzAttemptResult`).
  *
- * Requires a contiguous verified chain for this game: hands 0..N-1 must all
- * be present before hand N can replay. No fallback to an earlier hand.
+ * Requires a contiguous chain for this game: hands 0..N-1 must all be
+ * accounted for before hand N can replay. A hand counts as accounted for if
+ * it is verified, or if it is explicitly recorded as advanced-without-receipt
+ * — the attempt is already `rejected` in that case, so refusing later hands
+ * buys no integrity and only strands the player.
+ *
+ * A prior hand that is neither is a genuine gap and still fails closed.
  */
 export function resolveHandStartScoresForVerification(input: {
   result: Record<string, unknown> | null;
@@ -294,20 +352,35 @@ export function resolveHandStartScoresForVerification(input: {
   }
 
   for (let priorIndex = 0; priorIndex < handIndex; priorIndex += 1) {
-    if (!findVerifiedHand(result, gameNumber, priorIndex)) {
-      throwMissingHandStartProgress({
-        gameNumber,
-        handIndex,
-        missingPriorHandIndex: priorIndex,
-      });
+    if (findVerifiedHand(result, gameNumber, priorIndex)) continue;
+    const unverified = findUnverifiedHand(result, gameNumber, priorIndex);
+    // Recorded but score-less (pre-existing rows, or a writer that had no
+    // scores to hand over) cannot seed the chain, so treat it as a real gap.
+    if (unverified && unverified.playerScoreAfter != null && unverified.fritzScoreAfter != null) {
+      continue;
     }
+    throwMissingHandStartProgress({
+      gameNumber,
+      handIndex,
+      missingPriorHandIndex: priorIndex,
+    });
   }
 
-  const immediatePrior = findVerifiedHand(result, gameNumber, handIndex - 1)!;
+  const immediatePrior = findVerifiedHand(result, gameNumber, handIndex - 1);
+  if (immediatePrior) {
+    return {
+      gameNumber,
+      you: immediatePrior.playerScoreAfter,
+      fritz: immediatePrior.fritzScoreAfter,
+    };
+  }
+
+  // Loop above guarantees this exists with finite scores.
+  const priorUnverified = findUnverifiedHand(result, gameNumber, handIndex - 1)!;
   return {
     gameNumber,
-    you: immediatePrior.playerScoreAfter,
-    fritz: immediatePrior.fritzScoreAfter,
+    you: priorUnverified.playerScoreAfter!,
+    fritz: priorUnverified.fritzScoreAfter!,
   };
 }
 


### PR DESCRIPTION
This is the cause of the recurring "saving progress" errors, and why they **always** appear at the End of Hand modal. It's a cascade, not a daily flake.

## The chain

1. A hand advances without a receipt for any transient reason. `writeUnverifiedDailyFritzHand` records it and sets `verification_status: 'rejected'` — but, per its own comment, *"The authority ledger is deliberately left untouched."*
2. The next hand calls `resolveHandStartScoresForVerification`, which requires every prior hand to be in that ledger — `findVerifiedHand` reads only `readAuthorityLedger().hands`.
3. Gap → `throwMissingHandStartProgress` → 409.
4. That code is classified **infrastructure**, so `canNeverStrandDailyFritzVerification` refuses to auto-recover. The player sees the error, retries twice, and the hand advances unverified.
5. Which creates the next gap. **Every remaining hand boundary of the run fails.**

One transient hiccup poisons the whole session.

## Why refusing bought nothing

By step 4 the attempt is already `verification_status: 'rejected'`, and that is **sticky** — no later hand can promote it back to verified, and `isDailyFritzAttemptLeaderboardEligible` admits only `'verified'`. So failing every subsequent hand gained zero integrity. It charged the player repeatedly for a decision that was already final.

## Fix

A gap in the ledger meant two different things — *"never played"* and *"played but unverifiable"*. That ambiguity is the actual design flaw.

Unverified hands now carry their post-hand scores, and the chain treats a hand as accounted for if it is verified **or** explicitly recorded as advanced-without-receipt. Strictness is kept exactly where it still matters:

- a prior hand that is **neither** verified nor recorded is a genuine gap and still fails closed
- a recorded row **without scores** cannot seed the chain and still fails closed
- a verified record is always preferred over an unverified one
- the attempt stays `rejected`, ops still gets the Sentry alert and the `unverified_hands` row for review

**Unverified hands stay OUT of the authority ledger.** `readAuthorityLedger().hands` is typed as verified records and every reader treats entries as authoritative — putting them there is precisely how an unverified hand gets mistaken for a verified one. They live in a parallel record, so the ledger keeps meaning what it meant.

Only the two next-hand call sites pass scores. `record-game` handles a game's terminal hand, and the next game restarts at `handIndex 0`, which short-circuits to `{0,0}` — no chain crosses games.

## Verification

- 7 new tests covering the cascade, the mixed chain, verified-wins-over-unverified, and both fail-closed cases
- **Verified by mutation**: reverting the resolver fails the two cascade tests with `missing_hand_start_progress` — the production code
- Server suite **999/999**, typecheck clean

## Scope

This stops the cascade. It does **not** stop the *first* error from being visible — that is step 3 of the plan (invert the recovery default so infrastructure failures never surface, and reconcile the stall watchdog with the failure policy, which is what produced "loading automatically" next to a Retry button). Worth doing next, but this is the change that turns a ruined run into a single blip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)