### PR TITLE
fix(daily-fritz): retry the first next-hand failure silently

### DIFF
--- a/client/src/dailyFritz/dailyFritzNextHandFailurePolicy.test.ts
+++ b/client/src/dailyFritz/dailyFritzNextHandFailurePolicy.test.ts
@@ -25,17 +25,21 @@ describe('resolveDailyFritzCompletedHandNextHandFailure', () => {
     }
   });
 
-  it('shows a calm Continue message before the fallback threshold', () => {
+  it('retries silently before the fallback threshold, showing nothing', () => {
     const decision = resolveDailyFritzCompletedHandNextHandFailure({
       verifierCode: 'illegal_action',
       status: 400,
       failureAttempt: 1,
     });
-    expect(decision.kind).toBe('continue');
-    if (decision.kind === 'continue') {
-      expect(decision.message).not.toMatch(/Couldn't verify/i);
-      expect(decision.message).not.toMatch(/Reload the hand/i);
+    // Previously a 'continue' decision carrying "the next deal is loading
+    // automatically" — copy that promised an automatic retry the caller never
+    // scheduled, so it sat next to the Retry button that did the real work.
+    expect(decision.kind).toBe('retry');
+    if (decision.kind === 'retry') {
+      expect(decision.delayMs).toBeGreaterThan(0);
     }
+    // A first failure must carry no player-facing text at all.
+    expect(decision).not.toHaveProperty('message');
   });
 
   it('never leaves any verifier code stuck on Continue forever', () => {

--- a/client/src/dailyFritz/dailyFritzNextHandFailurePolicy.ts
+++ b/client/src/dailyFritz/dailyFritzNextHandFailurePolicy.ts
@@ -1,10 +1,7 @@
 export type DailyFritzNextHandFailureDecision =
   | { kind: 'rebuild'; delayMs: number; reason: string }
   | { kind: 'unverified_fallback'; attempts: number; delayMs: number; reason: string }
-  | { kind: 'continue'; message: string; reason: string };
-
-const CONTINUE_COPY =
-  'Saving your hand — the next deal is loading automatically.';
+  | { kind: 'retry'; delayMs: number; reason: string };
 
 /**
  * Transport failures only. Verification no longer blocks advancement on a
@@ -35,18 +32,23 @@ export function resolveDailyFritzCompletedHandNextHandFailure(input: {
   if (code && REBUILD_CODES.has(code) && input.failureAttempt <= rebuildLimit) {
     return { kind: 'rebuild', delayMs: 150, reason: `rebuild-${code}` };
   }
+  const label = code ?? (input.status != null ? `http-${input.status}` : 'next-hand-rejected');
+
   // Legacy servers may still reject verification. Fall back to score-only advance.
   if (input.failureAttempt >= DAILY_FRITZ_UNVERIFIED_FALLBACK_AFTER_ATTEMPTS) {
     return {
       kind: 'unverified_fallback',
       attempts: input.failureAttempt,
       delayMs: 300,
-      reason: `unverified-fallback-${code ?? (input.status != null ? `http-${input.status}` : 'unknown')}`,
+      reason: `unverified-fallback-${label}`,
     };
   }
-  return {
-    kind: 'continue',
-    message: CONTINUE_COPY,
-    reason: code ?? (input.status != null ? `http-${input.status}` : 'next-hand-rejected'),
-  };
+
+  // First failure: retry silently. This used to return a 'continue' decision
+  // carrying the copy "the next deal is loading automatically" — but it
+  // scheduled no retry, so nothing was loading and the player had to press
+  // Retry. Schedule the retry the copy always promised, and show nothing: a
+  // late verification receipt is not the player's problem. The ladder stays
+  // unbounded by design, because unverified_fallback always advances.
+  return { kind: 'retry', delayMs: 300, reason: label };
 }

--- a/client/src/modules/match/hooks/useHandLifecycle.ts
+++ b/client/src/modules/match/hooks/useHandLifecycle.ts
@@ -547,11 +547,18 @@ export function useHandLifecycle(args: UseHandLifecycleArgs): UseHandLifecycleRe
               advanceRetry.schedule(recovery.delayMs, recovery.reason, () => advanceHandRef.current());
               return;
             }
-            setHandAdvanceError(recovery.kind === 'continue'
-              ? recovery.message
-              : formatDailyFritzNextHandUserMessage(errMsg));
+            if (recovery.kind === 'retry') {
+              // Silent: no error surface, no manual affordance. A late
+              // verification receipt is not the player's problem, and the
+              // ladder escalates to unverified_fallback on the next failure.
+              prefetchCoordinator.clear();
+              completedHandEvidenceRef.current = null;
+              advanceRetry.schedule(recovery.delayMs, recovery.reason, () => advanceHandRef.current());
+              return;
+            }
+            setHandAdvanceError(formatDailyFritzNextHandUserMessage(errMsg));
             logDailyFritzHandBreadcrumb('manual-advance-shown', {
-              reason: recovery.kind === 'continue' ? recovery.reason : 'nonretryable',
+              reason: 'nonretryable',
               source,
               failureAttempt,
               status,

--- a/server/src/http/routes/dailyFritzInfrastructureFallback.test.ts
+++ b/server/src/http/routes/dailyFritzInfrastructureFallback.test.ts
@@ -239,11 +239,16 @@ describe('Daily Fritz infrastructure verify failures on /next-hand', () => {
   });
 
   it('client policy requests unverified_fallback after the first infra 409', () => {
-    expect(resolveDailyFritzCompletedHandNextHandFailure({
+    // The first attempt retries SILENTLY: no player-facing message, and the
+    // retry is actually scheduled. It previously returned a 'continue'
+    // decision whose copy promised an automatic advance that never happened.
+    const first = resolveDailyFritzCompletedHandNextHandFailure({
       verifierCode: 'missing_hand_start_progress',
       status: 409,
       failureAttempt: 1,
-    }).kind).toBe('continue');
+    });
+    expect(first.kind).toBe('retry');
+    expect(first).not.toHaveProperty('message');
     expect(resolveDailyFritzCompletedHandNextHandFailure({
       verifierCode: 'missing_hand_start_progress',
       status: 409,


### PR DESCRIPTION
Step 3 of the reliability plan, and the one that removes the error from the player's view.

## The bug

The first next-hand failure returned a `continue` decision carrying:

> Saving your hand — the next deal is loading automatically.

…and then **scheduled no retry at all.**

`rebuild` and `unverified_fallback` both call `advanceRetry.schedule(...)` and `return`. `continue` fell through to `setHandAdvanceError()` + `setShowManualHandAdvance(true)`.

So nothing was loading. The copy promised an automatic advance while the Retry button beside it was the only thing that actually advanced the hand — which is exactly what was reported from production: the red box appears, and pressing Retry works.

That also explains the contradiction in the screenshot. It was never two subsystems disagreeing; it was one branch making a promise it didn't keep.

## Fix

Schedule the retry the copy always promised, and show nothing. A late verification receipt is not the player's problem. The ladder still escalates to `unverified_fallback` on the next failure, and that always advances, so the player reaches the next hand without learning any of this happened.

## On bounding the ladder

An earlier draft of this capped the retries and fell back to a manual affordance. **That was wrong and I reverted it.** It reintroduced the dead end the existing tests deliberately guard against — *"never leaves any verifier code stuck on Continue forever"*. `unverified_fallback` advancing unranked **is** the never-strand path; bounding it would strand the player, which is the whole problem. The ladder stays unbounded by design.

## Verification

- Client suite **1266/1266**, typecheck clean, lint holds at exactly **401**
- The one test encoding the old behaviour is updated to assert the new intent: a first failure returns `retry` with a real delay and carries **no player-facing message at all**

## Together with #55

- **#55** stops one hiccup poisoning the rest of the run (the cascade)
- **this** stops the remaining single blip from ever being visible

Neither addresses the *root trigger* — whatever makes a hand fail verification in the first place. That still needs the Sentry data (`gameNumber`, `handIndex`, `missingPriorHandIndex`) and is worth chasing once these two are deployed and the noise is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)