### PR TITLE
fix(auth): persist the username submitted at signup

### DIFF
--- a/server/src/signupProfileBootstrap.test.ts
+++ b/server/src/signupProfileBootstrap.test.ts
@@ -1,0 +1,53 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+function readRepoFile(relativePath: string): string {
+  return fs.readFileSync(path.resolve(__dirname, '../../', relativePath), 'utf8');
+}
+
+function compactSql(sql: string): string {
+  return sql.replace(/\s+/g, ' ').toLowerCase();
+}
+
+/**
+ * The signup form collects a username and Supabase stores it on
+ * auth.users.raw_user_meta_data. public.handle_new_user() is the only writer of
+ * the profile row the UI later reads back, so if it ignores that metadata the
+ * submitted username is silently replaced by the bootstrap placeholder and the
+ * player is prompted to pick a handle they already chose.
+ */
+describe('signup profile bootstrap', () => {
+  const files = [
+    'supabase/schema.sql',
+    'supabase/migrations/2026-08-26_signup_profile_username_from_metadata.sql',
+  ];
+
+  for (const file of files) {
+    describe(file, () => {
+      const sql = compactSql(readRepoFile(file));
+      const trigger = sql.slice(sql.indexOf('function public.handle_new_user()'));
+
+      it('persists the username submitted at signup', () => {
+        expect(trigger).toContain("raw_user_meta_data ->> 'username'");
+      });
+
+      it('accepts the alternate preferred_username metadata key the client also sends', () => {
+        expect(trigger).toContain("raw_user_meta_data ->> 'preferred_username'");
+      });
+
+      it('applies the same handle rules the signup form enforces', () => {
+        expect(trigger).toContain('[a-z0-9_]{3,}');
+      });
+
+      it('never lets a taken or invalid handle abort the signup transaction', () => {
+        expect(trigger).toContain('select 1 from public.profiles');
+        expect(trigger).toContain("'user_' || left(replace(new.id::text, '-', ''), 8)");
+      });
+
+      it('does not hand out the reserved placeholder namespace as a real handle', () => {
+        expect(trigger).toContain("like 'user\\_%'");
+      });
+    });
+  }
+});

--- a/supabase/README.md
+++ b/supabase/README.md
@@ -137,6 +137,24 @@ available to `service_role`; it should not be granted to `anon` or
 `authenticated`. The server's `/ready` endpoint and the admin
 `/api/daily-fritz/metrics` endpoint provide the runtime verification path.
 
+## Signup username persistence (2026-08-26)
+
+`supabase/migrations/2026-08-26_signup_profile_username_from_metadata.sql`
+replaces `public.handle_new_user()` so the username submitted on the signup form
+(carried on `auth.users.raw_user_meta_data`) becomes the profile handle instead
+of the `user_<id-prefix>` placeholder. Databases created from the current
+`supabase/schema.sql` already include it; existing databases must run the
+migration. Profiles bootstrapped before it keep their placeholder handle and
+still use the username prompt.
+
+Verify after applying:
+
+```sql
+select prosrc like '%raw_user_meta_data%' as reads_submitted_username
+from pg_proc
+where proname = 'handle_new_user';
+```
+
 ## Notes
 - If env vars are missing, the app stays in Guest mode and gameplay still works.
 - Auth methods enabled in Supabase should include Email/Password.

--- a/supabase/migrations/2026-08-26_signup_profile_username_from_metadata.sql
+++ b/supabase/migrations/2026-08-26_signup_profile_username_from_metadata.sql
@@ -1,0 +1,58 @@
+-- Persist the username submitted at signup.
+--
+-- Regression: the signup form sends the chosen handle to Supabase as
+-- auth.users.raw_user_meta_data, but public.handle_new_user() -- the only writer
+-- of the profile row the UI reads back -- always inserted the
+-- 'user_<id-prefix>' bootstrap placeholder. The submitted handle was therefore
+-- discarded, and the client's isTemporaryUsername() check prompted the player to
+-- choose a username they had just chosen.
+--
+-- The trigger runs inside the auth.users insert, so it must never raise: an
+-- invalid, reserved, or already-taken handle falls back to the placeholder
+-- rather than aborting signup.
+
+create or replace function public.handle_new_user()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  fallback_username text := 'user_' || left(replace(new.id::text, '-', ''), 8);
+  desired_username text;
+begin
+  desired_username := lower(trim(coalesce(
+    nullif(new.raw_user_meta_data ->> 'username', ''),
+    nullif(new.raw_user_meta_data ->> 'preferred_username', ''),
+    ''
+  )));
+
+  -- Same rules the signup form enforces, plus the reserved placeholder
+  -- namespace, which the app treats as "no handle chosen yet".
+  if desired_username !~ '^[a-z0-9_]{3,}$'
+    or desired_username like 'user\_%'
+    or exists (select 1 from public.profiles p where p.username = desired_username)
+  then
+    desired_username := fallback_username;
+  end if;
+
+  begin
+    insert into public.profiles (id, username)
+    values (new.id, desired_username)
+    on conflict (id) do nothing;
+  exception
+    when unique_violation then
+      -- The handle was claimed between the check and the insert.
+      insert into public.profiles (id, username)
+      values (new.id, fallback_username)
+      on conflict (id) do nothing;
+  end;
+
+  return new;
+end;
+$$;
+
+drop trigger if exists on_auth_user_created on auth.users;
+create trigger on_auth_user_created
+  after insert on auth.users
+  for each row execute procedure public.handle_new_user();

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -125,17 +125,45 @@ create policy "ghost_profiles_update_own"
   using (auth.uid() = user_id)
   with check (auth.uid() = user_id);
 
--- Auto-bootstrap a temporary profile row after signup.
+-- Bootstrap the profile row after signup, honouring the submitted username
+-- and falling back to a placeholder handle when none is usable.
 create or replace function public.handle_new_user()
 returns trigger
 language plpgsql
 security definer
 set search_path = public
 as $$
+declare
+  fallback_username text := 'user_' || left(replace(new.id::text, '-', ''), 8);
+  desired_username text;
 begin
-  insert into public.profiles (id, username)
-  values (new.id, 'user_' || left(replace(new.id::text, '-', ''), 8))
-  on conflict (id) do nothing;
+  desired_username := lower(trim(coalesce(
+    nullif(new.raw_user_meta_data ->> 'username', ''),
+    nullif(new.raw_user_meta_data ->> 'preferred_username', ''),
+    ''
+  )));
+
+  -- Same rules the signup form enforces, plus the reserved placeholder
+  -- namespace, which the app treats as "no handle chosen yet".
+  if desired_username !~ '^[a-z0-9_]{3,}$'
+    or desired_username like 'user\_%'
+    or exists (select 1 from public.profiles p where p.username = desired_username)
+  then
+    desired_username := fallback_username;
+  end if;
+
+  begin
+    insert into public.profiles (id, username)
+    values (new.id, desired_username)
+    on conflict (id) do nothing;
+  exception
+    when unique_violation then
+      -- The handle was claimed between the check and the insert.
+      insert into public.profiles (id, username)
+      values (new.id, fallback_username)
+      on conflict (id) do nothing;
+  end;
+
   return new;
 end;
 $$;


### PR DESCRIPTION
## ⚠️ Requires a manual Supabase migration on deploy

**This PR does not take effect on merge.** `supabase/migrations/2026-08-26_signup_profile_username_from_metadata.sql` must be applied to the production Supabase project by hand (SQL Editor) as part of the deploy — there is no automatic migration runner wired to merges. Until it is applied, every new signup keeps discarding the chosen username.

Verify after applying:

```sql
select prosrc like '%raw_user_meta_data%' as reads_submitted_username
from pg_proc
where proname = 'handle_new_user';
```

## Root cause

Server-side persistence, not a client race and not a client-side overwrite.

1. `AuthModal.tsx:112` → `useAuth.signUp(email, password, username)`.
2. `useAuth.ts:526-534` sends the username **only as auth metadata** (`options.data.username` / `preferred_username`), landing on `auth.users.raw_user_meta_data`.
3. `public.handle_new_user()` — the trigger that creates the profile row — never read that metadata:
   ```sql
   insert into public.profiles (id, username)
   values (new.id, 'user_' || left(replace(new.id::text, '-', ''), 8))
   ```
   It unconditionally wrote the placeholder. Nothing else copies metadata → `profiles.username`; that column has exactly two writers, this trigger and the manual `UsernameModal` update (`useAuth.ts:726`).
4. `signUp` → `hydrateProfile` → `refreshProfile` (`useAuth.ts:278`) reads `profiles.username` and gets `user_1a2b3c4d`.
5. `useAppSessionUi.ts:97` → `isTemporaryUsername()` (true for any `user_` prefix) → username prompt opens.

The "default value" the player sees is the real persisted value; the typed username never existed server-side. What makes it *look* like a reset is `fallbackProfile` (`useAuth.ts:207`) briefly showing the email local-part before the real read lands.

**Ruled out:** the trigger runs inside the `auth.users` insert transaction, so the fire-and-forget `void hydrateProfile(...)` at `useAuth.ts:552` cannot race the write.

## The fix

The trigger now reads the submitted handle, applies the same rules the signup form enforces (`^[a-z0-9_]{3,}$`), and falls back to the placeholder when the handle is invalid, reserved, or already taken.

Because it runs inside the `auth.users` insert it must never raise — `profiles.username` is `unique not null`, so an unguarded insert of a taken handle would abort signup outright. Hence the explicit `unique_violation` handler covering the check-then-insert window.

Applied both to the new migration (existing databases) and to `supabase/schema.sql` (fresh installs).

## Test

`server/src/signupProfileBootstrap.test.ts` — 10 assertions, confirmed failing against the shipped trigger before the fix.

**Limitation, stated plainly:** this is a SQL-text guardrail following the existing `dbIdempotencySchema.test.ts` convention — *not* an executed create-account-then-read-back test. The suite has no Postgres available (no `pg`/`pglite` dependency) and CI has no Supabase credentials, so a behavioral test would not run in CI. Wiring up PGlite with a stub `auth.users` table for a real round-trip test is a reasonable follow-up.

## Known gap left out of scope

A user who types a `user_`-prefixed handle still gets prompted (the trigger falls back). Fixing that properly means rejecting the reserved prefix in the client validator so they see an error rather than a silent swap — left out to keep this change to one root cause.

## Verification

Run on this branch:

- server: **178 files, 1020 tests passed**
- client: **185 files, 1275 tests passed**
- `tsc -b` in `client/` and `server/`: **exit 0** both

(Server counts are lower than on `fix/daily-fritz-unverified-soft-flag` because this branch is cut from `main` and does not include that branch's three unmerged Daily Fritz commits or the tests they add.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)