### PR TITLE
fix(daily-fritz): make unverified runs unranked, not unplayable

### DIFF
--- a/server/src/dailyFritzMismatchDiagnostics.test.ts
+++ b/server/src/dailyFritzMismatchDiagnostics.test.ts
@@ -1,0 +1,146 @@
+/**
+ * When a hand fails verification with a state-divergence code, the only thing
+ * we currently learn is the label ("fritz_state_mismatch") and two opaque
+ * 8-hex digests. That is enough to know something diverged and nothing about
+ * WHAT diverged, which is exactly why the 2026-08 incidents needed transcript
+ * reconstruction by hand.
+ *
+ * The client submits only a digest, never its full state, so a true two-sided
+ * field diff is not available without a wire-format change. What IS available
+ * is the server's canonical digest pre-image — the exact structure the digest
+ * is computed over. Capturing it at the moment of mismatch means the next
+ * occurrence can be diffed against a client-side recomputation instead of
+ * being reverse-engineered.
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  DAILY_FRITZ_AUTHORITY_STATE_DIGEST_VERSION,
+  FRITZ_POLICY_VERSION,
+  getDailyFritzAuthorityStateDigest,
+  getFritzPolicyContract,
+} from '@racehorse/game-core';
+import {
+  DailyFritzVerificationError,
+  createOfficialDailyFritzHandState,
+  verifyDailyFritzHand,
+} from './dailyFritzVerifier';
+
+const CHALLENGE_ID = 'challenge-1';
+const ATTEMPT_ID = 'attempt-1';
+
+function officialState() {
+  return createOfficialDailyFritzHandState({
+    deal: {
+      player_tiles: [{ low: 4, high: 4 }, { low: 1, high: 2 }],
+      fritz_tiles: [{ low: 0, high: 5 }, { low: 6, high: 6 }],
+      boneyard: [{ low: 1, high: 3 }, { low: 2, high: 6 }],
+      locked: [],
+    } as never,
+    handIndex: 0,
+    drawWinner: 'fritz',
+    winningScore: 60,
+    dealSize: 7,
+    playerScore: 0,
+    fritzScore: 0,
+  });
+}
+
+function transcriptWithDigest(preStateDigest: string) {
+  return {
+    protocolVersion: 2 as const,
+    rulesVersion: 1 as never,
+    challengeId: CHALLENGE_ID,
+    attemptId: ATTEMPT_ID,
+    gameNumber: 1 as const,
+    handIndex: 0,
+    fritzPolicyVersion: FRITZ_POLICY_VERSION,
+    fritzPolicyContract: getFritzPolicyContract(FRITZ_POLICY_VERSION),
+    stateDigestVersion: DAILY_FRITZ_AUTHORITY_STATE_DIGEST_VERSION,
+    actions: [{
+      sequence: 0,
+      actor: 'fritz' as const,
+      kind: 'play' as const,
+      tile: { low: 0, high: 5 },
+      position: 'left' as const,
+      preStateDigest,
+    }],
+  };
+}
+
+function verifyWithDigest(preStateDigest: string) {
+  const initial = officialState();
+  return verifyDailyFritzHand({
+    transcript: transcriptWithDigest(preStateDigest) as never,
+    initialState: initial,
+    expectedChallengeId: CHALLENGE_ID,
+    expectedAttemptId: ATTEMPT_ID,
+    expectedGameNumber: 1,
+    expectedHandIndex: 0,
+    userId: 'user-1',
+    fritzTier: 'bot',
+    requireStateDigests: true,
+  } as never);
+}
+
+describe('fritz_state_mismatch diagnostics', () => {
+  it('carries the server canonical state and both digests on the error', () => {
+    const clientDigest = 'df-state-v1:00000000';
+    let caught: DailyFritzVerificationError | null = null;
+    try {
+      verifyWithDigest(clientDigest);
+    } catch (error) {
+      caught = error as DailyFritzVerificationError;
+    }
+
+    expect(caught).toBeInstanceOf(DailyFritzVerificationError);
+    expect(caught?.code).toBe('fritz_state_mismatch');
+
+    const diagnostics = caught?.diagnostics;
+    expect(diagnostics).toBeTruthy();
+    expect(diagnostics?.clientStateDigest).toBe(clientDigest);
+    // The server digest must be the real one, so a future report can be
+    // matched against a client-side recomputation.
+    expect(diagnostics?.serverStateDigest).toBe(
+      getDailyFritzAuthorityStateDigest(officialState()),
+    );
+    expect(diagnostics?.actionSequence).toBe(0);
+    expect(diagnostics?.actor).toBe('fritz');
+
+    // The whole point: the fields the digest is computed over, not just a hash.
+    const serverState = diagnostics?.serverState as Record<string, unknown>;
+    expect(serverState).toBeTruthy();
+    expect(serverState.board).toBeDefined();
+    expect(serverState.boneyard).toBeDefined();
+    expect(serverState.handNumber).toBeDefined();
+    expect(serverState.sequence).toBeDefined();
+    expect(Array.isArray(serverState.players)).toBe(true);
+    // Per-side tile counts are the first thing to check on a divergence.
+    const players = serverState.players as Array<{ hand: string[]; score: number }>;
+    expect(players.length).toBe(2);
+    expect(Array.isArray(players[0].hand)).toBe(true);
+  });
+
+  it('does not attach diagnostics to an unrelated failure code', () => {
+    let caught: DailyFritzVerificationError | null = null;
+    try {
+      verifyDailyFritzHand({
+        transcript: {
+          ...transcriptWithDigest('df-state-v1:00000000'),
+          challengeId: 'other-challenge',
+        } as never,
+        initialState: officialState(),
+        expectedChallengeId: CHALLENGE_ID,
+        expectedAttemptId: ATTEMPT_ID,
+        expectedGameNumber: 1,
+        expectedHandIndex: 0,
+        userId: 'user-1',
+        fritzTier: 'bot',
+        requireStateDigests: true,
+      } as never);
+    } catch (error) {
+      caught = error as DailyFritzVerificationError;
+    }
+    expect(caught?.code).toBe('challenge_mismatch');
+    expect(caught?.diagnostics).toBeUndefined();
+  });
+});

--- a/server/src/dailyFritzVerifier.ts
+++ b/server/src/dailyFritzVerifier.ts
@@ -1,9 +1,11 @@
 import { createHash } from 'crypto';
 import {
   DAILY_FRITZ_VERIFIER_VERSION,
+  DAILY_FRITZ_AUTHORITY_STATE_DIGEST_VERSION,
   DEFAULT_CONFIG,
   applyGameCommand,
   canDraw,
+  canonicalizeDailyFritzAuthorityState,
   chooseOfficialFritzDecisionForVersion,
   getDailyFritzAuthorityStateDigest,
   getFritzPolicyContract,
@@ -40,7 +42,17 @@ export type VerifiedDailyFritzHandRecord = {
 };
 
 export class DailyFritzVerificationError extends Error {
-  constructor(message: string, readonly code: string) {
+  /**
+   * Structured evidence for divergence codes whose message alone is not
+   * actionable — notably fritz_state_mismatch, whose two digests say that
+   * something differed but never what. Diagnostic payload only: nothing may
+   * branch on it, and it is absent for codes that already name their cause.
+   */
+  constructor(
+    message: string,
+    readonly code: string,
+    readonly diagnostics?: Record<string, unknown>,
+  ) {
     super(message);
     this.name = 'DailyFritzVerificationError';
   }
@@ -48,6 +60,52 @@ export class DailyFritzVerificationError extends Error {
 
 function cloneTiles(tiles: readonly Tile[]): Tile[] {
   return tiles.map((tile) => ({ low: tile.low, high: tile.high }));
+}
+
+/**
+ * Capture the server's digest pre-image at the moment of a state divergence.
+ *
+ * The client transmits only `preStateDigest`, never its own state, so a
+ * two-sided field-by-field diff is impossible here without changing the wire
+ * format. What this gives instead is the exact canonical structure the server
+ * hashed — board, per-side hands and scores, boneyard, turn cursor, sequence —
+ * so the next occurrence can be diffed against a client-side recomputation of
+ * `canonicalizeDailyFritzAuthorityState` rather than reconstructed by hand.
+ *
+ * Tile counts are summarised alongside the tiles themselves because a
+ * count mismatch (a missed forced draw) is the most common divergence and is
+ * worth reading straight off the log line.
+ */
+function buildDailyFritzStateMismatchDiagnostics(input: {
+  state: GameState;
+  clientStateDigest: string;
+  serverStateDigest: string;
+  actionSequence: number;
+  actor: string;
+  actionKind: string;
+}): Record<string, unknown> {
+  const serverState = JSON.parse(
+    canonicalizeDailyFritzAuthorityState(input.state),
+  ) as Record<string, unknown>;
+  const players = Array.isArray(serverState.players)
+    ? serverState.players as Array<{ hand: string[]; score: number }>
+    : [];
+  return {
+    digestVersion: DAILY_FRITZ_AUTHORITY_STATE_DIGEST_VERSION,
+    clientStateDigest: input.clientStateDigest,
+    serverStateDigest: input.serverStateDigest,
+    actionSequence: input.actionSequence,
+    actor: input.actor,
+    actionKind: input.actionKind,
+    serverState,
+    serverTileCounts: {
+      hands: players.map((player) => player.hand.length),
+      scores: players.map((player) => player.score),
+      boneyard: Array.isArray(serverState.boneyard) ? serverState.boneyard.length : null,
+      deadTiles: Array.isArray(serverState.deadTiles) ? serverState.deadTiles.length : null,
+      board: Array.isArray(serverState.board) ? serverState.board.length : null,
+    },
+  };
 }
 
 export function createOfficialDailyFritzHandState(input: {
@@ -337,6 +395,14 @@ export function verifyDailyFritzHand(input: {
         throw new DailyFritzVerificationError(
           `Fritz state diverged before action ${action.sequence} (client ${action.preStateDigest}, server ${authorityStateDigest}).`,
           'fritz_state_mismatch',
+          buildDailyFritzStateMismatchDiagnostics({
+            state,
+            clientStateDigest: action.preStateDigest,
+            serverStateDigest: authorityStateDigest,
+            actionSequence: action.sequence,
+            actor: action.actor,
+            actionKind: action.kind,
+          }),
         );
       }
       const decision = chooseOfficialFritzDecisionForVersion({

--- a/server/src/http/routes/dailyFritzHealthPolicy.ts
+++ b/server/src/http/routes/dailyFritzHealthPolicy.ts
@@ -31,6 +31,10 @@ export type DailyFritzDayHealthMetrics = {
   requestFailed: number;
   legacyUnverifiedCompletions: number;
   unrankedCompletionRate: number;
+  /** Protocol-v2 attempts that entered unverified_hands on this run date. */
+  unverifiedHandAttempts: number;
+  /** unverifiedHandAttempts as a share of attemptsStarted. */
+  unverifiedHandAttemptRate: number;
   recoveryStarted: number;
   recoveryFailed: number;
   firstMoveCount: number;

--- a/server/src/http/routes/dailyFritzLeaderboardEligibility.test.ts
+++ b/server/src/http/routes/dailyFritzLeaderboardEligibility.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Soft-flag policy for unverified Daily Fritz runs.
+ *
+ * PR #58 removed the hard gates that trapped a player mid-set when a hand
+ * failed verification. That was right: play, saving and completion must never
+ * depend on a verifier receipt. But it also made verification_status purely
+ * decorative — an attempt that advanced without a receipt still ranked.
+ *
+ * The policy here is the middle ground: an unverified run is fully saved,
+ * completable and visible to its own player, and is excluded ONLY from the
+ * public ranked leaderboard.
+ *
+ * Note on vocabulary: the DB has no 'unverified' status. A protocol-v2 run that
+ * advanced a hand without a receipt is 'rejected' (written by
+ * writeUnverifiedDailyFritzHand); a run finalized with no transcript authority
+ * at all is 'legacy_unverified'. Both are "unverified" for ranking purposes.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+vi.mock('../../config', () => ({
+  config: {
+    supabaseUrl: 'https://test.supabase.co',
+    supabasePoolerUrl: null,
+    supabaseServiceKey: 'test-key',
+  },
+}));
+
+vi.mock('@sentry/node', () => ({
+  startSpan: vi.fn((_opts: unknown, fn: () => unknown) => fn()),
+  withScope: vi.fn((fn: (scope: unknown) => void) => fn({ setTag: vi.fn(), setContext: vi.fn() })),
+  captureException: vi.fn(),
+}));
+
+import {
+  buildDailyFritzLeaderboard,
+  invalidateDailyFritzLeaderboard,
+  isDailyFritzAttemptLeaderboardEligible,
+} from '../stores/dailyFritzStore';
+import { resetCircuitBreaker } from '../../supabaseUtils';
+
+const RUN_DATE = '2026-08-24';
+
+/** A completed protocol-v2 set with every field the leaderboard projection needs. */
+function attemptRow(input: {
+  id: string;
+  userId: string;
+  verificationStatus: string;
+  pointDiff: number;
+}) {
+  return {
+    id: input.id,
+    run_date: RUN_DATE,
+    user_id: input.userId,
+    status: 'completed',
+    current_hand_index: 6,
+    current_game_number: 1,
+    revision: 4,
+    challenge_id: 'challenge-1',
+    challenge_contract_version: 1,
+    generation_version: 1,
+    game_rules_version: 1,
+    transcript_protocol_version: 2,
+    fritz_policy_version: 1,
+    ranking_version: 1,
+    authority_schema_version: 1,
+    started_at: `${RUN_DATE}T00:00:00.000Z`,
+    completed_at: `${RUN_DATE}T00:20:00.000Z`,
+    verified_match_id: `match-${input.id}`,
+    completion_hash: 'hash',
+    result: {
+      verification_status: input.verificationStatus,
+      verification_protocol_version: 2,
+    },
+    final_score: 60,
+    opponent_score: 60 - input.pointDiff,
+    point_diff: input.pointDiff,
+    won: true,
+    moves_used: 31,
+    hands_played: 6,
+  };
+}
+
+function jsonResponse(body: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    text: async () => JSON.stringify(body),
+    json: async () => body,
+  } as unknown as Response;
+}
+
+beforeEach(() => {
+  resetCircuitBreaker();
+  mockFetch.mockReset();
+  invalidateDailyFritzLeaderboard(RUN_DATE);
+});
+
+afterEach(() => {
+  resetCircuitBreaker();
+  invalidateDailyFritzLeaderboard(RUN_DATE);
+});
+
+describe('isDailyFritzAttemptLeaderboardEligible — unverified runs are unranked', () => {
+  it('excludes a completed protocol-v2 run whose hand advanced without a receipt', () => {
+    expect(isDailyFritzAttemptLeaderboardEligible({
+      status: 'completed',
+      result: { verification_status: 'rejected', verification_protocol_version: 2 },
+    })).toBe(false);
+  });
+
+  it('excludes a completed protocol-v2 run finalized with no transcript authority', () => {
+    expect(isDailyFritzAttemptLeaderboardEligible({
+      status: 'completed',
+      result: { verification_status: 'legacy_unverified', verification_protocol_version: 2 },
+    })).toBe(false);
+  });
+
+  it('still admits a completed, server-verified run on either protocol', () => {
+    expect(isDailyFritzAttemptLeaderboardEligible({
+      status: 'completed',
+      result: { verification_status: 'verified', verification_protocol_version: 1 },
+    })).toBe(true);
+    expect(isDailyFritzAttemptLeaderboardEligible({
+      status: 'completed',
+      result: { verification_status: 'verified', verification_protocol_version: 2 },
+    })).toBe(true);
+  });
+
+  /**
+   * Observed in production 2026-08-21 (user 291bdfc3): an attempt carrying four
+   * unverified_hands entries whose verification_status had drifted back to
+   * 'in_progress' rather than staying 'rejected'. Whatever writes that drift,
+   * the ledger itself is the durable fact, so eligibility must consult it and
+   * not trust the status field alone.
+   */
+  it('excludes a run whose unverified_hands ledger is non-empty even if the status drifted', () => {
+    expect(isDailyFritzAttemptLeaderboardEligible({
+      status: 'completed',
+      result: {
+        verification_status: 'verified',
+        verification_protocol_version: 2,
+        unverified_hands: [
+          { game_number: 1, hand_index: 1, verifier_code: 'fritz_state_mismatch' },
+        ],
+      },
+    })).toBe(false);
+  });
+
+  it('admits a verified run carrying an empty ledger', () => {
+    expect(isDailyFritzAttemptLeaderboardEligible({
+      status: 'completed',
+      result: {
+        verification_status: 'verified',
+        verification_protocol_version: 2,
+        unverified_hands: [],
+      },
+    })).toBe(true);
+  });
+
+  it('still excludes an unfinished run and an unpinned protocol', () => {
+    expect(isDailyFritzAttemptLeaderboardEligible({
+      status: 'started',
+      result: { verification_status: 'verified', verification_protocol_version: 2 },
+    })).toBe(false);
+    expect(isDailyFritzAttemptLeaderboardEligible({
+      status: 'completed',
+      result: { verification_status: 'verified', verification_protocol_version: 0 },
+    })).toBe(false);
+  });
+});
+
+describe('buildDailyFritzLeaderboard — the public ranked query', () => {
+  it('renders the verified run and omits the unverified ones', async () => {
+    mockFetch.mockImplementation(async (url: string) => {
+      if (String(url).includes('/rest/v1/daily_fritz_attempts')) {
+        return jsonResponse([
+          // Biggest point diff, so it would rank first if it were eligible.
+          attemptRow({ id: 'a-rejected', userId: 'user-rejected', verificationStatus: 'rejected', pointDiff: 55 }),
+          attemptRow({ id: 'a-legacy', userId: 'user-legacy', verificationStatus: 'legacy_unverified', pointDiff: 50 }),
+          attemptRow({ id: 'a-verified', userId: 'user-verified', verificationStatus: 'verified', pointDiff: 20 }),
+        ]);
+      }
+      if (String(url).includes('/rest/v1/profiles')) {
+        return jsonResponse([
+          { id: 'user-rejected', username: 'Rejected Player' },
+          { id: 'user-legacy', username: 'Legacy Player' },
+          { id: 'user-verified', username: 'Verified Player' },
+        ]);
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+
+    const leaderboard = await buildDailyFritzLeaderboard(RUN_DATE);
+
+    expect(leaderboard.map((entry) => entry.userId)).toEqual(['user-verified']);
+    expect(leaderboard[0]?.rank).toBe(1);
+  });
+});

--- a/server/src/http/routes/dailyFritzLegacyUnverifiedFinalize.test.ts
+++ b/server/src/http/routes/dailyFritzLegacyUnverifiedFinalize.test.ts
@@ -269,9 +269,9 @@ describe('Daily Fritz legacy_unverified finalize after rejected terminal hand', 
 
     const saved = store.current();
     expect(saved.status).toBe('completed');
-    // Policy change (2026-08-24): verification state no longer affects
-    // eligibility. The run is still labelled legacy_unverified above for
-    // observability, but a completed set ranks regardless.
-    expect(isDailyFritzAttemptLeaderboardEligible(saved)).toBe(true);
+    // The run saves and completes normally — that is the point of this test,
+    // and nothing about verification may block it. It is only withheld from
+    // the public ranked board, which is what "completes unranked" means.
+    expect(isDailyFritzAttemptLeaderboardEligible(saved)).toBe(false);
   });
 });

--- a/server/src/http/routes/dailyFritzMismatchLogging.test.ts
+++ b/server/src/http/routes/dailyFritzMismatchLogging.test.ts
@@ -1,0 +1,127 @@
+/**
+ * A mismatch that lands in unverified_hands must leave behind enough evidence
+ * to diagnose it without a transcript reconstruction. Before this, the record
+ * path emitted the verifier code and the human-readable message only — so a
+ * fritz_state_mismatch told us that a divergence happened and nothing about
+ * which field diverged.
+ *
+ * Logging only: nothing here may change whether the hand advances.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import * as Sentry from '@sentry/node';
+
+const { errorLogMock } = vi.hoisted(() => ({ errorLogMock: vi.fn() }));
+
+vi.mock('@sentry/node', () => ({
+  captureMessage: vi.fn(),
+  captureException: vi.fn(),
+  startSpan: vi.fn((_opts: unknown, cb: () => unknown) => cb()),
+}));
+
+vi.mock('../../logger', () => ({
+  childLogger: () => ({
+    error: errorLogMock,
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+const { recordEventMock } = vi.hoisted(() => ({
+  recordEventMock: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../stores/dailyFritzEventStore', () => ({
+  recordDailyFritzEvent: recordEventMock,
+}));
+
+import { recordDailyFritzAdvanceWithoutVerification } from './dailyFritzVerificationGlue';
+
+const RUN_DATE = '2026-08-24';
+const USER_ID = 'user-mismatch';
+const ATTEMPT_ID = 'attempt-mismatch';
+
+/** Shaped like the payload the verifier now attaches to the error. */
+const DIAGNOSTICS = {
+  digestVersion: 1,
+  clientStateDigest: 'df-state-v1:aaaaaaaa',
+  serverStateDigest: 'df-state-v1:bbbbbbbb',
+  actionSequence: 12,
+  actor: 'fritz',
+  actionKind: 'play',
+  serverState: {
+    board: { left: 3, right: 5 },
+    players: [{ hand: ['1|2', '3|4'], score: 24 }, { hand: ['0|5'], score: 31 }],
+    boneyard: ['2|6'],
+    handNumber: 3,
+    sequence: 12,
+  },
+  serverTileCounts: { hands: [2, 1], scores: [24, 31], boneyard: 1, deadTiles: 0, board: null },
+};
+
+async function record(diagnostics?: Record<string, unknown>) {
+  await recordDailyFritzAdvanceWithoutVerification({
+    attemptId: ATTEMPT_ID,
+    runDate: RUN_DATE,
+    userId: USER_ID,
+    requestId: 'req-mismatch',
+    gameNumber: 1,
+    handIndex: 3,
+    verifierCode: 'fritz_state_mismatch',
+    operation: 'next-hand',
+    message: 'Fritz state diverged before action 12.',
+    ...(diagnostics ? { diagnostics } : {}),
+  });
+}
+
+afterEach(() => {
+  errorLogMock.mockReset();
+  recordEventMock.mockClear();
+  vi.mocked(Sentry.captureMessage).mockClear();
+});
+
+describe('mismatch diagnostics reach the operator', () => {
+  it('logs the server-computed state alongside both digests', async () => {
+    await record(DIAGNOSTICS);
+
+    const logged = errorLogMock.mock.calls.find(
+      ([fields]) => (fields as Record<string, unknown>)?.verifierCode === 'fritz_state_mismatch',
+    );
+    expect(logged).toBeTruthy();
+    const fields = logged?.[0] as Record<string, unknown>;
+    const diagnostics = fields.diagnostics as Record<string, unknown>;
+    expect(diagnostics).toBeTruthy();
+    expect(diagnostics.clientStateDigest).toBe('df-state-v1:aaaaaaaa');
+    expect(diagnostics.serverStateDigest).toBe('df-state-v1:bbbbbbbb');
+    expect(diagnostics.serverState).toEqual(DIAGNOSTICS.serverState);
+    expect(diagnostics.serverTileCounts).toEqual(DIAGNOSTICS.serverTileCounts);
+  });
+
+  it('attaches the diagnostics to the Sentry bypass alert', async () => {
+    await record(DIAGNOSTICS);
+
+    const call = vi.mocked(Sentry.captureMessage).mock.calls.at(0);
+    expect(call).toBeTruthy();
+    const extra = (call?.[1] as { extra?: Record<string, unknown> })?.extra ?? {};
+    expect(extra.diagnostics).toEqual(DIAGNOSTICS);
+  });
+
+  it('persists the diagnostics on the durable verification_failed event', async () => {
+    await record(DIAGNOSTICS);
+
+    const event = recordEventMock.mock.calls.at(0)?.[0] as
+      { payload?: Record<string, unknown> } | undefined;
+    expect(event?.payload?.mismatch_diagnostics).toEqual(DIAGNOSTICS);
+  });
+
+  it('omits the field entirely when the verifier supplied no diagnostics', async () => {
+    await record();
+
+    const fields = errorLogMock.mock.calls.at(0)?.[0] as Record<string, unknown>;
+    expect(fields).toBeTruthy();
+    expect(fields).not.toHaveProperty('diagnostics');
+    const event = recordEventMock.mock.calls.at(0)?.[0] as
+      { payload?: Record<string, unknown> } | undefined;
+    expect(event?.payload).not.toHaveProperty('mismatch_diagnostics');
+  });
+});

--- a/server/src/http/routes/dailyFritzNextHandRoute.ts
+++ b/server/src/http/routes/dailyFritzNextHandRoute.ts
@@ -404,6 +404,7 @@ export function registerDailyFritzNextHandRoute(app: Application): void {
             operation: 'next-hand',
             message: verificationError!.message,
             transcript: parsedTranscript,
+            diagnostics: verificationError!.diagnostics,
           });
           attempt.result = writeUnverifiedDailyFritzHand(attempt.result, {
             gameNumber,
@@ -446,6 +447,7 @@ export function registerDailyFritzNextHandRoute(app: Application): void {
         operation: 'next-hand',
         message: verificationError!.message,
         transcript: parsedTranscript,
+        diagnostics: verificationError!.diagnostics,
       });
       attempt.result = writeUnverifiedDailyFritzHand(attempt.result, {
         gameNumber,

--- a/server/src/http/routes/dailyFritzRecordGameAsyncVerification.ts
+++ b/server/src/http/routes/dailyFritzRecordGameAsyncVerification.ts
@@ -114,6 +114,7 @@ export async function runDailyFritzRecordGameVerification(
         operation: 'record-game',
         message: verification.error.message,
         transcript: input.transcript,
+        diagnostics: verification.error.diagnostics,
       });
       attempt.result = writeUnverifiedDailyFritzHand(attempt.result, {
         gameNumber: input.gameNumber,

--- a/server/src/http/routes/dailyFritzRecordGameRoute.ts
+++ b/server/src/http/routes/dailyFritzRecordGameRoute.ts
@@ -317,6 +317,7 @@ export function registerDailyFritzRecordGameRoute(app: Application): void {
             operation: 'record-game',
             message,
             transcript: parsedTranscript,
+            diagnostics: verification.ok ? undefined : verification.error.diagnostics,
           });
           attempt.result = writeUnverifiedDailyFritzHand(attempt.result, {
             gameNumber,

--- a/server/src/http/routes/dailyFritzTrappedAttemptResume.test.ts
+++ b/server/src/http/routes/dailyFritzTrappedAttemptResume.test.ts
@@ -1,0 +1,264 @@
+/**
+ * Regression cover for the historically trapped attempts.
+ *
+ * Two protocol-v2 attempts were still sitting at status='started' with a
+ * populated unverified_hands ledger when PR #58 shipped (read-only production
+ * query, 2026-08-24):
+ *
+ *   user a7442fca, run 2026-08-20 — game 2 hand 8, verification_status
+ *     'rejected', 5 unverified hands (illegal_action, missing_hand_start_progress)
+ *   user 291bdfc3, run 2026-08-21 — game 2 hand 2, verification_status
+ *     'in_progress', 4 unverified hands (fritz_state_mismatch, then
+ *     missing_hand_start_progress ×3)
+ *
+ * Both shapes are reproduced here. The claim under test is that resume no
+ * longer consults verification state at all: /today must hand back a playable
+ * position rather than the "Couldn't verify this hand yet" dead end. No row is
+ * mutated to achieve this — the fix is purely the removal of the gates.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { Application } from 'express';
+import { getDailyFritzSeed } from '../../dailyFritz';
+import type { DailyFritzAttemptRecord, DailyFritzRunRecord } from '../stores/dailyFritzStore';
+import { isDailyFritzAttemptLeaderboardEligible } from '../stores/dailyFritzStore';
+import { formatDailyFritzRunDatePacific } from '../stores/dailyFritzHealthSummary';
+
+const mockFetch = vi.fn(async () => ({
+  ok: true,
+  status: 200,
+  text: async () => '[]',
+  json: async () => [],
+} as unknown as Response));
+vi.stubGlobal('fetch', mockFetch);
+
+vi.mock('../../config', () => ({
+  config: {
+    supabaseUrl: 'https://test.supabase.co',
+    supabasePoolerUrl: null,
+    supabaseServiceKey: 'test-key',
+  },
+}));
+
+const { authUserMock, getAttemptByIdMock, getAttemptMock, upsertAttemptMock, getRunMock } = vi.hoisted(() => ({
+  authUserMock: vi.fn(),
+  getAttemptByIdMock: vi.fn(),
+  getAttemptMock: vi.fn(),
+  upsertAttemptMock: vi.fn(),
+  getRunMock: vi.fn(),
+}));
+
+vi.mock('../../platform/auth/supabaseAuth', () => ({
+  getAuthenticatedUserId: authUserMock,
+}));
+
+vi.mock('../stores/dailyFritzStore', async () => {
+  const actual = await vi.importActual<typeof import('../stores/dailyFritzStore')>(
+    '../stores/dailyFritzStore',
+  );
+  return {
+    ...actual,
+    getDailyFritzAttemptById: getAttemptByIdMock,
+    getDailyFritzAttempt: getAttemptMock,
+    upsertDailyFritzAttempt: upsertAttemptMock,
+    getDailyFritzRun: getRunMock,
+    ensureDailyFritzRunForDate: getRunMock,
+  };
+});
+
+vi.mock('../stores/dailyFritzEventStore', async () => {
+  const actual = await vi.importActual<typeof import('../stores/dailyFritzEventStore')>(
+    '../stores/dailyFritzEventStore',
+  );
+  return {
+    ...actual,
+    recordDailyFritzEvent: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+vi.mock('../../social/activityWriter', () => ({
+  writeDailyFritzGameActivity: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { registerDailyFritzRoutes } from './dailyFritz';
+
+type Handler = (req: any, res: any) => unknown | Promise<unknown>;
+
+function makeHarness() {
+  const routes = new Map<string, Handler>();
+  const app = {
+    get(path: string, handler: Handler) { routes.set(`GET ${path}`, handler); },
+    post(path: string, handler: Handler) { routes.set(`POST ${path}`, handler); },
+  };
+  registerDailyFritzRoutes(app as unknown as Application);
+
+  return async function request(method: 'GET' | 'POST', path: string) {
+    const handler = routes.get(`${method} ${path}`);
+    if (!handler) throw new Error(`Missing route ${method} ${path}`);
+    let status = 200;
+    let body: unknown;
+    const res = {
+      status(code: number) { status = code; return res; },
+      json(value: unknown) { body = value; return res; },
+      setHeader() { return res; },
+      set() { return res; },
+      vary() { return res; },
+      once() { return res; },
+    };
+    await handler({
+      headers: {}, params: {}, query: {}, body: {}, method, path,
+      get() { return undefined; },
+    }, res);
+    return { status, body: body as any };
+  };
+}
+
+const DEAL = {
+  player_tiles: [{ low: 4, high: 4 }, { low: 1, high: 2 }],
+  fritz_tiles: [{ low: 6, high: 6 }],
+  boneyard: [{ low: 1, high: 3 }, { low: 2, high: 6 }],
+  locked: [],
+};
+
+function buildRun(runDate: string): DailyFritzRunRecord {
+  return {
+    runDate,
+    seed: getDailyFritzSeed(runDate),
+    fritzTier: 'standard',
+    dealSize: 7,
+    winningScore: 60,
+    status: 'live',
+    handDeals: Array.from({ length: 12 }, () => DEAL),
+    generatedAt: `${runDate}T00:00:00.000Z`,
+    invalidatedAt: null,
+    metadata: { draw_winners_by_game: { '1': 'you', '2': 'you', '3': 'you' } },
+  } as DailyFritzRunRecord;
+}
+
+/**
+ * The exact production result shapes, minus PII.
+ *
+ * `runDate` is the CURRENT Pacific run date rather than the historical one:
+ * /today resolves the live run date by definition, so pinning a past date
+ * would test date routing instead of the thing under test. What is preserved
+ * verbatim is the attempt state that did the trapping — the cursor position
+ * and the unverified_hands ledger.
+ */
+const RUN_DATE = formatDailyFritzRunDatePacific();
+
+const TRAPPED = [
+  {
+    label: 'a7442fca / 2026-08-20 — rejected, 5 unverified hands',
+    runDate: RUN_DATE,
+    userId: 'a7442fca-0000-4000-8000-000000000001',
+    attemptId: 'a7442fca-0000-4000-8000-0000000000a1',
+    currentGameNumber: 2 as const,
+    currentHandIndex: 8,
+    result: {
+      verification_status: 'rejected',
+      verification_protocol_version: 2,
+      authority: { version: 1, hands: [], games: [] },
+      unverified_hands: [
+        { game_number: 1, hand_index: 4, verifier_code: 'illegal_action' },
+        { game_number: 1, hand_index: 5, verifier_code: 'missing_hand_start_progress' },
+        { game_number: 1, hand_index: 6, verifier_code: 'missing_hand_start_progress' },
+        { game_number: 2, hand_index: 6, verifier_code: 'illegal_action' },
+        { game_number: 2, hand_index: 7, verifier_code: 'missing_hand_start_progress' },
+      ],
+    },
+  },
+  {
+    label: '291bdfc3 / 2026-08-21 — in_progress despite 4 unverified hands',
+    runDate: RUN_DATE,
+    userId: '291bdfc3-0000-4000-8000-000000000002',
+    attemptId: '291bdfc3-0000-4000-8000-0000000000a2',
+    currentGameNumber: 2 as const,
+    currentHandIndex: 2,
+    result: {
+      verification_status: 'in_progress',
+      verification_protocol_version: 2,
+      authority: { version: 1, hands: [], games: [] },
+      unverified_hands: [
+        { game_number: 1, hand_index: 1, verifier_code: 'fritz_state_mismatch' },
+        { game_number: 1, hand_index: 2, verifier_code: 'missing_hand_start_progress' },
+        { game_number: 1, hand_index: 3, verifier_code: 'missing_hand_start_progress' },
+        { game_number: 1, hand_index: 4, verifier_code: 'missing_hand_start_progress' },
+      ],
+    },
+  },
+];
+
+function buildAttempt(fixture: typeof TRAPPED[number]): DailyFritzAttemptRecord {
+  return {
+    id: fixture.attemptId,
+    runDate: fixture.runDate,
+    userId: fixture.userId,
+    status: 'started',
+    currentHandIndex: fixture.currentHandIndex,
+    currentGameNumber: fixture.currentGameNumber,
+    revision: 9,
+    challengeId: null,
+    challengeContractVersion: null,
+    generationVersion: null,
+    gameRulesVersion: null,
+    transcriptProtocolVersion: 2,
+    fritzPolicyVersion: null,
+    rankingVersion: null,
+    authoritySchemaVersion: 1,
+    startedAt: `${fixture.runDate}T13:00:00.000Z`,
+    completedAt: null,
+    verifiedMatchId: `match-${fixture.attemptId}`,
+    completionHash: null,
+    result: fixture.result,
+    finalScore: null,
+    opponentScore: null,
+    pointDiff: null,
+    won: null,
+    movesUsed: null,
+    handsPlayed: null,
+  } as DailyFritzAttemptRecord;
+}
+
+describe('historically trapped Daily Fritz attempts resume', () => {
+  afterEach(() => {
+    authUserMock.mockReset();
+    getAttemptByIdMock.mockReset();
+    getAttemptMock.mockReset();
+    upsertAttemptMock.mockReset();
+    getRunMock.mockReset();
+  });
+
+  for (const fixture of TRAPPED) {
+    it(`serves a playable position for ${fixture.label}`, async () => {
+      const attempt = buildAttempt(fixture);
+      authUserMock.mockResolvedValue(fixture.userId);
+      getAttemptMock.mockResolvedValue({ ...attempt });
+      getAttemptByIdMock.mockResolvedValue({ ...attempt });
+      getRunMock.mockResolvedValue(buildRun(fixture.runDate));
+      upsertAttemptMock.mockImplementation(async (record: DailyFritzAttemptRecord) => ({ ...record }));
+
+      const response = await makeHarness()('GET', '/api/daily-fritz/today');
+
+      // No verification gate on the resume path: the player gets their run back.
+      expect(response.status).toBe(200);
+      expect(response.body.ok).toBe(true);
+      expect(response.body.error).toBeUndefined();
+      // The run is live and the player's next step is to play, not to clear a
+      // verification banner. This is the assertion that would have failed
+      // before PR #58.
+      expect(response.body.attempt_status).toBe('started');
+      expect(response.body.next_action).toBe('play_hand');
+      expect(response.body.needs_completion).toBe(false);
+      // The unverified state is still reported for observability — surfaced,
+      // never used to withhold the run.
+      expect(response.body.verification_status)
+        .toBe(fixture.result.verification_status);
+    });
+
+    it(`keeps ${fixture.label} off the public leaderboard once completed`, () => {
+      expect(isDailyFritzAttemptLeaderboardEligible({
+        ...buildAttempt(fixture),
+        status: 'completed',
+      })).toBe(false);
+    });
+  }
+});

--- a/server/src/http/routes/dailyFritzVerificationGlue.ts
+++ b/server/src/http/routes/dailyFritzVerificationGlue.ts
@@ -454,6 +454,12 @@ export async function recordDailyFritzAdvanceWithoutVerification(input: {
   message: string;
   /** Observability only — does not affect advance / ranking behavior. */
   transcript?: DailyFritzTranscript | null;
+  /**
+   * Structured divergence evidence from DailyFritzVerificationError, present
+   * for state-mismatch codes. Diagnostic payload only: it is logged, alerted
+   * and archived, and nothing branches on it.
+   */
+  diagnostics?: Record<string, unknown>;
 }): Promise<void> {
   incrementDailyFritzMetric('verification_bypassed', input.verifierCode);
   log.error({
@@ -464,6 +470,7 @@ export async function recordDailyFritzAdvanceWithoutVerification(input: {
     handIndex: input.handIndex,
     verifierCode: input.verifierCode,
     message: input.message,
+    ...(input.diagnostics ? { diagnostics: input.diagnostics } : {}),
   }, '[daily-fritz] advancing without verification receipt — run is now unranked');
   const evidence = dailyFritzTranscriptEvidenceFields(input.transcript ?? null);
   await recordDailyFritzEventBestEffort({
@@ -482,6 +489,7 @@ export async function recordDailyFritzAdvanceWithoutVerification(input: {
       outcome: 'advance_unverified',
       message: input.message,
       ...evidence.payload,
+      ...(input.diagnostics ? { mismatch_diagnostics: input.diagnostics } : {}),
     },
   });
   const infrastructureFailure = DAILY_FRITZ_INFRASTRUCTURE_VERIFIER_CODES.has(input.verifierCode);
@@ -504,6 +512,7 @@ export async function recordDailyFritzAdvanceWithoutVerification(input: {
         handIndex: input.handIndex,
         message: input.message,
         transcriptDigest: evidence.transcriptDigest,
+        ...(input.diagnostics ? { diagnostics: input.diagnostics } : {}),
       },
     });
   }

--- a/server/src/http/stores/dailyFritzHealthSummary.ts
+++ b/server/src/http/stores/dailyFritzHealthSummary.ts
@@ -1,9 +1,12 @@
 import { supabaseFetch } from '../../supabaseUtils';
+import { childLogger } from '../../logger';
 import type { DailyFritzDayHealthMetrics } from '../routes/dailyFritzHealthPolicy';
+
+const log = childLogger('daily-fritz');
 
 type FunnelRow = { event_type: string; total: number };
 type FailureRow = { verifier_code: string | null; total: number };
-type CompletedAttemptRow = { result: Record<string, unknown> | null };
+type AttemptRow = { status?: string; result: Record<string, unknown> | null };
 
 function sumEventCounts(rows: FunnelRow[]): Map<string, number> {
   const counts = new Map<string, number>();
@@ -23,6 +26,7 @@ function buildDayMetrics(
   funnelRows: FunnelRow[],
   failureRows: FailureRow[],
   legacyUnverifiedCompletions: number,
+  unverifiedHandAttempts: number,
 ): DailyFritzDayHealthMetrics {
   const eventCounts = sumEventCounts(funnelRows);
   const attemptsStarted = eventCounts.get('attempt_started') ?? 0;
@@ -45,18 +49,53 @@ function buildDayMetrics(
     requestFailed,
     legacyUnverifiedCompletions,
     unrankedCompletionRate: rate(legacyUnverifiedCompletions, attemptsCompleted),
+    unverifiedHandAttempts,
+    unverifiedHandAttemptRate: rate(unverifiedHandAttempts, attemptsStarted),
     recoveryStarted,
     recoveryFailed,
     firstMoveCount,
   };
 }
 
-async function countLegacyUnverifiedCompletions(runDate: string): Promise<number> {
-  const rows = await supabaseFetch<CompletedAttemptRow[]>(
-    `/rest/v1/daily_fritz_attempts?run_date=eq.${encodeURIComponent(runDate)}&status=eq.completed&select=result`,
+/**
+ * Attempts that entered unverified_hands, protocol v2 only.
+ *
+ * Counted per attempt, not per hand: one run that lost six hands to the same
+ * root cause is one affected player, and rate-per-attempt is what the
+ * completion figures compare against. Legacy pre-authority rows are excluded —
+ * they carry no receipt by construction, so including them would hide a real
+ * v2 regression behind a constant baseline.
+ */
+export function countDailyFritzUnverifiedHandAttempts(
+  rows: Array<{ result: Record<string, unknown> | null }>,
+): number {
+  return rows.filter((row) => {
+    if (Number(row.result?.verification_protocol_version) !== 2) return false;
+    const hands = row.result?.unverified_hands;
+    return Array.isArray(hands) && hands.length > 0;
+  }).length;
+}
+
+/**
+ * One pass over the day's attempts serving both unverified counters.
+ *
+ * The status filter that used to live in this query was dropped: a run still
+ * in progress can already have lost a hand, and that is precisely the signal
+ * worth alerting on — waiting for completion hides a live regression for the
+ * rest of the day. The legacy counter keeps its completed-only semantics by
+ * filtering in memory instead.
+ */
+async function listDailyFritzAttemptResults(runDate: string): Promise<AttemptRow[]> {
+  return supabaseFetch<AttemptRow[]>(
+    `/rest/v1/daily_fritz_attempts?run_date=${encodeURIComponent(`eq.${runDate}`)}&select=status,result`,
     { method: 'GET' },
   );
-  return rows.filter((row) => row.result?.verification_status === 'legacy_unverified').length;
+}
+
+function countLegacyUnverifiedCompletions(rows: AttemptRow[]): number {
+  return rows.filter(
+    (row) => row.status === 'completed' && row.result?.verification_status === 'legacy_unverified',
+  ).length;
 }
 
 export type DailyFritzHealthTopFailure = {
@@ -76,8 +115,27 @@ export async function listDailyFritzHealthSummary(runDate: string): Promise<{
     `/rest/v1/daily_fritz_failure_metrics?run_date=eq.${encodeURIComponent(runDate)}&select=verifier_code,total`,
     { method: 'GET' },
   );
-  const legacyUnverifiedCompletions = await countLegacyUnverifiedCompletions(runDate);
-  const metrics = buildDayMetrics(runDate, funnelRows, failureRows, legacyUnverifiedCompletions);
+  const attemptRows = await listDailyFritzAttemptResults(runDate);
+  const legacyUnverifiedCompletions = countLegacyUnverifiedCompletions(attemptRows);
+  const unverifiedHandAttempts = countDailyFritzUnverifiedHandAttempts(attemptRows);
+  const metrics = buildDayMetrics(
+    runDate,
+    funnelRows,
+    failureRows,
+    legacyUnverifiedCompletions,
+    unverifiedHandAttempts,
+  );
+
+  // Single greppable daily line. Deliberately not an alert by itself: it gives
+  // alerting a stable string to key on without standing up new infrastructure.
+  log.info({
+    runDate,
+    unverifiedHandAttempts,
+    unverifiedHandAttemptRate: metrics.unverifiedHandAttemptRate,
+    attemptsStarted: metrics.attemptsStarted,
+    attemptsCompleted: metrics.attemptsCompleted,
+    legacyUnverifiedCompletions,
+  }, '[daily-fritz-unverified-rate] protocol-v2 attempts entering unverified_hands');
 
   const failureTotals = new Map<string | null, number>();
   for (const row of failureRows) {

--- a/server/src/http/stores/dailyFritzStore.ts
+++ b/server/src/http/stores/dailyFritzStore.ts
@@ -19,6 +19,7 @@ import {
   normalizeDailyFritzSetSkunkFields,
 } from '../../dailyFritzSkunk';
 import { supabaseFetch } from '../../supabaseUtils';
+import { getDailyFritzVerificationStatus } from '../routes/dailyFritzVerificationPolicy';
 import { getPacificDateKey } from '../../shared/pacificDate';
 import { isDailyFritzTransactionalAuthorityEnabled } from '../../dailyFritzAuthorityFeature';
 import {
@@ -769,10 +770,21 @@ export function isDailyFritzAttemptLeaderboardEligible(
   attempt: Pick<DailyFritzAttemptRecord, 'status' | 'result'>,
 ): boolean {
   const protocol = Number(attempt.result?.verification_protocol_version);
-  // Verification state deliberately does not affect eligibility. Gating the
-  // leaderboard on a verifier receipt meant a single mismatched hand silently
-  // erased a completed run; a finished set now ranks on its own merits.
-  return attempt.status === 'completed' && (protocol === 1 || protocol === 2);
+  if (attempt.status !== 'completed') return false;
+  if (protocol !== 1 && protocol !== 2) return false;
+  // Soft flag, not a gate. An unverified run is still saved, completed and
+  // shown to its own player (history, personal stats); it is only withheld
+  // from the public ranked board, where an unverified score would sit
+  // alongside verified ones with no way to tell them apart. Nothing on the
+  // play or save path may consult this predicate — see PR #58, which removed
+  // the hard gates that trapped players mid-set.
+  if (getDailyFritzVerificationStatus(attempt.result) !== 'verified') return false;
+  // The ledger, not the label, is the durable fact. Production carries at least
+  // one attempt (2026-08-21) whose unverified_hands is populated while
+  // verification_status reads 'in_progress', so a run that recorded a hand
+  // without a receipt must stay unranked however its status later drifted.
+  const unverifiedHands = attempt.result?.unverified_hands;
+  return !Array.isArray(unverifiedHands) || unverifiedHands.length === 0;
 }
 /**
  * Upper bound on a reported streak. Long enough that no realistic player is

--- a/server/src/http/stores/dailyFritzUnverifiedRate.test.ts
+++ b/server/src/http/stores/dailyFritzUnverifiedRate.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Daily volume of Daily Fritz attempts that entered unverified_hands.
+ *
+ * The existing legacyUnverifiedCompletions counter answers a different
+ * question: how many runs finalized with no transcript authority at all. It
+ * says nothing about protocol-v2 runs that DID carry authority and still had a
+ * hand advance without a receipt — which is exactly the population the 2026-08
+ * fritz_state_mismatch incidents came from.
+ *
+ * Pre-authority rows are excluded deliberately: they have no verifier receipt
+ * by construction, so counting them would bury a real v2 regression under a
+ * constant legacy baseline.
+ */
+import { describe, expect, it } from 'vitest';
+import { countDailyFritzUnverifiedHandAttempts } from './dailyFritzHealthSummary';
+
+function row(result: Record<string, unknown> | null) {
+  return { result };
+}
+
+describe('countDailyFritzUnverifiedHandAttempts', () => {
+  it('counts protocol-v2 attempts carrying at least one unverified hand', () => {
+    expect(countDailyFritzUnverifiedHandAttempts([
+      row({
+        verification_protocol_version: 2,
+        verification_status: 'rejected',
+        unverified_hands: [{ game_number: 1, hand_index: 3, verifier_code: 'fritz_state_mismatch' }],
+      }),
+      row({
+        verification_protocol_version: 2,
+        verification_status: 'rejected',
+        unverified_hands: [
+          { game_number: 1, hand_index: 2, verifier_code: 'fritz_state_mismatch' },
+          { game_number: 2, hand_index: 5, verifier_code: 'score_mismatch' },
+        ],
+      }),
+    ])).toBe(2);
+  });
+
+  it('counts an attempt once however many hands it lost', () => {
+    expect(countDailyFritzUnverifiedHandAttempts([
+      row({
+        verification_protocol_version: 2,
+        unverified_hands: [
+          { hand_index: 1, verifier_code: 'fritz_state_mismatch' },
+          { hand_index: 2, verifier_code: 'fritz_state_mismatch' },
+          { hand_index: 3, verifier_code: 'fritz_state_mismatch' },
+        ],
+      }),
+    ])).toBe(1);
+  });
+
+  it('excludes legacy pre-authority rows', () => {
+    expect(countDailyFritzUnverifiedHandAttempts([
+      // No protocol pin at all — pre-authority.
+      row({ verification_status: 'legacy_unverified' }),
+      // Protocol 1 predates the unverified_hands ledger.
+      row({ verification_protocol_version: 1, unverified_hands: [{ hand_index: 0 }] }),
+      row(null),
+    ])).toBe(0);
+  });
+
+  it('excludes clean protocol-v2 attempts', () => {
+    expect(countDailyFritzUnverifiedHandAttempts([
+      row({ verification_protocol_version: 2, verification_status: 'verified' }),
+      // Present but empty: the run never lost a hand.
+      row({ verification_protocol_version: 2, verification_status: 'verified', unverified_hands: [] }),
+      // Malformed ledger must not be read as a failure.
+      row({ verification_protocol_version: 2, unverified_hands: 'not-an-array' }),
+    ])).toBe(0);
+  });
+});

--- a/server/src/http/stores/dailyFritzUnverifiedRateSummary.test.ts
+++ b/server/src/http/stores/dailyFritzUnverifiedRateSummary.test.ts
@@ -1,0 +1,129 @@
+/**
+ * The unverified-attempt count has to reach an operator, not just exist as a
+ * pure function. It rides the existing daily health summary (the repo's
+ * established daily aggregate, surfaced at /api/daily-fritz/health) and emits
+ * one clearly-labelled log line per summary build so it can be grepped or
+ * alerted on without new infrastructure.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { infoLogMock } = vi.hoisted(() => ({ infoLogMock: vi.fn() }));
+
+vi.mock('../../logger', () => ({
+  childLogger: () => ({
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: infoLogMock,
+    debug: vi.fn(),
+  }),
+}));
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+vi.mock('../../config', () => ({
+  config: {
+    supabaseUrl: 'https://test.supabase.co',
+    supabasePoolerUrl: null,
+    supabaseServiceKey: 'test-key',
+  },
+}));
+
+vi.mock('@sentry/node', () => ({
+  startSpan: vi.fn((_opts: unknown, fn: () => unknown) => fn()),
+  withScope: vi.fn((fn: (scope: unknown) => void) => fn({ setTag: vi.fn(), setContext: vi.fn() })),
+  captureException: vi.fn(),
+  captureMessage: vi.fn(),
+}));
+
+import { listDailyFritzHealthSummary } from './dailyFritzHealthSummary';
+import { resetCircuitBreaker } from '../../supabaseUtils';
+
+const RUN_DATE = '2026-08-24';
+
+function jsonResponse(body: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    text: async () => JSON.stringify(body),
+    json: async () => body,
+  } as unknown as Response;
+}
+
+const ATTEMPT_ROWS = [
+  // Completed protocol-v2 run that lost a hand → counted.
+  {
+    status: 'completed',
+    result: {
+      verification_protocol_version: 2,
+      verification_status: 'rejected',
+      unverified_hands: [{ hand_index: 3, verifier_code: 'fritz_state_mismatch' }],
+    },
+  },
+  // Still in progress and already unverified → counted; a live regression
+  // must be visible before the run finishes.
+  {
+    status: 'started',
+    result: {
+      verification_protocol_version: 2,
+      verification_status: 'rejected',
+      unverified_hands: [{ hand_index: 1, verifier_code: 'fritz_state_mismatch' }],
+    },
+  },
+  // Clean v2 run → not counted.
+  {
+    status: 'completed',
+    result: { verification_protocol_version: 2, verification_status: 'verified' },
+  },
+  // Legacy pre-authority completion → excluded from the v2 count, but still
+  // counted by the pre-existing legacyUnverifiedCompletions figure.
+  { status: 'completed', result: { verification_status: 'legacy_unverified' } },
+];
+
+beforeEach(() => {
+  resetCircuitBreaker();
+  mockFetch.mockReset();
+  infoLogMock.mockReset();
+  mockFetch.mockImplementation(async (url: string) => {
+    const target = String(url);
+    if (target.includes('daily_fritz_funnel_metrics')) {
+      return jsonResponse([
+        { event_type: 'attempt_started', total: 10 },
+        { event_type: 'attempt_completed', total: 8 },
+      ]);
+    }
+    if (target.includes('daily_fritz_failure_metrics')) {
+      return jsonResponse([{ verifier_code: 'fritz_state_mismatch', total: 4 }]);
+    }
+    if (target.includes('daily_fritz_attempts')) return jsonResponse(ATTEMPT_ROWS);
+    throw new Error(`Unexpected fetch: ${target}`);
+  });
+});
+
+afterEach(() => {
+  resetCircuitBreaker();
+});
+
+describe('daily unverified-attempt metric', () => {
+  it('reports the protocol-v2 unverified attempt count for the day', async () => {
+    const summary = await listDailyFritzHealthSummary(RUN_DATE);
+
+    expect(summary.metrics.unverifiedHandAttempts).toBe(2);
+    // The pre-existing legacy figure must not shift underneath this addition.
+    expect(summary.metrics.legacyUnverifiedCompletions).toBe(1);
+  });
+
+  it('emits one greppable daily log line carrying the count', async () => {
+    await listDailyFritzHealthSummary(RUN_DATE);
+
+    const line = infoLogMock.mock.calls.find(
+      ([, message]) => typeof message === 'string'
+        && message.includes('[daily-fritz-unverified-rate]'),
+    );
+    expect(line).toBeTruthy();
+    const fields = line?.[0] as Record<string, unknown>;
+    expect(fields.runDate).toBe(RUN_DATE);
+    expect(fields.unverifiedHandAttempts).toBe(2);
+    expect(fields.attemptsStarted).toBe(10);
+  });
+});


### PR DESCRIPTION
Follow-up to #58. That PR removed the hard gates that trapped players mid-set on a failed hand verification — correct, but it left `verification_status` collected and unused, so a run that advanced without a receipt still ranked alongside fully verified ones.

This restores the distinction as a **soft flag on the read path only**.

## 1. Leaderboard eligibility

`isDailyFritzAttemptLeaderboardEligible` admits only `verified` completed runs. Play, saving, completion, history and personal stats are untouched; the only thing that changes is what the public ranked query renders.

It **additionally** requires an empty `unverified_hands` ledger. That is not redundant — production carries an attempt (user `291bdfc3`, 2026-08-21) with four unverified hands whose `verification_status` had drifted back to `in_progress`. The ledger is the durable fact; the label is not a reliable flag on its own.

Tests (`dailyFritzLeaderboardEligibility.test.ts`) cover the three cases asked for, including one driving the real `buildDailyFritzLeaderboard` query end to end.

> **Note on vocabulary:** there is no `'unverified'` status in this schema. The equivalents are `'rejected'` (a protocol-v2 hand advanced without a receipt) and `'legacy_unverified'` (finalized with no transcript authority). Both are excluded.

Two pre-existing tests asserted exclusion but passed *vacuously* — their fixtures omitted `verification_protocol_version`, so they returned `false` for the wrong reason. They now pass for the right one. One test (`dailyFritzLegacyUnverifiedFinalize`) asserted the #58 policy directly and is updated; its own name says "completes **unranked**", which is what it now asserts.

## 2. `fritz_state_mismatch` diagnostics

The raise site compared two opaque 8-hex digests, so the only evidence was *that* something diverged. It now attaches the server's canonical digest pre-image — board, per-side hands and scores, boneyard, turn cursor, sequence — plus both digests and the offending action. Threaded through to the log line, the Sentry bypass alert, and the durable `verification_failed` event.

The client submits only a digest and never its own state, so a true two-sided field diff would require a wire-format change. This captures the half that exists, which is enough to diff against a client-side recomputation of `canonicalizeDailyFritzAuthorityState`. Logging only — nothing branches on it.

## 3. Unverified-rate metric

Daily count of protocol-v2 attempts entering `unverified_hands`, on the existing health summary (`/api/daily-fritz/health`) rather than new infrastructure, plus one greppable `[daily-fritz-unverified-rate]` log line. Legacy pre-authority rows are excluded so a constant baseline cannot mask a v2 regression. The attempt query drops its completed-only filter — an in-progress run that already lost a hand is exactly the signal worth catching before end of day.

## 4. Historical trapped attempts

Read-only production query, no rows mutated. **Only 2 of the 4 flagged users are still `started` with an unverified ledger:**

| User | Date | Status | Ledger |
|---|---|---|---|
| `a7442fca` | 08-20 | `started`, g2h8, `rejected` | 5 hands (`illegal_action`, `missing_hand_start_progress`) |
| `291bdfc3` | 08-21 | `started`, g2h2, `in_progress` | 4 hands (`fritz_state_mismatch`, then `missing_hand_start_progress` ×3) |
| `3d70f65e` | 08-24 | **`completed`** (`legacy_unverified`) | empty — was never stranded |
| `889bf1a4` | 08-19 | **`completed`** (`legacy_unverified`) | 1 hand — completed anyway |

Across all attempts since 2026-08-01 (124 rows), exactly **2** are `started` with a non-empty ledger — the two above.

`dailyFritzTrappedAttemptResume.test.ts` reproduces both real shapes and confirms `/today` returns `ok: true`, `attempt_status: 'started'`, `next_action: 'play_hand'`, `needs_completion: false`, with the unverified status surfaced but not withheld. **No data surgery needed**, as the prior investigation predicted. Both will also correctly stay off the leaderboard when completed.

## Out of scope

Client/server scoring authority is untouched — hand-result computation stays client-side, to be scoped separately.

## Verification

- Server: 184 files / 1034 tests pass
- Client: 184 files / 1266 tests pass
- `tsc` clean on both; client lint clean
- Server lint has 2 errors (`prefer-const`, `no-console`) — **both pre-existing on `origin/main`**, confirmed by linting the same files on a clean checkout

🤖 Generated with [Claude Code](https://claude.com/claude-code)