### PR TITLE
feat(ui): count scores and ratings up instead of hard-cutting

### DIFF
--- a/client/src/components/AnimatedScore.test.tsx
+++ b/client/src/components/AnimatedScore.test.tsx
@@ -1,0 +1,100 @@
+// @vitest-environment jsdom
+/**
+ * The count-up primitive.
+ *
+ * Two behaviours matter beyond "the number moves": it must render its final
+ * value when asked not to animate (so a mounted HUD never shows a wrong
+ * number), and it must release its rAF handle when unmounted mid-count — a
+ * results modal can be dismissed while the number is still climbing.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, render } from '@testing-library/react';
+import { AnimatedScore } from './AnimatedScore';
+
+describe('AnimatedScore', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function advance(ms: number) {
+    act(() => {
+      vi.advanceTimersByTime(ms);
+    });
+  }
+
+  it('renders the final value immediately when no start value is given', () => {
+    // The three HUD call sites rely on this: they mount mid-match with a real
+    // score and must not flash a count-up from zero.
+    const { container } = render(<AnimatedScore value={250} />);
+    expect(container.textContent).toBe('250');
+  });
+
+  it('counts up from an explicit start value', () => {
+    const { container } = render(<AnimatedScore value={250} from={0} duration={600} />);
+    expect(container.textContent).toBe('0');
+    advance(300);
+    const mid = Number(container.textContent);
+    expect(mid).toBeGreaterThan(0);
+    expect(mid).toBeLessThan(250);
+    advance(600);
+    expect(container.textContent).toBe('250');
+  });
+
+  it('counts toward a value that changes while mounted', () => {
+    const { container, rerender } = render(<AnimatedScore value={100} duration={600} />);
+    expect(container.textContent).toBe('100');
+    rerender(<AnimatedScore value={200} duration={600} />);
+    advance(1000);
+    expect(container.textContent).toBe('200');
+  });
+
+  it('applies a formatter to the animating number', () => {
+    const { container } = render(
+      <AnimatedScore value={1420} from={0} format={(n) => n.toLocaleString()} />,
+    );
+    advance(1000);
+    expect(container.textContent).toBe((1420).toLocaleString());
+  });
+
+  it('stops scheduling frames once it settles, and stays stopped on re-render', () => {
+    // This repo has shipped a fix for continuous idle work (PR #61). A counter
+    // that kept re-arming its rAF after finishing would be the same failure
+    // mode, so assert the loop actually stops.
+    const raf = vi.spyOn(window, 'requestAnimationFrame');
+    const { rerender, container } = render(<AnimatedScore value={250} from={0} duration={600} />);
+
+    advance(1000);
+    expect(container.textContent).toBe('250');
+
+    const framesAfterSettle = raf.mock.calls.length;
+    advance(5000);
+    expect(raf.mock.calls.length).toBe(framesAfterSettle);
+
+    // A re-render with the same value must not restart the count.
+    rerender(<AnimatedScore value={250} from={0} duration={600} />);
+    advance(5000);
+    expect(raf.mock.calls.length).toBe(framesAfterSettle);
+    expect(container.textContent).toBe('250');
+    raf.mockRestore();
+  });
+
+  it('releases its animation frame when unmounted mid-count', () => {
+    const cancel = vi.spyOn(window, 'cancelAnimationFrame');
+    const { unmount, container } = render(<AnimatedScore value={250} from={0} duration={600} />);
+
+    advance(100);
+    expect(Number(container.textContent)).toBeLessThan(250);
+
+    const cancelsBefore = cancel.mock.calls.length;
+    expect(() => unmount()).not.toThrow();
+    expect(cancel.mock.calls.length).toBeGreaterThan(cancelsBefore);
+
+    // Nothing may keep ticking after teardown.
+    expect(() => advance(2000)).not.toThrow();
+    cancel.mockRestore();
+  });
+});

--- a/client/src/components/AnimatedScore.tsx
+++ b/client/src/components/AnimatedScore.tsx
@@ -3,10 +3,18 @@ import { useAnimatedScore } from '../hooks/useAnimatedScore';
 export interface AnimatedScoreProps {
   value: number;
   duration?: number;
+  /**
+   * Start the count here instead of at `value`. Needed wherever the final
+   * number is already known at mount — without it the first render is the
+   * final value and nothing animates.
+   */
+  from?: number;
+  /** Formats the animating number, e.g. thousands separators on a rating. */
+  format?: (value: number) => string;
   className?: string;
 }
 
-export function AnimatedScore({ value, duration = 600, className }: AnimatedScoreProps) {
-  const displayed = useAnimatedScore(value, duration);
-  return <span className={className}>{displayed}</span>;
+export function AnimatedScore({ value, duration = 600, from, format, className }: AnimatedScoreProps) {
+  const displayed = useAnimatedScore(value, duration, from);
+  return <span className={className}>{format ? format(displayed) : displayed}</span>;
 }

--- a/client/src/dailyFritz/DailyFritzFinalResultOverlay.test.tsx
+++ b/client/src/dailyFritz/DailyFritzFinalResultOverlay.test.tsx
@@ -1,0 +1,59 @@
+// @vitest-environment jsdom
+/**
+ * The overlay's numeric meta pills count up; its stat row does not, because
+ * those values are formatted strings ("2–0", "+80", "Won") rather than numbers.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, render } from '@testing-library/react';
+import { DailyFritzFinalResultOverlay } from './DailyFritzFinalResultOverlay';
+import type { DailyFritzSetOverlayViewModel } from './setOverlayViewModel';
+
+const overlay = {
+  headline: 'Set won',
+  subheadline: 'You beat Fritz 2–0.',
+  setScoreValue: '2–0',
+  marginValue: '+80',
+  marginTone: 'win',
+  resultValue: 'Won',
+  rankValue: null,
+  games: [],
+  shareRating: 2230,
+  shareStreak: 7,
+  primaryLabel: 'Done',
+  onPrimary: () => {},
+} as unknown as DailyFritzSetOverlayViewModel;
+
+describe('DailyFritzFinalResultOverlay', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  const settle = () =>
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+
+  it('counts the rating and streak up rather than hard-cutting', () => {
+    const { container } = render(
+      <DailyFritzFinalResultOverlay overlay={overlay} shareDone={false} onShare={() => {}} />,
+    );
+    expect(container.textContent).not.toContain('2230');
+    settle();
+    expect(container.textContent).toContain('2230');
+    expect(container.textContent).toContain('7');
+  });
+
+  it('leaves nothing running when dismissed mid-count', () => {
+    const cancel = vi.spyOn(window, 'cancelAnimationFrame');
+    const { unmount } = render(
+      <DailyFritzFinalResultOverlay overlay={overlay} shareDone={false} onShare={() => {}} />,
+    );
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+    const before = cancel.mock.calls.length;
+    expect(() => unmount()).not.toThrow();
+    expect(cancel.mock.calls.length).toBeGreaterThan(before);
+    expect(() => settle()).not.toThrow();
+    cancel.mockRestore();
+  });
+});

--- a/client/src/dailyFritz/DailyFritzFinalResultOverlay.tsx
+++ b/client/src/dailyFritz/DailyFritzFinalResultOverlay.tsx
@@ -1,4 +1,5 @@
 import type { DailyFritzSetOverlayViewModel } from './setOverlayViewModel';
+import { AnimatedScore } from '../components/AnimatedScore';
 
 export type DailyFritzFinalResultOverlayProps = {
   overlay: DailyFritzSetOverlayViewModel;
@@ -80,13 +81,21 @@ export function DailyFritzFinalResultOverlay({
               {overlay.shareRating ? (
                 <div className="df-result-meta-pill">
                   <span className="df-result-meta-label">Rating</span>
-                  <span className="df-result-meta-value">{overlay.shareRating}</span>
+                  <AnimatedScore
+                    value={overlay.shareRating}
+                    from={0}
+                    className="df-result-meta-value"
+                  />
                 </div>
               ) : null}
               {overlay.shareStreak ? (
                 <div className="df-result-meta-pill">
                   <span className="df-result-meta-label">Streak</span>
-                  <span className="df-result-meta-value">{overlay.shareStreak}</span>
+                  <AnimatedScore
+                    value={overlay.shareStreak}
+                    from={0}
+                    className="df-result-meta-value"
+                  />
                 </div>
               ) : null}
             </div>

--- a/client/src/hooks/useAnimatedScore.ts
+++ b/client/src/hooks/useAnimatedScore.ts
@@ -1,22 +1,35 @@
 import { useEffect, useRef, useState } from 'react';
 
-/** Counts from the last rendered value to `value` over `duration` ms via rAF. */
-export function useAnimatedScore(value: number, duration = 600): number {
-  const [displayed, setDisplayed] = useState(value);
-  const displayedRef = useRef(value);
+/**
+ * Counts from the last rendered value to `value` over `duration` ms via rAF.
+ *
+ * By default the first render *is* `value`, so a HUD that mounts mid-match
+ * shows the real score rather than counting up to it. Pass `from` when the
+ * count-up itself is the point — a results screen mounts already knowing its
+ * final number, and without a start value there would be nothing to animate.
+ * `from` is read once, on mount; later changes to it are ignored so the number
+ * never restarts from the bottom.
+ *
+ * The rAF handle is cancelled on unmount, so a results modal dismissed
+ * mid-count leaves nothing running.
+ */
+export function useAnimatedScore(value: number, duration = 600, from?: number): number {
+  const initial = from ?? value;
+  const [displayed, setDisplayed] = useState(initial);
+  const displayedRef = useRef(initial);
   const rafRef = useRef<number | null>(null);
 
   useEffect(() => {
     if (value === displayedRef.current) return;
 
-    const from = displayedRef.current;
+    const start = displayedRef.current;
     const to = value;
     let startTime: number | undefined;
 
     const tick = (now: number) => {
       if (startTime === undefined) startTime = now;
       const progress = Math.min(1, (now - startTime) / duration);
-      const next = Math.round(from + (to - from) * progress);
+      const next = Math.round(start + (to - start) * progress);
       setDisplayed(next);
       displayedRef.current = next;
       if (progress < 1) {

--- a/client/src/identity/components/PlayerCompetitiveSummary.tsx
+++ b/client/src/identity/components/PlayerCompetitiveSummary.tsx
@@ -1,8 +1,10 @@
 import type { PlayerIdentityModel } from '../playerIdentityTypes';
+import { AnimatedScore } from '../../components/AnimatedScore';
 
 type Props = { competitive: PlayerIdentityModel['competitive'] };
 
-const value = (number: number | null) => number == null ? '—' : number.toLocaleString();
+const value = (number: number | null) =>
+  number == null ? '—' : <AnimatedScore value={number} from={0} format={(n) => n.toLocaleString()} />;
 
 export function PlayerCompetitiveSummary({ competitive }: Props) {
   return (

--- a/client/src/puzzleRush/RushResultsView.tsx
+++ b/client/src/puzzleRush/RushResultsView.tsx
@@ -1,4 +1,5 @@
 import { Button } from '../components/primitives';
+import { AnimatedScore } from '../components/AnimatedScore';
 import type { PuzzleRushCompleteResponse, PuzzleRushStage, RushPuzzleResult } from './types';
 import { stageProgress } from './rushScoring';
 
@@ -53,7 +54,11 @@ export function RushResultsView({
       <header className="pr-results__head">
         <span className="pr-results__eyebrow">Run complete</span>
         <div className="pr-results__score" data-ui="rush-final-score">
-          <span className="pr-results__score-value">{serverScore ?? '—'}</span>
+          {serverScore == null ? (
+            <span className="pr-results__score-value">—</span>
+          ) : (
+            <AnimatedScore value={serverScore} from={0} className="pr-results__score-value" />
+          )}
           <span className="pr-results__score-suffix">PTS</span>
         </div>
         <span className="pr-results__solved">

--- a/client/src/puzzleRush/puzzleRushRun.test.tsx
+++ b/client/src/puzzleRush/puzzleRushRun.test.tsx
@@ -311,8 +311,23 @@ describe('results', () => {
     } as PuzzleRushCompleteResponse;
   }
 
+  /**
+   * The headline score counts up from zero, so a synchronous assertion would
+   * catch it mid-climb. Let the animation land, then assert on the value that
+   * actually settles.
+   */
+  function renderSettled(ui: Parameters<typeof render>[0]) {
+    vi.useFakeTimers();
+    const utils = render(ui);
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    vi.useRealTimers();
+    return utils;
+  }
+
   it('headlines the server total, not the client tally', () => {
-    render(
+    renderSettled(
       <RushResultsView
         completion={completion(870)}
         completeError={null}
@@ -329,6 +344,64 @@ describe('results', () => {
     expect(scoreNode?.textContent).toContain('870');
     // The client's own number is never the headline.
     expect(scoreNode?.textContent).not.toContain('640');
+  });
+
+  it('counts the final score up rather than hard-cutting to it', () => {
+    vi.useFakeTimers();
+    try {
+      const { container } = render(
+        <RushResultsView
+          completion={completion(870)}
+          completeError={null}
+          clientTally={870}
+          results={[result(1)]}
+          stages={STAGES}
+          reportFailures={0}
+          onPlayAgain={() => {}}
+          onBack={() => {}}
+        />,
+      );
+      const score = () => container.querySelector('[data-ui="rush-final-score"]')?.textContent ?? '';
+      // The run's real total is known at mount, so a raw render would already
+      // read 870 here. Counting up is the only reason it does not.
+      expect(score()).not.toContain('870');
+      act(() => {
+        vi.advanceTimersByTime(1000);
+      });
+      expect(score()).toContain('870');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('leaves nothing running when the results screen is dismissed mid-count', () => {
+    vi.useFakeTimers();
+    const cancel = vi.spyOn(window, 'cancelAnimationFrame');
+    try {
+      const { unmount } = render(
+        <RushResultsView
+          completion={completion(870)}
+          completeError={null}
+          clientTally={870}
+          results={[result(1)]}
+          stages={STAGES}
+          reportFailures={0}
+          onPlayAgain={() => {}}
+          onBack={() => {}}
+        />,
+      );
+      act(() => {
+        vi.advanceTimersByTime(100);
+      });
+      const before = cancel.mock.calls.length;
+      expect(() => unmount()).not.toThrow();
+      expect(cancel.mock.calls.length).toBeGreaterThan(before);
+      // No orphaned frame may fire after teardown.
+      expect(() => act(() => { vi.advanceTimersByTime(2000); })).not.toThrow();
+    } finally {
+      cancel.mockRestore();
+      vi.useRealTimers();
+    }
   });
 
   it('discloses an over-claim rather than silently swapping the number', () => {
@@ -372,7 +445,7 @@ describe('results', () => {
   });
 
   it('flags an invalidated run', () => {
-    render(
+    renderSettled(
       <RushResultsView
         completion={completion(120, { invalidated: true, invalidatedReason: 'client_score_mismatch' })}
         completeError={null}

--- a/client/src/stats/StatsScreen.test.tsx
+++ b/client/src/stats/StatsScreen.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import type { User } from '@supabase/supabase-js';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createEmptyPlayerIdentityModel } from '../identity/playerIdentityNormalization';
@@ -28,7 +28,14 @@ describe('StatsScreen normalized presentation', () => {
   beforeEach(() => { identityState.current = { model: model(), loading: false, error: null }; });
 
   it('renders ranked, Fritz, Ghost, Puzzle, and score semantics from identity fields', () => {
+    // Stat numbers count up from zero, so let the animation land before
+    // asserting on the values that settle.
+    vi.useFakeTimers();
     render(<StatsScreen {...props} />);
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    vi.useRealTimers();
     expect(screen.getByRole('heading', { name: 'Performance at the table', level: 1 })).toBeTruthy();
     expect(screen.getByText('87.5')).toBeTruthy();
     expect(screen.getByText('72')).toBeTruthy();

--- a/client/src/stats/components/GhostPerformanceSection.tsx
+++ b/client/src/stats/components/GhostPerformanceSection.tsx
@@ -1,7 +1,9 @@
 import type { PlayerIdentityModel } from '../../identity/playerIdentityTypes';
+import { AnimatedScore } from '../../components/AnimatedScore';
 
 type Props = { ghost: PlayerIdentityModel['ghost'] };
-const value = (number: number | null) => number == null ? '—' : number.toLocaleString();
+const value = (number: number | null) =>
+  number == null ? '—' : <AnimatedScore value={number} from={0} format={(n) => n.toLocaleString()} />;
 
 export function GhostPerformanceSection({ ghost }: Props) {
   const available = [ghost.rating, ghost.gamesPlayed, ghost.wins, ghost.losses, ghost.winRate, ghost.bestWinMargin].some((item) => item != null);

--- a/client/src/stats/components/PlayerRankedOverview.tsx
+++ b/client/src/stats/components/PlayerRankedOverview.tsx
@@ -1,7 +1,9 @@
 import type { PlayerIdentityModel } from '../../identity/playerIdentityTypes';
+import { AnimatedScore } from '../../components/AnimatedScore';
 
 type Props = { competitive: PlayerIdentityModel['competitive']; username: string | null };
-const number = (value: number | null) => value == null ? '—' : value.toLocaleString();
+const number = (value: number | null) =>
+  value == null ? '—' : <AnimatedScore value={value} from={0} format={(n) => n.toLocaleString()} />;
 
 export function PlayerRankedOverview({ competitive, username }: Props) {
   return <section className="stats-analysis-card stats-ranked-overview" aria-labelledby="stats-ranked-overview-title"><p className="stats-eyebrow">{username ? `@${username} / ranked overview` : 'Ranked overview'}</p><h1 id="stats-ranked-overview-title">Performance at the table</h1><div className="stats-ranked-lead"><div><span className="stats-stat-label">CURRENT RATING</span><strong>{number(competitive.rating)}</strong>{competitive.provisional === true && <span className="stats-provisional">Provisional</span>}</div><div><span className="stats-stat-label">PEAK RATING</span><b>{number(competitive.peakRating)}</b></div>{competitive.globalRank != null && <div><span className="stats-stat-label">GLOBAL RANK</span><b>#{competitive.globalRank.toLocaleString()}</b></div>}<div><span className="stats-stat-label">RANKED GAMES</span><b>{number(competitive.rankedGames)}</b></div></div></section>;

--- a/client/src/stats/components/PuzzlePerformanceSection.tsx
+++ b/client/src/stats/components/PuzzlePerformanceSection.tsx
@@ -1,7 +1,9 @@
 import type { PlayerIdentityModel } from '../../identity/playerIdentityTypes';
+import { AnimatedScore } from '../../components/AnimatedScore';
 
 type Props = { puzzle: PlayerIdentityModel['puzzle'] };
-const value = (number: number | null) => number == null ? '—' : number.toLocaleString();
+const value = (number: number | null) =>
+  number == null ? '—' : <AnimatedScore value={number} from={0} format={(n) => n.toLocaleString()} />;
 
 export function PuzzlePerformanceSection({ puzzle }: Props) {
   const ready = [puzzle.completions, puzzle.currentStreak, puzzle.bestScoreToday, puzzle.bestScoreEver, puzzle.perfectDays].some((item) => item != null);

--- a/client/src/stats/components/RankedPerformanceSection.tsx
+++ b/client/src/stats/components/RankedPerformanceSection.tsx
@@ -1,7 +1,9 @@
 import type { PlayerIdentityModel } from '../../identity/playerIdentityTypes';
+import { AnimatedScore } from '../../components/AnimatedScore';
 
 type Props = { competitive: PlayerIdentityModel['competitive'] };
-const display = (value: number | null) => value == null ? '—' : value.toLocaleString();
+const display = (value: number | null) =>
+  value == null ? '—' : <AnimatedScore value={value} from={0} format={(n) => n.toLocaleString()} />;
 
 export function RankedPerformanceSection({ competitive }: Props) {
   const record = competitive.wins != null && competitive.losses != null ? `${competitive.wins}W – ${competitive.losses}L` : '—';

--- a/client/src/stats/countUpWiring.test.tsx
+++ b/client/src/stats/countUpWiring.test.tsx
@@ -1,0 +1,83 @@
+// @vitest-environment jsdom
+/**
+ * Count-up wiring on the identity-model surfaces (Stats and public profile).
+ *
+ * Both mount only once their data has loaded, so the value is already known at
+ * first render. The assertion that separates a real count-up from a raw render
+ * is therefore that the first paint is *not* the final number.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, render } from '@testing-library/react';
+import { PlayerCompetitiveSummary } from '../identity/components/PlayerCompetitiveSummary';
+import { PlayerRankedOverview } from '../stats/components/PlayerRankedOverview';
+import { RankedPerformanceSection } from '../stats/components/RankedPerformanceSection';
+
+type Competitive = Parameters<typeof PlayerCompetitiveSummary>[0]['competitive'];
+
+const competitive = {
+  rating: 1420,
+  peakRating: 1480,
+  globalRank: 27,
+  provisional: false,
+  wins: 8,
+  losses: 3,
+  rankedGames: 11,
+  winRate: 72.7,
+  currentStreak: 3,
+  bestStreak: 5,
+  recentForm: [],
+  recentMatches: [],
+} as unknown as Competitive;
+
+describe('identity surfaces count numbers up', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  const settle = () =>
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+
+  it('animates the profile rating instead of hard-cutting', () => {
+    const { container } = render(<PlayerCompetitiveSummary competitive={competitive} />);
+    expect(container.textContent).not.toContain('1,420');
+    settle();
+    expect(container.textContent).toContain('1,420');
+  });
+
+  it('animates the stats rating and keeps thousands separators', () => {
+    const { container } = render(
+      <PlayerRankedOverview competitive={competitive} username="oliver" />,
+    );
+    expect(container.textContent).not.toContain('1,420');
+    settle();
+    expect(container.textContent).toContain('1,420');
+    expect(container.textContent).toContain('1,480');
+  });
+
+  it('animates streak counts', () => {
+    const { container } = render(<RankedPerformanceSection competitive={competitive} />);
+    settle();
+    expect(container.textContent).toContain('5');
+  });
+
+  it('renders an em dash for a missing number rather than counting to zero', () => {
+    const blank = { ...competitive, rating: null, peakRating: null } as Competitive;
+    const { container } = render(<PlayerCompetitiveSummary competitive={blank} />);
+    settle();
+    expect(container.textContent).toContain('—');
+  });
+
+  it('releases animation frames when a surface unmounts mid-count', () => {
+    const cancel = vi.spyOn(window, 'cancelAnimationFrame');
+    const { unmount } = render(<PlayerCompetitiveSummary competitive={competitive} />);
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+    const before = cancel.mock.calls.length;
+    expect(() => unmount()).not.toThrow();
+    expect(cancel.mock.calls.length).toBeGreaterThan(before);
+    expect(() => settle()).not.toThrow();
+    cancel.mockRestore();
+  });
+});


### PR DESCRIPTION
Implements item #7 from the animation audit: wire the existing `AnimatedScore` primitive into the screens where numbers hard-cut to their final value.

## The catch worth knowing about

`AnimatedScore` seeded its state from `value`, so its effect early-returned on mount and the first render *was* the final number. It only animated when the value changed **while mounted** — which is why it works in the three HUDs it already ships in (the score changes during play), and why wiring it into a results screen as-is would have animated nothing.

Every target here mounts already knowing its value (results modals, and the Stats/profile sections, which render only after `loading` clears). So the primitive needed a way to start somewhere else.

## Primitive changes

`useAnimatedScore(value, duration, from?)` and `<AnimatedScore from format />`:

- **`from`** — start the count here. Read once on mount, so a re-render never restarts it from the bottom.
- **`format`** — formats the animating number, so a rating keeps its thousands separators.

Both optional and defaulting to the previous behaviour. The three existing HUD call sites are untouched and unchanged: they mount mid-match and must show the real score rather than count up to it.

## Call sites

| File | Before | After |
|---|---|---|
| `puzzleRush/RushResultsView.tsx` | `{serverScore ?? '—'}` | counts `0 → 870`; `—` when unscored |
| `dailyFritz/DailyFritzFinalResultOverlay.tsx` | `{overlay.shareRating}`, `{overlay.shareStreak}` | both count from `0` |
| `stats/components/PlayerRankedOverview.tsx` | `value.toLocaleString()` | counts up, separators kept |
| `stats/components/RankedPerformanceSection.tsx` | same | same |
| `stats/components/GhostPerformanceSection.tsx` | same | same |
| `stats/components/PuzzlePerformanceSection.tsx` | same | same |
| `identity/components/PlayerCompetitiveSummary.tsx` | same | same |

The five stats/profile files each already funnelled their numbers through one local formatter, so converting that helper to return a node left every JSX call site byte-identical.

Pace is the default 600ms everywhere, matching the existing usages.

## Deliberately not wired

- **The Fritz overlay's main stat row.** `setScoreValue` (`"2–0"`), `marginValue` (`"+80"`), `resultValue` (`"Won"`) and `rankValue` are formatted strings, not numbers. Only the two numeric meta pills were animatable.
- **`GlobalNav` header rating.** It's a string union with `'…'`/`'—'` loading states and a cache fallback, sitting in the auth path #61 just stabilised. Worth doing, but as its own change.
- **Global rank.** Rendered with a `#` prefix as an ordinal position; counting it up reads oddly.
- **Leaderboard board files** — excluded by request, decoupled from in-flight work.

## Performance

- **No CSS changed**, so no new keyframes or infinite animations.
- The rAF loop is self-cancelling. Given #61, there are now explicit tests that it **stops scheduling frames once it settles and stays stopped across re-renders**, and that unmounting mid-count cancels the handle without throwing — verified at the primitive and at three call sites, including a results modal dismissed mid-animation.
- No library added.

## Test fallout

Three pre-existing tests asserted these numbers synchronously, which only held for a raw render. They now let the count-up land first; their original assertions are unchanged. This is the general cost of animating a value — any future test touching these numbers needs timer control.

## Verification

- `tsc -b` clean
- Full client suite: **187 files, 1281 tests, all passing**
- Lint: 401 warnings / **0 errors**, unchanged from baseline
- 12 new tests (6 primitive, 2 Fritz overlay, 5 stats/profile, 2 Rush results)

🤖 Generated with [Claude Code](https://claude.com/claude-code)