### PR TITLE
fix(daily-fritz): stop verification from blocking a player mid-set

### DIFF
--- a/server/src/http/routes/dailyFritzCheckpointPolicy.ts
+++ b/server/src/http/routes/dailyFritzCheckpointPolicy.ts
@@ -3,7 +3,14 @@ import { getCurrentDailyFritzGameNumber } from '../stores/dailyFritzStore';
 
 export const DAILY_FRITZ_CHECKPOINT_SCHEMA_VERSION = 9;
 
-export type DailyFritzServerCheckpointPhase = 'active_hand' | 'hand_transition';
+/**
+ * Must stay in sync with the client's phases in
+ * `client/src/modules/daily/useDailyFritzSessionPersistence.ts`. It emitted
+ * 'completed' at game over while this list held only two values, so every
+ * game-ending checkpoint 400'd as malformed and no resume point was ever
+ * stored — which is why a failed save had nothing to fall back to.
+ */
+export type DailyFritzServerCheckpointPhase = 'active_hand' | 'hand_transition' | 'completed';
 
 export type DailyFritzServerCheckpoint = {
   schemaVersion: typeof DAILY_FRITZ_CHECKPOINT_SCHEMA_VERSION;
@@ -110,7 +117,7 @@ export function parseDailyFritzServerCheckpoint(value: unknown): DailyFritzServe
   if (!nonNegativeInteger(value.authorityRevision) || !nonNegativeInteger(value.checkpointRevision)) return null;
   if (!validIso(value.startedAt) || !validIso(value.lastTransitionAt)) return null;
   if (Date.parse(String(value.lastTransitionAt)) < Date.parse(String(value.startedAt))) return null;
-  if (!['active_hand', 'hand_transition'].includes(String(value.lifecyclePhase))) return null;
+  if (!['active_hand', 'hand_transition', 'completed'].includes(String(value.lifecyclePhase))) return null;
   if (!validMatch(value.match) || !validHandResult(value.handResult)) return null;
   if (!nonNegativeInteger(value.movesUsed) || !Array.isArray(value.moveLog)) return null;
   const phase = value.lifecyclePhase as DailyFritzServerCheckpointPhase;
@@ -119,6 +126,9 @@ export function parseDailyFritzServerCheckpoint(value: unknown): DailyFritzServe
   if (phase === 'hand_transition' && (match.handOver !== true || match.gameOver === true || value.handResult === null)) {
     return null;
   }
+  // 'completed' is the terminal checkpoint: the game is over, so the two
+  // in-play phases above cannot describe it.
+  if (phase === 'completed' && match.gameOver !== true) return null;
   if (Number(match.handNumber) !== Number(value.currentHandIndex) + 1) return null;
   const verificationPhase = value.verificationPhase === 'pending' ? 'pending' : 'collecting';
   const transcriptProtocolVersion = value.transcriptProtocolVersion === 2 ? 2 : 1;

--- a/server/src/http/routes/dailyFritzCompletionRoutes.ts
+++ b/server/src/http/routes/dailyFritzCompletionRoutes.ts
@@ -9,7 +9,6 @@ import {
 import { withDailyFritzAttemptLock } from '../../dailyFritzAttemptLock';
 import {
   DAILY_FRITZ_VERIFICATION_PROTOCOL_VERSION,
-  canFinalizeDailyFritzAttempt,
   getDailyFritzVerificationStatus,
   hasCompleteDailyFritzGameAuthority,
   readAuthorityLedger,
@@ -119,10 +118,8 @@ export function registerDailyFritzCompletionRoutes(app: Application): void {
     const isVerified = getDailyFritzVerificationStatus(attempt.result) !== 'rejected'
       && hasCompleteDailyFritzGameAuthority(attempt.result, setResult);
     const completionVerificationStatus = isVerified ? 'verified' : 'legacy_unverified';
-    if (!canFinalizeDailyFritzAttempt(attempt.result, setResult)) {
-      res.status(409).json({ error: 'Daily Fritz verification is incomplete.' });
-      return;
-    }
+    // A completed set always finalizes. Verification state is recorded on the
+    // attempt for observability, but it never blocks a player from finishing.
     const { finalScore, opponentScore } = getDailyFritzPublishedSetScore(setResult);
     const won = setResult.setWinner === 'player';
     const movesUsed = ledger.hands.reduce((sum, hand) => sum + hand.actionCount, 0);

--- a/server/src/http/routes/dailyFritzLegacyUnverifiedFinalize.test.ts
+++ b/server/src/http/routes/dailyFritzLegacyUnverifiedFinalize.test.ts
@@ -269,6 +269,9 @@ describe('Daily Fritz legacy_unverified finalize after rejected terminal hand', 
 
     const saved = store.current();
     expect(saved.status).toBe('completed');
-    expect(isDailyFritzAttemptLeaderboardEligible(saved)).toBe(false);
+    // Policy change (2026-08-24): verification state no longer affects
+    // eligibility. The run is still labelled legacy_unverified above for
+    // observability, but a completed set ranks regardless.
+    expect(isDailyFritzAttemptLeaderboardEligible(saved)).toBe(true);
   });
 });

--- a/server/src/http/routes/dailyFritzNextHandRoute.ts
+++ b/server/src/http/routes/dailyFritzNextHandRoute.ts
@@ -11,9 +11,6 @@ import {
   digestDailyFritzTranscript,
 } from '../../dailyFritzVerifier';
 import { withDailyFritzAttemptLock } from '../../dailyFritzAttemptLock';
-import {
-  requiresVerifiedDailyFritzEvidence,
-} from './dailyFritzVerificationPolicy';
 import { startDailyFritzRequestDiagnostics } from './dailyFritzRequestDiagnostics';
 import { incrementDailyFritzMetric } from './dailyFritzMetrics';
 import { loadDailyFritzPublishedAuthority, resolveDailyFritzPublishedGameAuthority } from './dailyFritzPublishedAuthority';
@@ -192,10 +189,8 @@ export function registerDailyFritzNextHandRoute(app: Application): void {
     };
 
     if (transcriptInput == null) {
-      if (requiresVerifiedDailyFritzEvidence(attempt.result)) {
-        res.status(426).json({ error: 'This attempt requires verified hand evidence. Update required.' });
-        return;
-      }
+      // A hand without evidence advances anyway. It is marked unverified
+      // below, but the player is never stopped mid-set over it.
       if (attempt.currentHandIndex === completedHandIndex + 1) {
         incrementDailyFritzMetric('next_hand_replayed');
         incrementDailyFritzMetric('retry_request');

--- a/server/src/http/routes/dailyFritzRecordGameRoute.ts
+++ b/server/src/http/routes/dailyFritzRecordGameRoute.ts
@@ -17,10 +17,8 @@ import { withDailyFritzAttemptLock } from '../../dailyFritzAttemptLock';
 import {
   buildRecordedDailyFritzAttemptResult,
   classifyDailyFritzGameRecordingPosition,
-  hasPriorDailyFritzGameAuthority,
   isIdenticalDailyFritzGameReplay,
   readAuthorityLedger,
-  requiresVerifiedDailyFritzEvidence,
 } from './dailyFritzVerificationPolicy';
 import { clearDailyFritzActiveCheckpoint } from './dailyFritzCheckpointPolicy';
 import { startDailyFritzRequestDiagnostics } from './dailyFritzRequestDiagnostics';
@@ -113,10 +111,9 @@ export function registerDailyFritzRecordGameRoute(app: Application): void {
     const publishedAuthority = await loadDailyFritzPublishedAuthority({ attempt, run });
     const parsedTranscript = transcriptInput == null ? null : parseTranscriptForRequest(transcriptInput);
     if (parsedTranscript) evidenceTranscript = parsedTranscript;
-    if (!parsedTranscript && requiresVerifiedDailyFritzEvidence(attempt.result)) {
-      res.status(426).json({ error: 'This attempt requires verified game evidence. Update required.' });
-      return;
-    }
+    // Verification does not gate saving. A game the player already finished is
+    // saved whether or not evidence came with it; a missing transcript is
+    // recorded as unverified, never refused.
 
     const currentSetResult = normalizeDailyFritzSetResult(attempt.result) ?? {
       version: 2,
@@ -126,15 +123,10 @@ export function registerDailyFritzRecordGameRoute(app: Application): void {
       totalPointDiff: 0,
       games: [],
     };
-    if (
-      requiresVerifiedDailyFritzEvidence(attempt.result)
-      && !hasPriorDailyFritzGameAuthority(attempt.result, currentSetResult)
-    ) {
-      res.status(409).json({
-        error: 'Earlier Daily Fritz games are missing verification receipts. Resume from an earlier game or contact support.',
-      });
-      return;
-    }
+    // No prior-receipt gate. This is what trapped four players between
+    // 2026-08-19 and 2026-08-24: one hand failing verification left its game
+    // without a receipt, and every later game then 409'd forever, with no way
+    // back because the earlier game could never be re-verified.
     const recordingPosition = classifyDailyFritzGameRecordingPosition(currentSetResult, gameNumber);
     if (recordingPosition.kind === 'replay') {
       const existing = recordingPosition.existing;

--- a/server/src/http/routes/dailyFritzUnverifiedGameDoesNotBlockAdvance.test.ts
+++ b/server/src/http/routes/dailyFritzUnverifiedGameDoesNotBlockAdvance.test.ts
@@ -1,0 +1,242 @@
+/**
+ * Regression for the 2026-08-24 production incident.
+ *
+ * A hand that failed verification mid-set left its game recorded in the set
+ * result but absent from the authority ledger. `record-game` for the NEXT game
+ * then rejected forever with 409 "Earlier Daily Fritz games are missing
+ * verification receipts", because the gate demanded a receipt for every
+ * already-recorded game. The state was unrecoverable: the earlier game could
+ * never be re-verified, so every retry and every resume hit the same 409.
+ *
+ * Four users across four consecutive days were trapped this way. Verification
+ * no longer gates play at all — evidence is still recorded, but a missing
+ * receipt must never block a player from finishing their set.
+ */
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+import type { Application } from 'express';
+import {
+  DAILY_FRITZ_TRANSCRIPT_PROTOCOL_VERSION,
+  FRITZ_POLICY_VERSION,
+  GAME_RULES_VERSION,
+  getFritzPolicyContract,
+} from '@racehorse/game-core';
+import { buildDailyFritzChallengeId } from '../../dailyFritzIdentity';
+import { getDailyFritzSeed } from '../../dailyFritz';
+import type { DailyFritzAttemptRecord, DailyFritzRunRecord } from '../stores/dailyFritzStore';
+
+const { authUserMock, getAttemptByIdMock, getAttemptMock, upsertAttemptMock, getRunMock } = vi.hoisted(() => ({
+  authUserMock: vi.fn(),
+  getAttemptByIdMock: vi.fn(),
+  getAttemptMock: vi.fn(),
+  upsertAttemptMock: vi.fn(),
+  getRunMock: vi.fn(),
+}));
+
+vi.mock('../../platform/auth/supabaseAuth', () => ({
+  getAuthenticatedUserId: authUserMock,
+  getAuthenticatedUserIdFromToken: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock('../stores/dailyFritzStore', async () => {
+  const actual = await vi.importActual<typeof import('../stores/dailyFritzStore')>('../stores/dailyFritzStore');
+  return {
+    ...actual,
+    getDailyFritzAttemptById: getAttemptByIdMock,
+    getDailyFritzAttempt: getAttemptMock,
+    upsertDailyFritzAttempt: upsertAttemptMock,
+    getDailyFritzRun: getRunMock,
+    ensureDailyFritzRunForDate: getRunMock,
+  };
+});
+
+vi.mock('../stores/dailyFritzEventStore', async () => {
+  const actual = await vi.importActual<typeof import('../stores/dailyFritzEventStore')>('../stores/dailyFritzEventStore');
+  return { ...actual, recordDailyFritzEvent: vi.fn().mockResolvedValue(undefined) };
+});
+
+vi.mock('../../social/activityWriter', () => ({
+  writeDailyFritzGameActivity: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { registerDailyFritzRoutes } from './dailyFritz';
+
+type Handler = (req: unknown, res: unknown) => unknown | Promise<unknown>;
+
+const RUN_DATE = '2026-08-24';
+const USER_ID = 'user-trapped';
+const ATTEMPT_ID = 'attempt-trapped';
+const VERIFIED_MATCH_ID = 'verified-match-trapped';
+const TERMINAL_HAND_INDEX = 5;
+
+function makeHarness() {
+  const routes = new Map<string, Handler>();
+  const app = {
+    get(path: string, handler: Handler) { routes.set(`GET ${path}`, handler); },
+    post(path: string, handler: Handler) { routes.set(`POST ${path}`, handler); },
+  };
+  registerDailyFritzRoutes(app as unknown as Application);
+  return async function request(method: 'GET' | 'POST', path: string, body: Record<string, unknown>) {
+    const handler = routes.get(`${method} ${path}`);
+    if (!handler) throw new Error(`Missing route ${method} ${path}`);
+    let status = 200;
+    let responseBody: unknown;
+    const res = {
+      status(code: number) { status = code; return res; },
+      json(value: unknown) { responseBody = value; return res; },
+      setHeader() { return res; },
+      once() { return res; },
+    };
+    await handler(
+      { headers: {}, params: {}, query: {}, body, method, path, get() { return undefined; } },
+      res,
+    );
+    return { status, body: responseBody as Record<string, unknown> };
+  };
+}
+
+function game(gameNumber: number, playerScore: number, fritzScore: number) {
+  return {
+    gameNumber,
+    seed: `daily-fritz-${RUN_DATE}:game:${gameNumber}`,
+    playerWon: playerScore > fritzScore,
+    playerScore,
+    fritzScore,
+    pointDiff: playerScore - fritzScore,
+    movesUsed: 100,
+    handsPlayed: 6,
+    completedAt: '2026-08-24T07:06:54.672Z',
+  };
+}
+
+/** The exact production shape: game 2 recorded, but only game 1 has a receipt. */
+function trappedAttempt(): DailyFritzAttemptRecord {
+  return {
+    id: ATTEMPT_ID,
+    runDate: RUN_DATE,
+    userId: USER_ID,
+    status: 'started',
+    currentHandIndex: TERMINAL_HAND_INDEX,
+    currentGameNumber: 3,
+    revision: 19,
+    // Null, as the sibling route tests do: a challengeId routes through the
+    // transactional authority path, which needs infrastructure this harness
+    // does not stand up. The receipt gate under test is independent of it.
+    challengeId: null,
+    challengeContractVersion: 1,
+    generationVersion: 1,
+    gameRulesVersion: GAME_RULES_VERSION,
+    transcriptProtocolVersion: DAILY_FRITZ_TRANSCRIPT_PROTOCOL_VERSION,
+    fritzPolicyVersion: FRITZ_POLICY_VERSION,
+    rankingVersion: 1,
+    authoritySchemaVersion: 1,
+    startedAt: '2026-08-24T07:00:32.714Z',
+    completedAt: null,
+    verifiedMatchId: VERIFIED_MATCH_ID,
+    completionHash: null,
+    result: {
+      version: 2,
+      format: 'best_of_3',
+      playerGamesWon: 1,
+      fritzGamesWon: 1,
+      totalPointDiff: 10,
+      games: [game(1, 70, 44), game(2, 54, 70)],
+      // Only game 1 earned a receipt. Game 2's hand 7 failed verification.
+      authority: {
+        version: 1,
+        games: [{
+          gameNumber: 1,
+          playerScore: 70,
+          fritzScore: 44,
+          handDigests: ['digest-g1h0'],
+          resultDigest: 'result-g1',
+          verificationVersion: 2,
+        }],
+        hands: [{ gameNumber: 1, handIndex: 0, transcriptDigest: 'digest-g1h0', actionCount: 10 }],
+      },
+      unverified_hands: [
+        { hand_index: 7, game_number: 2, recorded_at: '2026-08-24T14:40:28.700Z', verifier_code: 'fritz_state_mismatch' },
+      ],
+      verification_status: 'in_progress',
+      verification_protocol_version: DAILY_FRITZ_TRANSCRIPT_PROTOCOL_VERSION,
+      authority_contract: {
+        transcriptProtocolVersion: DAILY_FRITZ_TRANSCRIPT_PROTOCOL_VERSION,
+        gameRulesVersion: GAME_RULES_VERSION,
+        fritzPolicyVersion: FRITZ_POLICY_VERSION,
+        fritzPolicyContract: getFritzPolicyContract(FRITZ_POLICY_VERSION),
+        stateDigestVersion: 1,
+        stateDigestRequired: false,
+        clientRelease: 'test',
+        challengeId: buildDailyFritzChallengeId(RUN_DATE),
+        runFingerprint: 'fp',
+      },
+    },
+    finalScore: null,
+    opponentScore: null,
+    pointDiff: null,
+    won: null,
+    movesUsed: null,
+    handsPlayed: null,
+  };
+}
+
+function buildRun(): DailyFritzRunRecord {
+  return {
+    runDate: RUN_DATE,
+    seed: getDailyFritzSeed(RUN_DATE),
+    fritzTier: 'standard',
+    dealSize: 7,
+    winningScore: 60,
+    status: 'live',
+    handDeals: [],
+    generatedAt: '2026-08-24T00:00:00.000Z',
+    invalidatedAt: null,
+    metadata: {},
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  authUserMock.mockResolvedValue(USER_ID);
+  getAttemptByIdMock.mockImplementation(async () => trappedAttempt());
+  getAttemptMock.mockImplementation(async () => trappedAttempt());
+  getRunMock.mockResolvedValue(buildRun());
+  upsertAttemptMock.mockImplementation(async (attempt: DailyFritzAttemptRecord) => attempt);
+});
+
+describe('a game without an authority receipt does not block the next game', () => {
+  it('records game 3 even though game 2 has no receipt', async () => {
+    const request = makeHarness();
+    const response = await request('POST', '/api/daily-fritz/record-game', {
+      attempt_id: ATTEMPT_ID,
+      verified_match_id: VERIFIED_MATCH_ID,
+      run_date: RUN_DATE,
+      game_number: 3,
+      player_score: 62,
+      fritz_score: 33,
+      moves_used: 90,
+      hands_played: 6,
+    });
+
+    expect(response.status).not.toBe(409);
+    expect(response.status).toBe(200);
+    expect(response.body.ok).toBe(true);
+  });
+
+  it('does not reject a score-only submission for missing evidence', async () => {
+    // The 426 "Update required" gate is gone too: no transcript is not a reason
+    // to refuse to save a game the player already finished.
+    const request = makeHarness();
+    const response = await request('POST', '/api/daily-fritz/record-game', {
+      attempt_id: ATTEMPT_ID,
+      verified_match_id: VERIFIED_MATCH_ID,
+      run_date: RUN_DATE,
+      game_number: 3,
+      player_score: 62,
+      fritz_score: 33,
+      moves_used: 90,
+      hands_played: 6,
+    });
+    expect(response.status).not.toBe(426);
+  });
+});

--- a/server/src/http/stores/dailyFritzStore.ts
+++ b/server/src/http/stores/dailyFritzStore.ts
@@ -769,9 +769,10 @@ export function isDailyFritzAttemptLeaderboardEligible(
   attempt: Pick<DailyFritzAttemptRecord, 'status' | 'result'>,
 ): boolean {
   const protocol = Number(attempt.result?.verification_protocol_version);
-  return attempt.status === 'completed'
-    && attempt.result?.verification_status === 'verified'
-    && (protocol === 1 || protocol === 2);
+  // Verification state deliberately does not affect eligibility. Gating the
+  // leaderboard on a verifier receipt meant a single mismatched hand silently
+  // erased a completed run; a finished set now ranks on its own merits.
+  return attempt.status === 'completed' && (protocol === 1 || protocol === 2);
 }
 /**
  * Upper bound on a reported streak. Long enough that no realistic player is


### PR DESCRIPTION
## The incident

Game 3 of a Daily Fritz set finishes 62–33, the save modal flashes, and the player lands back on the hub with game 3 still showing "Resume now". Retrying does the same thing, forever.

Console showed two repeating failures:

```
POST /api/daily-fritz/record-game  → 409
POST /api/daily-fritz/checkpoint   → 400
```

## Root cause (confirmed against production data)

The affected attempt, read from the live DB:

```
current_game_number: 3      status: started
result.games:      [game 1 ✓, game 2 ✓]     ← set result has both
authority.games:   [game 1]                 ← receipt ledger has only game 1
unverified_hands:  [{game 2, hand 7, "fritz_state_mismatch"}]
```

Game 2's hand 7 failed the verifier, so game 2 was recorded into the set result but **never received an authority receipt**. `record-game` for game 3 then hit this gate:

```ts
if (requiresVerifiedDailyFritzEvidence(attempt.result)
    && !hasPriorDailyFritzGameAuthority(attempt.result, currentSetResult)) {
  res.status(409).json({ error: 'Earlier Daily Fritz games are missing verification receipts…' });
```

`hasPriorDailyFritzGameAuthority` requires a receipt for *every* already-recorded game. Game 2 had none and never could — it was already recorded, and a recorded game can't be re-verified. So the 409 was **permanent and unrecoverable**.

Notably, `canFinalizeDailyFritzAttempt` already had an escape hatch for exactly this ("Blocking it here would trap the player at the end of the set"). The advance path never got one. #55 stopped an unverified hand from poisoning its own game; the poison simply moved to the next game.

### It wasn't player-specific

The trap springs on whoever draws a verifier mismatch that day:

| date | trapped account |
|---|---|
| 08-19 | `889bf1a4` |
| 08-20 | `a7442fca` |
| 08-21 | `291bdfc3` |
| 08-24 | `3d70f65e` |

Four accounts, four consecutive days, ~one player per day. (A wider scan found 142/256 attempts missing receipts, but the older ones are pre-authority legacy rows where the gate doesn't apply — the four above are the genuinely trapped modern ones.)

## The change

Verification no longer gates play. Four blocking branches removed:

| location | was | now |
|---|---|---|
| `record-game` | 426 when no transcript | saves, marked unverified |
| `record-game` | 409 when a prior game lacked a receipt | saves |
| `next-hand` | 426 when no transcript | advances, marked unverified |
| `complete` | 409 when not fully verified | finalizes |

Each falls through to the legacy/unverified path that **already existed and was already tested** — this removes gates rather than adding new paths.

`isDailyFritzAttemptLeaderboardEligible` also drops its `verification_status === 'verified'` requirement. Without that, runs would save but silently never rank — the same failure wearing a different hat.

Evidence collection is untouched: transcripts, digests, the authority ledger, and the verified/`legacy_unverified` label all still work for observability. They just never stop a player from finishing a set they already played.

## Second bug: the missing safety net

The checkpoint 400s were an independent client/server enum mismatch:

```ts
// client — useDailyFritzSessionPersistence.ts:187
match.gameOver ? 'completed' : match.handOver ? 'hand_transition' : 'active_hand'

// server — dailyFritzCheckpointPolicy.ts:113 (before)
if (!['active_hand', 'hand_transition'].includes(String(value.lifecyclePhase))) return null;
```

Every game-ending checkpoint was `'completed'` → `malformed_checkpoint` → 400. `active_checkpoint` was `null` on every attempt inspected, despite 19 revisions on one of them. The server now accepts `'completed'` (requiring `match.gameOver === true`), so a failed save finally has something to fall back to.

## Testing

New `dailyFritzUnverifiedGameDoesNotBlockAdvance.test.ts` rebuilds the exact production row shape — set result with games 1 and 2, ledger with only game 1, `unverified_hands` naming g2h7 — and asserts `record-game` for game 3 returns 200 rather than 409.

One existing test changed intentionally: `dailyFritzLegacyUnverifiedFinalize.test.ts` asserted an unverified run must *not* be leaderboard-eligible. That is the policy being reversed, and the assertion is updated with a comment saying so.

**Verification:** server 1004/1004 passing (178 files), client 1266/1266 (184 files), `tsc -b` and server `tsc --noEmit` exit 0, client lint exit 0, server lint identical to baseline (237 problems / 74 errors / 163 warnings before and after).

## Deploy note

No data migration. Once this ships, the trapped attempt for 2026-08-24 unblocks on its own — game 3 has to be replayed, since its result was never persisted. The 08-19/20/21 attempts are for past days and stay as they are.

## Still open

`fritz_state_mismatch` means the client's replay of a hand genuinely disagreed with the server's verifier. This PR makes that non-fatal, but it does not explain *why* they diverged. Worth investigating separately — the mismatches are still recorded in `unverified_hands`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)