### PR TITLE
fix(auth): stop the ghost-profile fetch loop keyed on the user object

### DIFF
--- a/client/src/auth/useAppSessionUi.test.ts
+++ b/client/src/auth/useAppSessionUi.test.ts
@@ -404,3 +404,62 @@ describe('useAppSessionUi — justVerified toast', () => {
     );
   });
 });
+
+// ── Ghost profile fetch identity ──────────────────────────────────────────────
+
+/**
+ * Supabase hands back a NEW User object on every token refresh and auth-state
+ * event, with the same id. Keying the ghost-profile fetch on that object made
+ * each refresh refire the request; a 401 on the request triggers a refresh in
+ * api/client.ts, which produces another new object, which refires the request —
+ * a self-sustaining loop paced by network latency rather than any timer.
+ */
+describe('useAppSessionUi — ghost profile fetch is keyed on identity, not object', () => {
+  beforeEach(() => {
+    vi.mocked(fetchGhostProfileSummary).mockClear();
+  });
+
+  it('fetches once for a mounted signed-in user', async () => {
+    renderHook((p: Params) => useAppSessionUi(p), {
+      initialProps: defaultParams({ authUser: makeUser() as never }),
+    });
+    await waitFor(() => expect(fetchGhostProfileSummary).toHaveBeenCalledTimes(1));
+  });
+
+  it('does not refetch when the same user arrives as a new object', async () => {
+    const { rerender } = renderHook((p: Params) => useAppSessionUi(p), {
+      initialProps: defaultParams({ authUser: makeUser() as never }),
+    });
+    await waitFor(() => expect(fetchGhostProfileSummary).toHaveBeenCalledTimes(1));
+
+    // Same id, fresh object — exactly what a token refresh produces.
+    for (let i = 0; i < 5; i += 1) {
+      rerender(defaultParams({ authUser: makeUser() as never }));
+    }
+
+    await Promise.resolve();
+    expect(fetchGhostProfileSummary).toHaveBeenCalledTimes(1);
+  });
+
+  it('refetches when a different user signs in', async () => {
+    const { rerender } = renderHook((p: Params) => useAppSessionUi(p), {
+      initialProps: defaultParams({ authUser: makeUser() as never }),
+    });
+    await waitFor(() => expect(fetchGhostProfileSummary).toHaveBeenCalledTimes(1));
+
+    rerender(defaultParams({ authUser: makeUser({ id: 'user-999' }) as never }));
+    await waitFor(() => expect(fetchGhostProfileSummary).toHaveBeenCalledTimes(2));
+    expect(vi.mocked(fetchGhostProfileSummary).mock.calls[1][0]).toBe('user-999');
+  });
+
+  it('clears the ghost profile on sign-out without fetching again', async () => {
+    const { result, rerender } = renderHook((p: Params) => useAppSessionUi(p), {
+      initialProps: defaultParams({ authUser: makeUser() as never }),
+    });
+    await waitFor(() => expect(fetchGhostProfileSummary).toHaveBeenCalledTimes(1));
+
+    rerender(defaultParams({ authUser: null }));
+    await waitFor(() => expect(result.current.ghostProfile).toBeNull());
+    expect(fetchGhostProfileSummary).toHaveBeenCalledTimes(1);
+  });
+});

--- a/client/src/auth/useAppSessionUi.ts
+++ b/client/src/auth/useAppSessionUi.ts
@@ -60,14 +60,23 @@ export function useAppSessionUi(params: UseAppSessionUiParams): UseAppSessionUiR
     return Date.now() - dismissedAt < SNOOZE_MS;
   });
 
-  // Fetch ghost profile when auth user changes
+  /**
+   * Fetch the ghost profile when the signed-in USER changes.
+   *
+   * Keyed on the id, not the user object: Supabase returns a fresh User object
+   * on every token refresh and auth-state event, so depending on the object
+   * refetched on each one. Worse, a 401 here makes api/client.ts refresh the
+   * session, which emits another new object and refires this effect — a loop
+   * paced by network latency, not by any timer.
+   */
+  const authUserId = authUser?.id ?? null;
   useEffect(() => {
-    if (!authUser) {
+    if (!authUserId) {
       setGhostProfile(null);
       return;
     }
     let active = true;
-    void fetchGhostProfileSummary(authUser.id)
+    void fetchGhostProfileSummary(authUserId)
       .then((summary) => {
         if (active) setGhostProfile(summary);
       })
@@ -77,7 +86,7 @@ export function useAppSessionUi(params: UseAppSessionUiParams): UseAppSessionUiR
     return () => {
       active = false;
     };
-  }, [authUser]);
+  }, [authUserId]);
 
   // Open welcome modal on first visit
   useEffect(() => {

--- a/client/src/social/ActivityFeedScreen.tsx
+++ b/client/src/social/ActivityFeedScreen.tsx
@@ -148,8 +148,11 @@ export default function ActivityFeedScreen({
     { rank: number; username: string; rating: number; delta: string }[]
   >([]);
 
+  // Keyed on the id, not the user object: Supabase hands back a fresh User on
+  // every token refresh, and depending on the object refetched each time.
+  const feedUserId = user?.id ?? null;
   useEffect(() => {
-    if (!user) return;
+    if (!feedUserId) return;
     let cancelled = false;
 
     void fetchFriendsWithPresence().then((result) => {
@@ -160,7 +163,7 @@ export default function ActivityFeedScreen({
     return () => {
       cancelled = true;
     };
-  }, [user]);
+  }, [feedUserId]);
 
   const friends = user ? loadedFriends : [];
 


### PR DESCRIPTION
## Symptom

An idle, signed-in tab issued `GET /api/ghost/profile/:id` continuously — hundreds of calls a minute, **30–90ms apart**, never stopping. It drove Chrome's heavy-page intervention: sustained CPU, continuous network, and heavy GC.

Located with the repo's own auditor (`debug/requestAudit.ts`) on localhost while idle and signed in.

## Root cause

`useAppSessionUi` keyed its ghost-profile effect on the **`authUser` object** rather than the id:

```js
void fetchGhostProfileSummary(authUser.id)
…
}, [authUser]);   // ← object, not id
```

Supabase returns a **fresh `User` instance** on every token refresh and auth-state event — same `id`, new reference — so each one refired the fetch.

That closes into a self-sustaining loop, entirely within our own code:

1. Effect fires → `GET /api/ghost/profile/:id`
2. A 401 makes `api/client.ts:131` call `refreshSession()`
3. `supabase.auth.refreshSession()` emits `TOKEN_REFRESHED`
4. `syncSession` → `setUser(newUserObject)` — new identity, same id
5. `[authUser]` changed → back to 1

Nothing paces it but network latency, which is why the auditor showed **irregular** 30–90ms gaps rather than a timer's clean cadence. No `setInterval` in the codebase produces jitter like that; a round-trip does.

This also explains the Performance-panel signature (`fetch` + `setTimeout` + `clearTimeout` all heavy together, ~700ms combined GC across 25s idle): that is simply what a high volume of calls looks like through `apiFetch`, which arms and clears a 15s abort timeout per request. One `AbortController`, closure and listener per call is the garbage.

## Fix

Key the effect on `authUser?.id` — the convention `GlobalNav.tsx:113` already used.

`ActivityFeedScreen.tsx:163` had the identical defect (`fetchFriendsWithPresence()` keyed on `[user]`) and would loop on the Social screen by the same mechanism; fixed the same way.

Swept the rest: the only other effects depending on the user object are a `useCallback` dependency (`useAuth.ts:797`) and a ref assignment (`useAuthSession.ts:51`) — neither does any work. The other two `fetchGhostProfileSummary` call sites (`GhostSetupScreen`, `useSinglePlayerHubStats`) already key on a string id and were correct.

## Evidence

**Deterministic** — the new regression test drives five identity-only changes of the same user. Against the old code:

```
AssertionError: expected "vi.fn()" to be called 1 times, but got 6 times
```

After the fix: 1. The test also asserts a genuinely *different* user still refetches, so the fix can't degrade into "never fetch".

**In the field** — confirmed on localhost with `__racehorseRequestAudit`: over a 10s idle window the `ghost/profile` count goes from hundreds of repeats to ~1.

## Verification

- client tests: **1345 passed**, 1 failed (see below)
- `tsc -b`: **exit 0**
- lint: **401 warnings**, at the configured budget

## Known issue, not introduced here

`src/journey/lessonHost/JourneyLessonHost.test.tsx > completes once after passed proof and keeps failed proof non-terminal` fails in the **full-suite** run and **passes in isolation**.

It is pre-existing and unrelated to this change — verified by stashing this branch's edits and re-running the full suite: the same single test fails (1341 passed). With this change: same single failure, 1345 pass, the four extra being the tests added here.

Left alone deliberately; it wants its own fix as a test-ordering/pollution problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)