### PR TITLE
feat(rush): count a solve only at 80% of the best line

### DIFF
--- a/client/src/puzzleRush/RushResultsView.tsx
+++ b/client/src/puzzleRush/RushResultsView.tsx
@@ -32,7 +32,12 @@ export function RushResultsView({
   onBack: () => void;
 }) {
   const serverScore = completion?.run.totalScore ?? completion?.authoritativeScore ?? null;
-  const solved = completion?.run.puzzlesSolved ?? results.filter((r) => r.solved).length;
+  // Only the server can count solves: a solve is now a share of the puzzle's
+  // best_possible_score, and the client is deliberately never told that number.
+  // With no completion there is nothing honest to show, so show nothing — the
+  // client's own per-puzzle `solved` flag is the old "scored anything" rule and
+  // would read high exactly when the real figure is missing.
+  const solved = completion?.run.puzzlesSolved ?? null;
   const invalidated = Boolean(completion?.invalidated) || completion?.run.status === 'invalidated';
   // The in-run number is a raw board score and the server's is a points total,
   // so they are not the same measure and normally differ — that is not worth
@@ -57,7 +62,7 @@ export function RushResultsView({
           <span className="pr-results__score-suffix">PTS</span>
         </div>
         <span className="pr-results__solved">
-          {solved} puzzle{solved === 1 ? '' : 's'} solved
+          {solved === null ? 'Solves unavailable' : `${solved} puzzle${solved === 1 ? '' : 's'} solved`}
         </span>
       </header>
 
@@ -65,7 +70,7 @@ export function RushResultsView({
           holds — no invented stats. */}
       <div className="pr-results__tiles">
         <div className="pr-results__tile">
-          <span className="pr-results__tile-value">{solved}</span>
+          <span className="pr-results__tile-value">{solved ?? '—'}</span>
           <span className="pr-results__tile-key">Solved</span>
         </div>
         <div className="pr-results__tile">

--- a/client/src/puzzleRush/types.ts
+++ b/client/src/puzzleRush/types.ts
@@ -116,6 +116,14 @@ export interface RushPuzzleResult {
   /** Board score for this puzzle. The client's only honest scoring signal. */
   rawScore: number;
   bonusSeconds: number;
+  /**
+   * Optimistic "scored anything" flag, for in-run feel only.
+   *
+   * NOT the run's solve count. A solve is a share of the puzzle's
+   * `best_possible_score` (see `isRushSolve` on the server), and the client is
+   * deliberately never told that number, so it cannot compute one. The results
+   * screen reads the server's `puzzlesSolved` and shows nothing without it.
+   */
   solved: boolean;
   /** The line as played, forwarded verbatim for the server's replay. */
   submittedLine: Array<Record<string, unknown>>;

--- a/server/src/puzzleRush/config.ts
+++ b/server/src/puzzleRush/config.ts
@@ -80,6 +80,19 @@ export type PuzzleRushConfig = {
     curveExponent: number;
     /** Flat bonus added when a solve matches best_possible_score exactly. */
     perfectBonusPoints: number;
+    /**
+     * Share of `best_possible_score` a line must reach to count as a *solve*.
+     *
+     * This gates the solve **count** only — `awardedPoints` and banked seconds
+     * stay continuous in the score ratio either side of it. Set from the pool
+     * measured 2026-08-23: achievable scores are dense, not clustered (master
+     * puzzles average ~37 distinct reachable totals and the second-best line
+     * sits at ~0.97 of the best), so there is no natural gap to sit in and this
+     * is a difficulty dial rather than a structural boundary. At 0.8 roughly
+     * 5% of random legal master lines clear it, ~12% of tactical, ~24% of
+     * quick_line — the warm-up tier is deliberately the most forgiving.
+     */
+    solveRatioThreshold: number;
   };
 
   antiCheat: {
@@ -107,7 +120,7 @@ export type PuzzleRushConfig = {
 };
 
 export const PUZZLE_RUSH_CONFIG: PuzzleRushConfig = {
-  version: 3,
+  version: 4,
 
   clock: {
     baseSeconds: 120,
@@ -171,6 +184,7 @@ export const PUZZLE_RUSH_CONFIG: PuzzleRushConfig = {
   scoring: {
     curveExponent: 1.5,
     perfectBonusPoints: 25,
+    solveRatioThreshold: 0.8,
   },
 
   antiCheat: {

--- a/server/src/puzzleRush/grading.ts
+++ b/server/src/puzzleRush/grading.ts
@@ -62,6 +62,33 @@ export function calculateRushAwardedPoints(params: {
   return base + (perfect ? config.scoring.perfectBonusPoints : 0);
 }
 
+/**
+ * Whether a replayed line counts as a *solve*.
+ *
+ * Deliberately stricter than the daily ladder's `rawScore > 0`, which rush used
+ * until 2026-08-23: in a timed mode, "played one legal tile and moved on" would
+ * otherwise post the same 15-solve headline as a run that actually found the
+ * lines, and `puzzles_solved` is the leaderboard's tiebreaker.
+ *
+ * This is a *count* gate, not a scoring gate. `calculateRushAwardedPoints` and
+ * `calculateRushBonusSeconds` stay continuous in the same ratio, so a near-miss
+ * still earns its partial credit and its banked seconds.
+ *
+ * A line at or beyond the recorded best always solves: at least one pool row
+ * has a stored `best_possible_score` below what its board actually allows, and
+ * out-scoring the record must never read as a miss.
+ */
+export function isRushSolve(params: {
+  rawScore: number;
+  bestPossibleScore: number;
+  config?: PuzzleRushConfig;
+}): boolean {
+  const config = params.config ?? PUZZLE_RUSH_CONFIG;
+  if (!Number.isFinite(params.bestPossibleScore) || params.bestPossibleScore <= 0) return false;
+  if (!Number.isFinite(params.rawScore) || params.rawScore <= 0) return false;
+  return params.rawScore / params.bestPossibleScore >= config.scoring.solveRatioThreshold;
+}
+
 /** Seconds banked by a solve. A zero-score puzzle banks nothing. */
 export function calculateRushBonusSeconds(params: {
   rawScore: number;
@@ -154,7 +181,13 @@ export function gradeRun(params: {
         ...base,
         rawScore: validation.rawScore,
         awardedPoints,
-        solved: validation.solved,
+        // Not `validation.solved` — that is the ladder's `rawScore > 0` rule,
+        // shared with the daily ladder and deliberately left alone.
+        solved: isRushSolve({
+          rawScore: validation.rawScore,
+          bestPossibleScore: entry.bestPossibleScore,
+          config,
+        }),
         perfect: validation.perfect,
         movesUsed: validation.movesUsed,
         bonusSeconds: calculateRushBonusSeconds({

--- a/server/src/puzzleRush/puzzleRush.test.ts
+++ b/server/src/puzzleRush/puzzleRush.test.ts
@@ -7,7 +7,7 @@
  */
 import { describe, expect, it } from 'vitest';
 import { createHighScorePuzzle, computeBestPossiblePuzzleScore } from '../generatePuzzles';
-import { getLegalMoves } from '../game/engine';
+import { applyMove, getLegalMoves } from '../game/engine';
 import { DEFAULT_CONFIG, type BoardState, type GameState, type PlayMove, type Tile } from '../game/types';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
@@ -20,10 +20,12 @@ import {
   stageForOrdinal,
 } from './config';
 import { deriveDifficultyScore, selectRunPuzzles, summarizeSelectionFallbacks } from './difficulty';
+import { validateDailyPuzzleSubmission } from '../dailyPuzzleSubmissionValidation';
 import {
   calculateRushAwardedPoints,
   calculateRushBonusSeconds,
   gradeRun,
+  isRushSolve,
   type ReportedPuzzle,
 } from './grading';
 import { buildPuzzleRushLeaderboard, findPersonalBestRun } from './leaderboard';
@@ -92,6 +94,65 @@ function bestSingleMoveLine(board: unknown, hand: Tile[]): Array<Record<string, 
   const moves = getLegalMoves(state, 'you').filter((move): move is PlayMove => move.type === 'play');
   if (moves.length === 0) return [];
   return [{ tile: moves[0].tile, position: moves[0].position }];
+}
+
+/**
+ * The highest-scoring single first move, as a submitted line.
+ *
+ * `bestSingleMoveLine` takes whatever move the engine lists first, which is
+ * frequently a zero-scoring one — fine for replay tests, useless for testing a
+ * threshold, where the line has to score *something* to be a near-miss rather
+ * than a miss.
+ */
+function scoringSingleMoveLine(board: unknown, hand: Tile[]): Array<Record<string, unknown>> {
+  const state: GameState = {
+    config: { ...DEFAULT_CONFIG, tilesPerPlayer: Math.max(1, hand.length), deadTileCount: 0, winningScore: 999 },
+    playerIds: ['you', 'bot'],
+    players: { you: { id: 'you', hand, score: 0 }, bot: { id: 'bot', hand: [], score: 0 } },
+    board: board as BoardState,
+    boneyard: [],
+    deadTiles: [],
+    currentPlayerIndex: 0,
+    handNumber: 1,
+    handOpen: true,
+    handOver: false,
+    gameOver: false,
+    winnerId: null,
+    consecutivePasses: 0,
+    sequence: 0,
+  } as GameState;
+  const moves = getLegalMoves(state, 'you').filter((move): move is PlayMove => move.type === 'play');
+  let best: { move: PlayMove; score: number } | null = null;
+  for (const move of moves) {
+    const score = applyMove(state, 'you', move).state.players.you.score;
+    if (!best || score > best.score) best = { move, score };
+  }
+  if (!best || best.score <= 0) throw new Error('no scoring first move for this puzzle');
+  return [{ tile: best.move.tile, position: best.move.position }];
+}
+
+/**
+ * A real puzzle paired with a scoring first move.
+ *
+ * Not every generated puzzle has one — plenty of boards open with only
+ * zero-scoring placements — so walk seeds until one does rather than letting a
+ * threshold test fail on puzzle generation.
+ */
+function makeScoringPuzzle(seed: string): {
+  board: unknown;
+  hand: Tile[];
+  bestPossibleScore: number;
+  line: Array<Record<string, unknown>>;
+} {
+  for (let attempt = 1; attempt <= 25; attempt++) {
+    const { board, hand, bestPossibleScore } = makeRealPuzzle(`${seed}:${attempt}`);
+    try {
+      return { board, hand, bestPossibleScore, line: scoringSingleMoveLine(board, hand) };
+    } catch {
+      /* no scoring opener on this board; try the next seed */
+    }
+  }
+  throw new Error(`Could not find a scoring first move for seed ${seed}`);
 }
 
 function run(overrides: Partial<PuzzleRushRun> & { id: string; userId: string }): PuzzleRushRun {
@@ -503,6 +564,49 @@ describe('rush scoring', () => {
   });
 });
 
+// ─── the solve threshold ─────────────────────────────────────────────────
+
+describe('rush solve threshold', () => {
+  const threshold = PUZZLE_RUSH_CONFIG.scoring.solveRatioThreshold;
+
+  it('counts a solve only at or above the configured share of the best line', () => {
+    const atThreshold = Math.ceil(threshold * 100);
+    expect(isRushSolve({ rawScore: 100, bestPossibleScore: 100 })).toBe(true);
+    expect(isRushSolve({ rawScore: atThreshold, bestPossibleScore: 100 })).toBe(true);
+    expect(isRushSolve({ rawScore: atThreshold - 1, bestPossibleScore: 100 })).toBe(false);
+  });
+
+  it('does not count a merely legal line as a solve', () => {
+    // The behaviour this threshold exists for: one tile played, turn over.
+    expect(isRushSolve({ rawScore: 5, bestPossibleScore: 40 })).toBe(false);
+    expect(isRushSolve({ rawScore: 0, bestPossibleScore: 40 })).toBe(false);
+  });
+
+  it('never counts a solve when the best score is unknown', () => {
+    expect(isRushSolve({ rawScore: 50, bestPossibleScore: 0 })).toBe(false);
+    expect(isRushSolve({ rawScore: 50, bestPossibleScore: Number.NaN })).toBe(false);
+  });
+
+  it('a line at or beyond the recorded best always solves', () => {
+    // The pool has at least one row whose stored best_possible_score is below
+    // what the board actually allows; an over-best line must not read as a miss.
+    expect(isRushSolve({ rawScore: 120, bestPossibleScore: 100 })).toBe(true);
+  });
+
+  it('leaves the daily ladder on its own looser rule', () => {
+    // `validateDailyPuzzleSubmission.solved` is shared with the ladder. Rush
+    // tightens its own count in gradeRun; the ladder must not move with it.
+    const { board, hand, bestPossibleScore, line } = makeScoringPuzzle('ladder-boundary');
+    const validation = validateDailyPuzzleSubmission({
+      slot: { startingBoard: board, startingHand: hand, bestPossibleScore } as never,
+      submittedLine: line,
+      elapsedSeconds: 0,
+    });
+    expect(validation.rawScore).toBeGreaterThan(0);
+    expect(validation.solved).toBe(true);
+  });
+});
+
 // ─── grading / anti-cheat ────────────────────────────────────────────────
 
 describe('end-of-run grading', () => {
@@ -544,6 +648,75 @@ describe('end-of-run grading', () => {
     expect(firstPass.puzzles.every((puzzle) => puzzle.gradingError === null)).toBe(true);
     expect(firstPass.puzzlesSolved).toBe(firstPass.puzzles.filter((p) => p.solved).length);
     expect(firstPass.bankedBonusSeconds).toBeGreaterThan(0);
+  });
+
+  it('a run of weak-but-legal lines scores points and solves nothing', () => {
+    // Every line replays legally and earns partial credit, but none reaches the
+    // threshold, so the headline "solved" count stays at zero. This is the
+    // "play one tile, move on" run the loose rule used to call a full clear.
+    const poolById = new Map<string, PuzzlePoolEntry>();
+    const reported: ReportedPuzzle[] = [];
+    for (let i = 0; i < 3; i++) {
+      const { board, hand, bestPossibleScore, line } = makeScoringPuzzle(`weak-${i}`);
+      const id = `pool-weak-${i}`;
+      poolById.set(
+        id,
+        poolEntry({
+          id,
+          startingBoard: board,
+          startingHand: hand,
+          // Ten times the reachable best: any real line lands far below the
+          // threshold, without needing a hand-built losing board.
+          bestPossibleScore: bestPossibleScore * 10,
+        }),
+      );
+      reported.push({
+        ordinal: i + 1,
+        puzzleId: id,
+        submittedLine: line,
+        clientRawScore: 0,
+      });
+    }
+
+    const grade = gradeRun({ reported, poolById, clientReportedScore: 0, runDurationSeconds: 60 });
+
+    expect(grade.valid).toBe(true);
+    expect(grade.puzzles.every((puzzle) => puzzle.gradingError === null)).toBe(true);
+    expect(grade.puzzles.every((puzzle) => puzzle.rawScore > 0)).toBe(true);
+    expect(grade.puzzlesSolved).toBe(0);
+    expect(grade.totalScore).toBeGreaterThan(0);
+  });
+
+  it('a sub-threshold line still earns its points and its banked seconds', () => {
+    // The threshold gates the solve *count* only. It must not become a scoring
+    // gate: partial credit and the clock reward are already continuous in the
+    // score ratio, and a cliff at the threshold would double-punish.
+    const { board, hand, bestPossibleScore, line } = makeScoringPuzzle('sub-threshold');
+    const id = 'pool-sub';
+    const poolById = new Map<string, PuzzlePoolEntry>([
+      [
+        id,
+        poolEntry({ id, startingBoard: board, startingHand: hand, bestPossibleScore: bestPossibleScore * 10 }),
+      ],
+    ]);
+    const grade = gradeRun({
+      reported: [{ ordinal: 1, puzzleId: id, submittedLine: line, clientRawScore: 0 }],
+      poolById,
+      clientReportedScore: 0,
+      runDurationSeconds: 60,
+    });
+
+    const [puzzle] = grade.puzzles;
+    expect(puzzle.solved).toBe(false);
+    expect(puzzle.awardedPoints).toBeGreaterThan(0);
+    expect(puzzle.bonusSeconds).toBeGreaterThan(0);
+    expect(puzzle.awardedPoints).toBe(
+      calculateRushAwardedPoints({
+        rawScore: puzzle.rawScore,
+        bestPossibleScore: bestPossibleScore * 10,
+        maxPoints: stageForOrdinal(1).maxPointsPerPuzzle,
+      }),
+    );
   });
 
   it('a client reporting the true score stays valid', () => {


### PR DESCRIPTION
## The problem

Puzzle Rush inherited the daily ladder's solve rule — `solved: rawScore > 0` in `dailyPuzzleSubmissionValidation.ts:198`. So playing one legal tile, letting the turn end, and moving on counted exactly the same as finding the line.

That matters more than it looks, because `puzzles_solved` is not a cosmetic stat: it's the leaderboard's tiebreaker (`leaderboard.ts:43`), the secondary sort key in every Supabase query, the "Most solved" podium figure, and the results screen's headline. A player dumping one tile per puzzle could post "15 solved" beside a genuinely strong run.

## The change

A solve now requires reaching `scoring.solveRatioThreshold` (**0.8**) of the puzzle's `best_possible_score`, via a new `isRushSolve()` in `grading.ts`.

This gates the solve **count** only. Awarded points (already convex, `ratio^1.5`) and banked seconds (linear in the ratio) are deliberately unchanged — both are already continuous, and adding a cliff at the threshold would punish a near-miss twice. A regression test pins that.

`validateDailyPuzzleSubmission` is **untouched**: its `solved` is shared with the daily ladder (`dailyPuzzle.ts:413,529`), which keeps the looser rule. A test locks that boundary so the two can't drift together later.

## Where 0.8 came from

Not a guess. I walked every legal line of 1,000 enabled pool puzzles (Supabase caps at 1,000 rows/request, so a sample of the ~2,284 pool) using the same exhaustive DFS as `computeBestPossiblePuzzleScore`, but collecting the full terminal-score distribution instead of just the max.

The working assumption going in was that scores would be lumpy, with an isolated top cluster to place the threshold in. **They aren't:**

| tier | analyzed | median best | distinct scores/puzzle | secondBest/best (median) |
|---|---|---|---|---|
| `quick_line` | 106 | 15 | 7.3 | 0.93 |
| `tactical_setup` | 43 | 21 | 18.2 | 0.95 |
| `master_chain` | 839 | 38 | 37.2 | 0.97 |

Master puzzles average ~37 distinct reachable totals with the second-best line at ~97% of the best — a smooth gradient, no gap. So the threshold is a difficulty dial, not a structural boundary, and the right lens is what share of random legal lines clear it:

| threshold | quick_line | tactical | master |
|---|---|---|---|
| ≥0.70 | 31.8% | 18.7% | 12.2% |
| **≥0.80** | **23.9%** | **12.0%** | **5.4%** |
| ≥0.90 | 15.9% | 6.9% | 1.7% |
| =1.00 | 10.7% | 3.0% | 0.3% |

In absolute terms 0.8 is "31+ of 38" on a median master puzzle, "12 of 15" on a warm-up. The ~4× tier asymmetry falls the right way: the 3 warm-up puzzles stay forgiving, Master (7 puzzles, 69% of a full clear) is where a run is made.

Caveat worth stating: random-line share is a difficulty proxy, not a real player's clear rate. Players aren't random. The measurement is recorded in the config doc comment so the next retune knows the basis.

## Era split

`config_version` goes **3 → 4**. Historical rows keep their loose counts and are **not** backfilled — that was a deliberate call over rewriting history.

⚠️ Nothing filters on `config_version` yet, so the all-time leaderboard will compare loose-era and strict-era counts side by side until something does.

## Client

The client is deliberately never told `best_possible_score`, so it *cannot* compute a solve. `RushResultsView` previously fell back to its own optimistic `results.filter(r => r.solved)` when `/complete` failed — which would now read high exactly when the real figure is missing. It shows `—` instead. The per-puzzle `solved` flag is kept for in-run feel and documented as not being a solve count.

## Testing

7 new tests in `puzzleRush.test.ts`:
- threshold boundary (at / just below / zero / unknown best / over-best)
- the "one tile, moved on" run grading `puzzlesSolved: 0` while `totalScore > 0` — the exact case this PR exists for
- sub-threshold lines keep their points and banked seconds (threshold must not become a scoring gate)
- the daily ladder still counts a 1-point line as solved

**Verification:** server 1009/1009 (177 files), client 1266/1266 (184 files), `tsc -b` and server `tsc --noEmit` exit 0, client lint exit 0 within budget, server lint unchanged from baseline (237 problems / 74 errors / 163 warnings both with and without this diff).

## Found but not fixed

1. **Stale pool row:** `5c07d6da-300e-45dd-b152-c203d00fcbdd` (`quick_line`) stores `best_possible_score: 15`, but its board allows **19**. That value is the denominator for every ratio, so finding the 19 line yields ratio 1.27 → clamped → a free "perfect" +25. `isRushSolve` handles over-best lines correctly, but the stored value wants a reseed. 1 of 106 in that tier.
2. **`npm run lint` in `server/` fails on a clean checkout** — 74 pre-existing `no-console` errors; the script's `--max-warnings 9999` doesn't gate errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)