### PR TITLE
feat(leaderboard): rebuild the Daily Fritz and Puzzle Rush boards

### DIFF
--- a/client/src/dailyFritz/DailyFritzLeaderboardScreen.tsx
+++ b/client/src/dailyFritz/DailyFritzLeaderboardScreen.tsx
@@ -5,7 +5,7 @@ import { GlobalNav } from '../components';
 import { GameOverlayPortal } from '../components/GameOverlayPortal';
 import { fetchFriends } from '../friends/friendsApi';
 import FilterPills from '../social/hub/FilterPills';
-import { PlayerInitialsAvatar } from '../components/hub';
+import { avatarHue, getInitials } from '../components/hub/playerInitialsAvatarUtils';
 import {
   fetchDailyFritzLeaderboard,
   getTodayDailyFritz,
@@ -17,11 +17,11 @@ import {
 import { buildDailyFritzFinalOverlayViewModel } from './buildFinalOverlayViewModel';
 import { DailyFritzFinalResultOverlay } from './DailyFritzFinalResultOverlay';
 import { buildShareText } from './shareCard';
-import { getGameSkunkChipLabel } from './skunk';
+import { describeSetStory } from './setStory';
 import { formatCountdownHms, secondsUntilNextPacificMidnight } from './format';
 import '../components/hub/hubDesignTokens.css';
 import '../social/hub/hubShared.css';
-import './dailyFritzLeaderboardScreen.css';
+import './dailyFritzLeaderboardBoard.css';
 
 type LeaderboardFilter = 'global' | 'friends' | 'topRated';
 
@@ -32,7 +32,10 @@ const FILTER_OPTIONS = [
 ];
 
 const GAME_NUMBERS: DailyFritzSetGameNumber[] = [1, 2, 3];
-const SPARSE_ROW_THRESHOLD = 8;
+/** Racers named outright in the skunk record before it collapses to a count. */
+const SKUNK_NAMES_SHOWN = 2;
+
+type LeaderboardGame = NonNullable<DailyFritzLeaderboardRow['games']>[number];
 
 interface DailyFritzLeaderboardScreenProps {
   user: User | null;
@@ -70,17 +73,18 @@ function formatDateLabel(dateText: string): string {
   });
 }
 
-function formatGameChip(game: NonNullable<DailyFritzLeaderboardRow['games']>[number]): string {
-  return (
-    getGameSkunkChipLabel({
-      gameNumber: game.gameNumber,
-      playerWon: game.playerWon,
-      playerScore: game.playerScore,
-      fritzScore: game.fritzScore,
-      skunk: game.skunk,
-      skunkBy: game.skunkBy,
-    }) ?? `G${game.gameNumber} ${game.playerScore}–${game.fritzScore}`
-  );
+function ordinalSuffix(rank: number): string {
+  const tens = rank % 100;
+  if (tens >= 11 && tens <= 13) return 'th';
+  const ones = rank % 10;
+  if (ones === 1) return 'st';
+  if (ones === 2) return 'nd';
+  if (ones === 3) return 'rd';
+  return 'th';
+}
+
+function hasSkunk(row: DailyFritzLeaderboardRow): boolean {
+  return (row.games ?? []).some((game) => game.skunk);
 }
 
 function isCurrentUserRow(row: DailyFritzLeaderboardRow, currentUsername: string | null): boolean {
@@ -92,192 +96,105 @@ function isCurrentUserRow(row: DailyFritzLeaderboardRow, currentUsername: string
   );
 }
 
-function RankIcon({ rank }: { rank: 1 | 2 | 3 }) {
-  if (rank === 1) {
-    return (
-      <span className="dflb-crown dflb-rank-icon--gold" aria-hidden="true">
-        <svg viewBox="0 0 24 24" width="18" height="18">
-          <path
-            d="M5 16L3 5l5.5 5L12 4l3.5 6L21 5l-2 11H5zm14 3c0 .6-.4 1-1 1H6c-.6 0-1-.4-1-1v-1h14v1z"
-            fill="var(--tier-elite)"
-          />
-        </svg>
-      </span>
-    );
-  }
-
-  const trophyColor = rank === 2 ? '#94a3b8' : '#c97b3f';
-  const tone = rank === 2 ? 'silver' : 'bronze';
-
+function RacerAvatar({ username }: { username: string }) {
+  const hue = avatarHue(username);
   return (
-    <span className={`dflb-trophy dflb-rank-icon--${tone}`} aria-hidden="true">
-      <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke={trophyColor} strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
-        <path d="M6 9H4.5a2.5 2.5 0 0 1 0-5H6" />
-        <path d="M18 9h1.5a2.5 2.5 0 0 0 0-5H18" />
-        <path d="M4 22h16" />
-        <path d="M10 14.66V17c0 .55-.47.98-.97 1.21C7.85 18.75 7 20.24 7 22" />
-        <path d="M14 14.66V17c0 .55.47.98.97 1.21C16.15 18.75 17 20.24 17 22" />
-        <path d="M18 2H6v7a6 6 0 0 0 12 0V2Z" />
+    <span
+      className="dfl-avatar"
+      aria-hidden="true"
+      style={{
+        background: `linear-gradient(145deg, hsl(${hue} 42% 38%), hsl(${(hue + 48) % 360} 48% 24%))`,
+      }}
+    >
+      {getInitials(username)}
+    </span>
+  );
+}
+
+function CrownGlyph() {
+  return (
+    <span className="dfl-rank__crown" aria-hidden="true">
+      <svg viewBox="0 0 24 24" width="13" height="13" fill="currentColor">
+        <path d="M5 16L3 5l5.5 5L12 4l3.5 6L21 5l-2 11H5zm14 3c0 .6-.4 1-1 1H6c-.6 0-1-.4-1-1v-1h14v1z" />
       </svg>
     </span>
   );
 }
 
-function GameBreakdown({ row }: { row: DailyFritzLeaderboardRow }) {
-  const gamesByNumber = new Map(
-    (row.games ?? []).map((game) => [game.gameNumber, game] as const),
-  );
+function GameMarginBar({ game }: { game: LeaderboardGame | undefined }) {
+  if (!game) {
+    return (
+      <div className="dfl-game dfl-game--empty">
+        <div className="dfl-game__track" />
+        <span className="dfl-game__score">—</span>
+      </div>
+    );
+  }
 
   return (
-    <div className="dflb-breakdown-chips">
-      {GAME_NUMBERS.map((gameNumber) => {
-        const game = gamesByNumber.get(gameNumber);
-        if (!game) {
-          return (
-            <span key={`${row.username}-g${gameNumber}`} className="dflb-game-chip is-muted">
-              G{gameNumber} —
-            </span>
-          );
-        }
-        return (
-          <span
-            key={`${row.username}-g${gameNumber}`}
-            className={`dflb-game-chip ${game.playerWon ? 'is-win' : 'is-loss'} ${game.skunk ? 'is-skunk' : ''}`}
-          >
-            {formatGameChip(game)}
-          </span>
-        );
-      })}
+    <div className="dfl-game">
+      <div
+        className={`dfl-game__track is-${game.playerWon ? 'win' : 'loss'}`}
+        role="img"
+        aria-label={`Game ${game.gameNumber}: ${game.playerWon ? 'won' : 'lost'}, you ${game.playerScore}, Fritz ${game.fritzScore}`}
+      />
+      <span className="dfl-game__score">
+        {game.playerScore}–{game.fritzScore}
+        {game.skunk ? <span className="dfl-game__skunk">SKUNK</span> : null}
+      </span>
     </div>
   );
 }
 
 function LeaderboardRow({
   row,
-  currentUsername,
+  isSelf,
 }: {
   row: DailyFritzLeaderboardRow;
-  currentUsername: string | null;
+  isSelf: boolean;
 }) {
-  const topRank = row.rank <= 3 ? (row.rank as 1 | 2 | 3) : null;
-  const isSelf = isCurrentUserRow(row, currentUsername);
+  const story = describeSetStory(row);
+  const gamesByNumber = new Map((row.games ?? []).map((game) => [game.gameNumber, game] as const));
 
   return (
-    <article
-      className={[
-        'dflb-row',
-        topRank ? `dflb-row--rank-${topRank}` : '',
-        isSelf ? 'dflb-row--self' : '',
-      ]
-        .filter(Boolean)
-        .join(' ')}
-    >
-      <div className="dflb-rank">
-        {topRank ? <RankIcon rank={topRank} /> : null}
-        <strong className={`dflb-rank-num${topRank ? ` is-${topRank}` : ''}`}>{row.rank}</strong>
+    <article className={`dfl-row dfl-row-grid${isSelf ? ' dfl-row--self' : ''}`}>
+      <div className="dfl-rank">
+        {row.rank === 1 ? <CrownGlyph /> : null}
+        <span>{row.rank}</span>
       </div>
-      <div className="dflb-player">
-        <PlayerInitialsAvatar
-          username={row.username}
-          size="md"
-          ring={topRank === 1 ? 'gold' : topRank === 2 ? 'silver' : topRank === 3 ? 'bronze' : 'none'}
-        />
-        <div className="dflb-player-copy">
-          <strong>
-            {row.username}
-            {isSelf ? <span className="dflb-you-tag">You</span> : null}
-          </strong>
+
+      <div className="dfl-racer">
+        <RacerAvatar username={row.username} />
+        <div className="dfl-racer__copy">
+          <div className="dfl-racer__name">
+            <span className="dfl-racer__handle">{row.username}</span>
+            {isSelf ? <span className="dfl-you">YOU</span> : null}
+          </div>
+          <div className={`dfl-racer__story is-${story.tone}`}>{story.label}</div>
         </div>
       </div>
-      <div className={`dflb-cell dflb-result ${row.won ? 'is-win' : 'is-loss'}`}>
-        {row.won ? 'Won' : 'Lost'}
+
+      <div className="dfl-set">
+        <div className="dfl-set__games">
+          {row.finalScore}-{row.opponentScore}
+        </div>
+        <div className={`dfl-set__margin ${row.pointDiff >= 0 ? 'is-win' : 'is-loss'}`}>
+          {formatMargin(row.pointDiff)}
+        </div>
       </div>
-      <div className="dflb-cell dflb-set-score">
-        {row.finalScore}–{row.opponentScore}
+
+      <div className="dfl-games">
+        {GAME_NUMBERS.map((gameNumber) => (
+          <GameMarginBar key={gameNumber} game={gamesByNumber.get(gameNumber)} />
+        ))}
       </div>
-      <div className={`dflb-cell dflb-margin ${row.pointDiff >= 0 ? 'is-win' : 'is-loss'}`}>
-        {formatMargin(row.pointDiff)}
-      </div>
-      <div className="dflb-cell dflb-finished">{formatCompletedAt(row.completedAt)}</div>
-      <div className="dflb-breakdown">
-        <GameBreakdown row={row} />
-      </div>
+
+      <div className="dfl-finished">{formatCompletedAt(row.completedAt)}</div>
     </article>
   );
 }
 
-function PodiumSlot({
-  rank,
-  row,
-}: {
-  rank: 1 | 2 | 3;
-  row: DailyFritzLeaderboardRow | null;
-}) {
-  const ring = rank === 1 ? 'gold' : rank === 2 ? 'silver' : 'bronze';
-
-  const rankDisplay = rank === 1 ? null : (
-    <RankIcon rank={rank} />
-  );
-
-  const crownBadge = rank === 1 ? (
-    <span className="dflb-podium-crown-badge" aria-hidden="true">
-      <RankIcon rank={1} />
-    </span>
-  ) : null;
-
-  if (!row) {
-    return (
-      <div className={`dflb-podium-slot place-${rank} is-empty`}>
-        {crownBadge}
-        {rankDisplay}
-        <span className="dflb-podium-avatar dflb-podium-avatar--empty" aria-hidden="true">
-          <span className="dflb-podium-avatar__glyph">+</span>
-        </span>
-        <span className="dflb-podium-name">—</span>
-        <span className="dflb-podium-empty-hint">Unclaimed</span>
-      </div>
-    );
-  }
-
-  return (
-    <div className={`dflb-podium-slot place-${rank}${rank === 1 ? ' is-featured' : ''}`}>
-      {crownBadge}
-      {rankDisplay}
-      <PlayerInitialsAvatar username={row.username} size={rank === 1 ? 'lg' : 'md'} ring={ring} />
-      <span className="dflb-podium-name">{row.username}</span>
-      <span className="dflb-podium-score">{row.finalScore}–{row.opponentScore}</span>
-      <span className="dflb-podium-margin">{formatMargin(row.pointDiff)}</span>
-    </div>
-  );
-}
-
-function InsightStatIcon({ tone }: { tone: 'blue' | 'gold' }) {
-  if (tone === 'blue') {
-    return (
-      <span className="dflb-insight-stat__icon" aria-hidden="true">
-        <svg viewBox="0 0 24 24" width="14" height="14" fill="none">
-          <circle cx="12" cy="12" r="9" stroke="currentColor" strokeWidth="1.5" />
-          <path d="M12 7v5l3 2" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
-        </svg>
-      </span>
-    );
-  }
-  return (
-    <span className="dflb-insight-stat__icon" aria-hidden="true">
-      <svg viewBox="0 0 24 24" width="14" height="14" fill="none">
-        <path
-          d="M4 18l4-10 4 6 4-8 4 12"
-          stroke="currentColor"
-          strokeWidth="1.5"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        />
-      </svg>
-    </span>
-  );
-}
-
-function InsightStat({
+function RecordRow({
   label,
   name,
   value,
@@ -286,22 +203,15 @@ function InsightStat({
   label: string;
   name: string | null;
   value: string;
-  tone: 'blue' | 'gold';
+  tone?: 'win' | 'accent';
 }) {
   return (
-    <div className={`dflb-insight-stat is-${tone}`}>
-      <div className="dflb-insight-stat__head">
-        <InsightStatIcon tone={tone} />
-        <span className="dflb-insight-stat__label">{label}</span>
+    <div className="dfl-record">
+      <div className="dfl-record__copy">
+        <span className="dfl-record__label">{label}</span>
+        <span className="dfl-record__name">{name ?? '—'}</span>
       </div>
-      {name ? (
-        <>
-          <strong className="dflb-insight-stat__name">{name}</strong>
-          <span className="dflb-insight-stat__value">{value}</span>
-        </>
-      ) : (
-        <span className="dflb-insight-stat__empty">—</span>
-      )}
+      <span className={`dfl-record__value${tone ? ` is-${tone}` : ''}`}>{value}</span>
     </div>
   );
 }
@@ -389,9 +299,7 @@ export default function DailyFritzLeaderboardScreen({
   const hasCompletedSetToday = Boolean(
     today?.attempt_status === 'completed' && today.set_result?.setWinner,
   );
-  const completedButUnranked = Boolean(
-    hasCompletedSetToday && !selfRow,
-  );
+  const completedButUnranked = Boolean(hasCompletedSetToday && !selfRow);
 
   useEffect(() => {
     if (!user?.id) {
@@ -475,29 +383,31 @@ export default function DailyFritzLeaderboardScreen({
     setShareDone(false);
   }, [resultShareText, resultOverlayOpen]);
 
-  const podiumSlots = useMemo(
-    () => [rows[0] ?? null, rows[1] ?? null, rows[2] ?? null] as const,
-    [rows],
-  );
-
-  const fastestFinisher = useMemo(() => {
-    if (rows.length === 0) return null;
-    return [...rows].sort(
-      (a, b) => new Date(a.completedAt).getTime() - new Date(b.completedAt).getTime(),
-    )[0];
-  }, [rows]);
-
   const bestMargin = useMemo(() => {
     const winners = rows.filter((r) => r.won);
     if (winners.length === 0) return null;
     return [...winners].sort((a, b) => b.pointDiff - a.pointDiff)[0];
   }, [rows]);
 
-  const isSparse = !loading && !error && filteredRows.length > 0 && filteredRows.length < SPARSE_ROW_THRESHOLD;
-  const playerCountLabel = `${rows.length} ${rows.length === 1 ? 'player' : 'players'}`;
+  const skunkRacers = useMemo(() => rows.filter(hasSkunk), [rows]);
+
+  const skunkRacersLabel = useMemo(() => {
+    if (skunkRacers.length === 0) return null;
+    const named = skunkRacers.slice(0, SKUNK_NAMES_SHOWN).map((row) => row.username);
+    const rest = skunkRacers.length - named.length;
+    return rest > 0 ? `${named.join(', ')} +${rest}` : named.join(', ');
+  }, [skunkRacers]);
+
+  const goBackToDailyFritz = useCallback(() => {
+    if (onNavigate) {
+      onNavigate('dailyFritz');
+      return;
+    }
+    onBack();
+  }, [onNavigate, onBack]);
 
   return (
-    <div className="rh-hub-screen dflb-page">
+    <div className="rh-hub-screen dfl-page">
       <div className="rh-hub-shell">
         <GlobalNav
           currentMode="leaderboard"
@@ -514,113 +424,116 @@ export default function DailyFritzLeaderboardScreen({
         />
 
         <div className="rh-hub-body">
-          <div className="rh-hub-inner dflb-inner">
-            <header className="dflb-command">
-              <div className="dflb-command-hero">
-                <div className="dflb-command__brand">
-                  <span className="rh-hub-tag dflb-eyebrow">Daily Fritz</span>
-                  <h1 className="dflb-command__title">Leaderboard</h1>
-                  <p className="dflb-command__sub">
-                    Global ranking · Compete daily against Fritz and the world.
-                  </p>
+          <div className="rh-hub-inner dfl-inner">
+            <div className="dfl-board">
+              <header className="dfl-masthead">
+                <div>
+                  <span className="dfl-eyebrow">Daily Fritz</span>
+                  <h1 className="dfl-title">
+                    Leaderboard<span className="dfl-title__dot">.</span>
+                  </h1>
+                  <p className="dfl-tagline">Everyone plays the same tiles. The only variable is you.</p>
                 </div>
-                <div className="dflb-command__aside">
-                  <div className="dflb-command__actions">
-                    {hasCompletedSetToday && resultOverlayConfig ? (
-                      <button
-                        type="button"
-                        className="dflb-share-result-btn"
-                        onClick={() => setResultOverlayOpen(true)}
-                      >
-                        Share Result
-                      </button>
-                    ) : null}
+                <div className="dfl-masthead__actions">
+                  <button type="button" className="dfl-btn" onClick={goBackToDailyFritz}>
+                    <span aria-hidden>←</span>
+                    Daily Fritz
+                  </button>
+                  {hasCompletedSetToday && resultOverlayConfig ? (
                     <button
                       type="button"
-                      className="dflb-back-link rh-back-button"
-                      onClick={() => {
-                        if (onNavigate) {
-                          onNavigate('dailyFritz');
-                          return;
-                        }
-                        onBack();
-                      }}
+                      className="dfl-btn dfl-btn--accent"
+                      onClick={() => setResultOverlayOpen(true)}
                     >
-                      <span aria-hidden>←</span>
-                      Back to Daily Fritz
+                      Share Result
                     </button>
-                  </div>
-                  <div className="dflb-command__meta" aria-label="Daily board status">
-                    <div className="dflb-meta-chip">
-                      <span className="dflb-meta-chip__label">Date</span>
-                      <span className="dflb-meta-chip__value">{formatDateLabel(runDate)}</span>
-                    </div>
-                    <div className="dflb-meta-chip dflb-meta-chip--board">
-                      <span className="dflb-meta-chip__label">Board</span>
-                      <span className="dflb-meta-chip__value">{playerCountLabel}</span>
-                    </div>
-                    <div className="dflb-meta-chip dflb-meta-chip--reset">
-                      <span className="dflb-meta-chip__label">Resets in</span>
-                      <span className="dflb-meta-chip__value is-cyan">{resetLabel}</span>
-                    </div>
-                  </div>
+                  ) : null}
+                </div>
+              </header>
+
+              <div className="dfl-meta" aria-label="Daily board status">
+                <div className="dfl-meta__cell">
+                  <span className="dfl-meta__label">Date</span>
+                  <span className="dfl-meta__value">{formatDateLabel(runDate)}</span>
+                </div>
+                <div className="dfl-meta__cell">
+                  <span className="dfl-meta__label">Racers</span>
+                  <span className="dfl-meta__value">{rows.length}</span>
+                </div>
+                <div className="dfl-meta__cell">
+                  <span className="dfl-meta__label">Skunks today</span>
+                  <span className="dfl-meta__value is-accent">{skunkRacers.length}</span>
+                </div>
+                <div className="dfl-meta__cell">
+                  <span className="dfl-meta__label">Resets in</span>
+                  <span className="dfl-meta__value">{resetLabel}</span>
                 </div>
               </div>
-              <div className="dflb-command__bar">
-                <FilterPills
-                  options={FILTER_OPTIONS}
-                  value={filter}
-                  onChange={setFilter}
-                  ariaLabel="Leaderboard filters"
-                />
-              </div>
-            </header>
 
-            <div className="dflb-layout">
-              <aside className="dflb-insights" aria-label="Board highlights">
-                <div className="rh-hub-panel dflb-insights-panel">
-                  <section className="dflb-insights__section" aria-label="Today's podium">
-                    <h3 className="dflb-insights__label">Today&apos;s podium</h3>
-                    <div className="dflb-podium-stage">
-                      <div className="dflb-podium">
-                        <PodiumSlot rank={2} row={podiumSlots[1]} />
-                        <PodiumSlot rank={1} row={podiumSlots[0]} />
-                        <PodiumSlot rank={3} row={podiumSlots[2]} />
+              <FilterPills
+                options={FILTER_OPTIONS}
+                value={filter}
+                onChange={setFilter}
+                ariaLabel="Leaderboard filters"
+              />
+
+              <div className="dfl-layout">
+                <section className="dfl-table" aria-label="Daily Fritz standings">
+                  <div className="dfl-thead dfl-row-grid" aria-hidden="true">
+                    <span>Rank</span>
+                    <span>Racer</span>
+                    <span>Set · Margin</span>
+                    <span className="dfl-thead__games">The three games</span>
+                    <span className="dfl-thead__finished">Finished</span>
+                  </div>
+
+                  <div className="dfl-tbody">
+                    {loading ? <p className="dfl-state">Loading leaderboard…</p> : null}
+                    {!loading && error ? (
+                      <p className="dfl-state dfl-state--error" role="alert">
+                        Couldn&apos;t load the leaderboard. Please try again.
+                      </p>
+                    ) : null}
+                    {!loading && !error && filteredRows.length === 0 ? (
+                      <div className="dfl-state">
+                        <p style={{ margin: 0 }}>No runs match this filter yet.</p>
+                        <p className="dfl-state__hint">
+                          Complete today&apos;s Daily Fritz set to claim the first spot.
+                        </p>
                       </div>
-                    </div>
-                  </section>
+                    ) : null}
+                    {!loading && !error
+                      ? filteredRows.map((row) => (
+                          <LeaderboardRow
+                            key={`${row.rank}-${row.username}-${row.completedAt}`}
+                            row={row}
+                            isSelf={isCurrentUserRow(row, currentUsername)}
+                          />
+                        ))
+                      : null}
+                  </div>
+                </section>
 
-                  <div className="dflb-insights__divider" aria-hidden="true" />
-
-                  <section className="dflb-insights__section dflb-insights__stats" aria-label="Daily records">
-                    <InsightStat
-                      label="Fastest finisher"
-                      name={fastestFinisher?.username ?? null}
-                      value={fastestFinisher ? formatCompletedAt(fastestFinisher.completedAt) : '—'}
-                      tone="blue"
-                    />
-                    <InsightStat
-                      label="Best margin"
-                      name={bestMargin?.username ?? null}
-                      value={bestMargin ? formatMargin(bestMargin.pointDiff) : '—'}
-                      tone="gold"
-                    />
-                  </section>
-
-                  <div className="dflb-insights__divider" aria-hidden="true" />
-
-                  <section className="dflb-insights__section dflb-insights__you" aria-label="Your position">
-                    <h3 className="dflb-insights__label">Your position</h3>
+                <aside className="dfl-rail" aria-label="Board highlights">
+                  <section className="dfl-card dfl-card--accent" aria-label="Your position">
+                    <h2 className="dfl-card__head">Your position</h2>
                     {selfRow ? (
-                      <div className="dflb-you-strip">
-                        <div className="dflb-you-strip__rank">
-                          <span className="dflb-you-strip__hash">#</span>
-                          <span className="dflb-you-strip__num">{selfRow.rank}</span>
+                      <>
+                        <div className="dfl-position">
+                          <span className="dfl-position__rank">
+                            {selfRow.rank}
+                            <span className="dfl-position__suffix">{ordinalSuffix(selfRow.rank)}</span>
+                          </span>
+                          <span className="dfl-position__of">
+                            of {rows.length} {rows.length === 1 ? 'racer' : 'racers'}
+                          </span>
                         </div>
-                        <dl className="dflb-you-strip__stats">
+                        <dl className="dfl-position__stats">
                           <div>
                             <dt>Set</dt>
-                            <dd>{selfRow.finalScore}–{selfRow.opponentScore}</dd>
+                            <dd>
+                              {selfRow.finalScore}-{selfRow.opponentScore}
+                            </dd>
                           </div>
                           <div>
                             <dt>Margin</dt>
@@ -633,97 +546,35 @@ export default function DailyFritzLeaderboardScreen({
                             <dd>{formatCompletedAt(selfRow.completedAt)}</dd>
                           </div>
                         </dl>
-                      </div>
+                      </>
                     ) : (
-                      <div className="dflb-you-empty">
-                        <p>
-                          {completedButUnranked
-                            ? today?.verification_status === 'verified'
-                              ? 'Your result is still syncing to the board.'
-                              : 'Finished today — not on the ranked board.'
-                            : "Play today's set to take your place."}
-                        </p>
-                      </div>
+                      <p className="dfl-position__empty">
+                        {completedButUnranked
+                          ? today?.verification_status === 'verified'
+                            ? 'Your result is still syncing to the board.'
+                            : 'Finished today — not on the ranked board.'
+                          : "Play today's set to take your place."}
+                      </p>
                     )}
                   </section>
-                </div>
-              </aside>
 
-              <section className="dflb-standings" aria-label="Daily Fritz standings">
-                <div
-                  className={[
-                    'rh-hub-panel',
-                    'dflb-standings-panel',
-                    isSparse ? 'is-compact' : '',
-                  ]
-                    .filter(Boolean)
-                    .join(' ')}
-                >
-                  <div className="dflb-table-head" aria-hidden="true">
-                    <span>Rank</span>
-                    <span>Player</span>
-                    <span>Result</span>
-                    <span>Set</span>
-                    <span>Margin</span>
-                    <span>Time</span>
-                    <span>Games</span>
-                  </div>
-
-                  <div
-                    className={[
-                      'dflb-table-body',
-                      filteredRows.length > SPARSE_ROW_THRESHOLD ? 'is-scrollable' : '',
-                    ]
-                      .filter(Boolean)
-                      .join(' ')}
-                  >
-                    {loading ? <p className="dflb-state">Loading leaderboard…</p> : null}
-                    {!loading && error ? (
-                      <p className="dflb-state dflb-state--error" role="alert">
-                        Couldn&apos;t load the leaderboard. Please try again.
-                      </p>
-                    ) : null}
-                    {!loading && !error && filteredRows.length === 0 ? (
-                      <div className="dflb-empty-board">
-                        <p className="dflb-state">No runs match this filter yet.</p>
-                        <p className="dflb-empty-hint">Complete today&apos;s Daily Fritz set to claim the first spot.</p>
-                      </div>
-                    ) : null}
-                    {!loading && !error
-                      ? filteredRows.map((row) => (
-                          <LeaderboardRow
-                            key={`${row.rank}-${row.username}-${row.completedAt}`}
-                            row={row}
-                            currentUsername={currentUsername}
-                          />
-                        ))
-                      : null}
-                  </div>
-
-                  {isSparse ? (
-                    <footer className="dflb-standings-foot" aria-live="polite">
-                      <span className="dflb-standings-foot__icon" aria-hidden="true">
-                        <svg viewBox="0 0 24 24" width="18" height="18" fill="none">
-                          <path
-                            d="M4 12h16M12 4v16"
-                            stroke="currentColor"
-                            strokeWidth="1.5"
-                            strokeLinecap="round"
-                            opacity="0.5"
-                          />
-                          <circle cx="12" cy="12" r="9" stroke="currentColor" strokeWidth="1.5" opacity="0.35" />
-                        </svg>
-                      </span>
-                      <div className="dflb-standings-foot__copy">
-                        <p className="dflb-standings-foot__title">More racers on the way</p>
-                        <p className="dflb-standings-foot__sub">
-                          More racers will appear as they finish today&apos;s set.
-                        </p>
-                      </div>
-                    </footer>
-                  ) : null}
-                </div>
-              </section>
+                  <section className="dfl-card" aria-label="Today's records">
+                    <h2 className="dfl-card__head">Today&apos;s records</h2>
+                    <RecordRow
+                      label="Best margin"
+                      name={bestMargin?.username ?? null}
+                      value={bestMargin ? formatMargin(bestMargin.pointDiff) : '—'}
+                      tone="win"
+                    />
+                    <RecordRow
+                      label="Skunks today"
+                      name={skunkRacersLabel}
+                      value={String(skunkRacers.length)}
+                      tone="accent"
+                    />
+                  </section>
+                </aside>
+              </div>
             </div>
           </div>
         </div>

--- a/client/src/dailyFritz/dailyFritzLeaderboardBoard.css
+++ b/client/src/dailyFritz/dailyFritzLeaderboardBoard.css
@@ -1,0 +1,763 @@
+/*
+ * Daily Fritz leaderboard — tabular board.
+ *
+ * One visual system with the result overlay: margin bars, not chips; hairline
+ * rules, not per-row cards; square corners throughout so crossing from the
+ * modal to the board never changes language.
+ */
+
+.dfl-page {
+  --dfl-line: rgba(255, 255, 255, 0.08);
+  --dfl-line-soft: rgba(255, 255, 255, 0.05);
+  --dfl-ink: rgba(255, 255, 255, 0.95);
+  --dfl-muted: rgba(255, 255, 255, 0.6);
+  --dfl-label: rgba(255, 255, 255, 0.42);
+  /* The board's accent. Daily Fritz is gold; a mode can retint the whole
+     board by redefining just this block (see .pr-board in puzzleRush.css). */
+  --dfl-accent: var(--hub-gold);
+  --dfl-accent-rgb: 231, 182, 74;
+  --dfl-accent-border: rgba(var(--dfl-accent-rgb), 0.42);
+  --dfl-accent-dim: rgba(var(--dfl-accent-rgb), 0.14);
+  --dfl-accent-row: rgba(var(--dfl-accent-rgb), 0.045);
+  --dfl-accent-row-hover: rgba(var(--dfl-accent-rgb), 0.065);
+  --dfl-accent-head: rgba(var(--dfl-accent-rgb), 0.09);
+  --dfl-accent-head-border: rgba(var(--dfl-accent-rgb), 0.22);
+  /* Text sitting on a filled accent button. */
+  --dfl-accent-ink: var(--bg-obsidian);
+  --dfl-win: var(--hub-win);
+  --dfl-loss: var(--hub-loss);
+  --dfl-line-strong: rgba(255, 255, 255, 0.14);
+  --dfl-subtle: rgba(255, 255, 255, 0.72);
+  --dfl-dim: rgba(255, 255, 255, 0.35);
+  --dfl-grid: rgba(255, 255, 255, 0.03);
+  --dfl-glass: rgba(10, 16, 28, 0.6);
+  --dfl-surface: rgba(255, 255, 255, 0.015);
+  --dfl-radius: 3px;
+}
+
+.dfl-inner {
+  display: flex;
+  flex-direction: column;
+  padding: 20px 28px 18px;
+}
+
+.dfl-board {
+  display: flex;
+  flex: 1 1 0;
+  min-height: 0;
+  flex-direction: column;
+  gap: 14px;
+}
+
+/* ---------------------------------------------------------------- masthead */
+
+.dfl-masthead {
+  position: relative;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 24px;
+  padding: 26px 26px 22px;
+  border: 1px solid var(--dfl-line);
+  border-radius: var(--dfl-radius) var(--dfl-radius) 0 0;
+  background-color: rgba(255, 255, 255, 0.012);
+  background-image:
+    linear-gradient(var(--dfl-grid) 1px, transparent 1px),
+    linear-gradient(90deg, var(--dfl-grid) 1px, transparent 1px);
+  background-size: 44px 44px, 44px 44px;
+}
+
+.dfl-eyebrow {
+  display: block;
+  margin: 0 0 6px;
+  font-family: var(--font-display);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--dfl-label);
+}
+
+.dfl-title {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: clamp(40px, 5vw, 62px);
+  font-weight: 800;
+  line-height: 0.92;
+  letter-spacing: -0.01em;
+  color: var(--dfl-ink);
+}
+
+.dfl-title__dot {
+  color: var(--dfl-accent);
+}
+
+.dfl-tagline {
+  margin: 10px 0 0;
+  font-size: 13px;
+  color: var(--dfl-muted);
+}
+
+.dfl-masthead__actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-shrink: 0;
+}
+
+.dfl-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  height: 34px;
+  padding: 0 14px;
+  border: 1px solid var(--dfl-line);
+  border-radius: var(--dfl-radius);
+  background: var(--dfl-glass);
+  color: var(--dfl-muted);
+  font-family: var(--font-body);
+  font-size: 12px;
+  font-weight: 600;
+  white-space: nowrap;
+  cursor: pointer;
+  transition: color 140ms ease, border-color 140ms ease;
+}
+
+.dfl-btn:hover {
+  color: var(--dfl-ink);
+  border-color: var(--dfl-line-strong);
+}
+
+.dfl-btn--accent {
+  border-color: var(--dfl-accent);
+  background: var(--dfl-accent);
+  color: var(--dfl-accent-ink);
+  font-weight: 700;
+}
+
+.dfl-btn--accent:hover {
+  color: var(--dfl-accent-ink);
+  border-color: var(--dfl-accent);
+  filter: brightness(1.07);
+}
+
+/* -------------------------------------------------------------- meta strip */
+
+.dfl-meta {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  border: 1px solid var(--dfl-line);
+  border-top: 0;
+  border-radius: 0 0 var(--dfl-radius) var(--dfl-radius);
+  background: var(--dfl-surface);
+}
+
+.dfl-meta__cell {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  height: 34px;
+  padding: 0 18px;
+  border-left: 1px solid var(--dfl-line-soft);
+  min-width: 0;
+}
+
+.dfl-meta__cell:first-child {
+  border-left: 0;
+}
+
+.dfl-meta__label {
+  flex-shrink: 0;
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--dfl-label);
+}
+
+.dfl-meta__value {
+  font-family: var(--font-display);
+  font-size: 14px;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+  color: var(--dfl-ink);
+  font-variant-numeric: tabular-nums;
+}
+
+.dfl-meta__value.is-accent {
+  color: var(--dfl-accent);
+}
+
+/* ----------------------------------------------------------------- filters */
+
+.dfl-page .rh-hub-filters {
+  flex: 0 0 auto;
+}
+
+.dfl-page .rh-hub-filter {
+  height: 30px;
+  padding: 0 14px;
+  border-radius: var(--dfl-radius);
+  border-color: var(--dfl-line);
+  font-size: 11px;
+  letter-spacing: 0.02em;
+}
+
+/* hubShared paints the active pill gold outright, so restate it on the
+   accent token — otherwise a retinted board keeps a gold filter. */
+.dfl-page .rh-hub-filter--active {
+  border-color: var(--dfl-accent-border);
+  background: var(--dfl-accent-dim);
+  color: var(--dfl-accent);
+  box-shadow: none;
+}
+
+.dfl-page .rh-hub-filter:hover {
+  border-color: var(--dfl-accent-border);
+}
+
+/* ------------------------------------------------------------------ layout */
+
+.dfl-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 288px;
+  gap: 16px;
+  flex: 1 1 0;
+  min-height: 0;
+}
+
+/* ------------------------------------------------------------------- table */
+
+.dfl-table {
+  display: flex;
+  min-height: 0;
+  flex-direction: column;
+  border: 1px solid var(--dfl-line);
+  border-radius: var(--dfl-radius);
+  background: var(--dfl-surface);
+  overflow: hidden;
+}
+
+.dfl-row-grid {
+  display: grid;
+  grid-template-columns: 64px minmax(0, 1fr) 104px 232px 92px;
+  align-items: center;
+  gap: 12px;
+  padding: 0 20px;
+}
+
+.dfl-thead {
+  height: 34px;
+  border-bottom: 1px solid var(--dfl-line);
+  background: rgba(255, 255, 255, 0.014);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--dfl-label);
+}
+
+.dfl-thead__finished {
+  text-align: right;
+}
+
+.dfl-tbody {
+  flex: 1 1 0;
+  min-height: 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+}
+
+.dfl-row {
+  position: relative;
+  min-height: 60px;
+  border-bottom: 1px solid var(--dfl-line-soft);
+  transition: background 140ms ease;
+}
+
+.dfl-row:last-child {
+  border-bottom: 0;
+}
+
+.dfl-row:hover {
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.dfl-row--self {
+  background: var(--dfl-accent-row);
+}
+
+.dfl-row--self:hover {
+  background: var(--dfl-accent-row-hover);
+}
+
+.dfl-row--self::before {
+  content: "";
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 3px;
+  background: var(--dfl-accent);
+}
+
+/* rank */
+
+.dfl-rank {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  font-family: var(--font-display);
+  font-size: 20px;
+  font-weight: 700;
+  color: var(--dfl-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.dfl-row--self .dfl-rank {
+  color: var(--dfl-accent);
+}
+
+.dfl-rank__crown {
+  display: inline-flex;
+  color: var(--dfl-accent);
+}
+
+/* racer */
+
+.dfl-racer {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  min-width: 0;
+}
+
+.dfl-avatar {
+  display: grid;
+  place-items: center;
+  width: 28px;
+  height: 28px;
+  flex-shrink: 0;
+  border-radius: var(--dfl-radius);
+  font-family: var(--font-display);
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  color: rgba(255, 255, 255, 0.92);
+  text-transform: uppercase;
+}
+
+.dfl-racer__copy {
+  min-width: 0;
+}
+
+.dfl-racer__name {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--dfl-ink);
+}
+
+.dfl-racer__handle {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.dfl-you {
+  flex-shrink: 0;
+  padding: 1px 5px;
+  border: 1px solid var(--dfl-accent-border);
+  border-radius: 2px;
+  background: var(--dfl-accent-dim);
+  color: var(--dfl-accent);
+  font-family: var(--font-display);
+  font-size: 9px;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+}
+
+.dfl-racer__story {
+  margin-top: 2px;
+  font-size: 11.5px;
+  color: var(--dfl-muted);
+}
+
+.dfl-racer__story.is-skunk {
+  color: var(--dfl-accent);
+}
+
+.dfl-racer__story.is-skunked {
+  color: var(--dfl-loss);
+}
+
+/* set · margin */
+
+.dfl-set {
+  font-variant-numeric: tabular-nums;
+}
+
+.dfl-set__games {
+  font-family: var(--font-display);
+  font-size: 22px;
+  font-weight: 700;
+  line-height: 1.05;
+  color: var(--dfl-ink);
+}
+
+.dfl-set__margin {
+  font-size: 11.5px;
+  font-weight: 600;
+  color: var(--dfl-muted);
+}
+
+.dfl-set__margin.is-win {
+  color: var(--dfl-win);
+}
+
+.dfl-set__margin.is-loss {
+  color: var(--dfl-loss);
+}
+
+/* three games */
+
+.dfl-games {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.dfl-game {
+  min-width: 0;
+}
+
+/*
+ * One bar per game, one colour: green if you took that game, red if Fritz did.
+ * The scores sit directly underneath, so the bar only has to answer "who won".
+ */
+.dfl-game__track {
+  height: 3px;
+  border-radius: 1px;
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.dfl-game__track.is-win {
+  background: var(--dfl-win);
+}
+
+.dfl-game__track.is-loss {
+  background: var(--dfl-loss);
+}
+
+.dfl-game__score {
+  display: block;
+  margin-top: 6px;
+  font-size: 10.5px;
+  font-weight: 600;
+  color: var(--dfl-muted);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.dfl-game__skunk {
+  margin-left: 4px;
+  font-family: var(--font-display);
+  font-size: 9px;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+  color: var(--dfl-accent);
+}
+
+.dfl-game--empty .dfl-game__score {
+  color: var(--dfl-dim);
+}
+
+/* finished */
+
+.dfl-finished {
+  text-align: right;
+  font-size: 12px;
+  color: var(--dfl-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+/* board states */
+
+.dfl-state {
+  margin: 0;
+  padding: 30px 22px;
+  font-size: 13px;
+  color: var(--dfl-muted);
+}
+
+.dfl-state--error {
+  color: var(--dfl-loss);
+}
+
+.dfl-state__hint {
+  margin: 6px 0 0;
+  font-size: 12px;
+  color: var(--dfl-dim);
+}
+
+/* -------------------------------------------------------------------- rail */
+
+.dfl-rail {
+  display: flex;
+  min-height: 0;
+  flex-direction: column;
+  gap: 16px;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+}
+
+.dfl-card {
+  flex-shrink: 0;
+  border: 1px solid var(--dfl-line);
+  border-radius: var(--dfl-radius);
+  background: var(--dfl-surface);
+}
+
+.dfl-card__head {
+  padding: 9px 14px;
+  border-bottom: 1px solid var(--dfl-line);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--dfl-label);
+}
+
+.dfl-card--accent .dfl-card__head {
+  background: var(--dfl-accent-head);
+  border-bottom-color: var(--dfl-accent-head-border);
+  color: var(--dfl-accent);
+}
+
+/* your position */
+
+.dfl-position {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  padding: 11px 14px 10px;
+}
+
+.dfl-position__rank {
+  font-family: var(--font-display);
+  font-size: 33px;
+  font-weight: 800;
+  line-height: 1;
+  color: var(--dfl-accent);
+  font-variant-numeric: tabular-nums;
+}
+
+.dfl-position__suffix {
+  font-size: 0.5em;
+  letter-spacing: 0.02em;
+}
+
+.dfl-position__of {
+  font-size: 12px;
+  color: var(--dfl-muted);
+}
+
+.dfl-position__stats {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  margin: 0;
+  border-top: 1px solid var(--dfl-line);
+}
+
+.dfl-position__stats > div {
+  padding: 8px 12px 9px;
+  border-left: 1px solid var(--dfl-line-soft);
+  min-width: 0;
+}
+
+.dfl-position__stats > div:first-child {
+  border-left: 0;
+}
+
+.dfl-position__stats dt {
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.13em;
+  text-transform: uppercase;
+  color: var(--dfl-label);
+}
+
+.dfl-position__stats dd {
+  margin: 4px 0 0;
+  font-family: var(--font-display);
+  font-size: 16px;
+  font-weight: 700;
+  color: var(--dfl-ink);
+  font-variant-numeric: tabular-nums;
+}
+
+.dfl-position__stats dd.is-win {
+  color: var(--dfl-win);
+}
+
+.dfl-position__stats dd.is-loss {
+  color: var(--dfl-loss);
+}
+
+.dfl-position__empty {
+  margin: 0;
+  padding: 16px;
+  font-size: 12.5px;
+  line-height: 1.45;
+  color: var(--dfl-muted);
+}
+
+/* records */
+
+.dfl-record {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 9px 14px 10px;
+  border-bottom: 1px solid var(--dfl-line-soft);
+}
+
+.dfl-record:last-child {
+  border-bottom: 0;
+}
+
+.dfl-record__copy {
+  min-width: 0;
+}
+
+.dfl-record__label {
+  display: block;
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.13em;
+  text-transform: uppercase;
+  color: var(--dfl-label);
+}
+
+.dfl-record__name {
+  display: block;
+  margin-top: 3px;
+  font-size: 12.5px;
+  font-weight: 600;
+  color: var(--dfl-ink);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.dfl-record__value {
+  flex-shrink: 0;
+  font-family: var(--font-display);
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--dfl-ink);
+  font-variant-numeric: tabular-nums;
+}
+
+.dfl-record__value.is-win {
+  color: var(--dfl-win);
+}
+
+.dfl-record__value.is-accent {
+  color: var(--dfl-accent);
+}
+
+/* ------------------------------------------------------------- responsive */
+
+/*
+ * Below the two-column breakpoint the rail drops under the table, so the page
+ * itself becomes the scroller instead of the table body and the rail.
+ */
+@media (max-width: 1100px) {
+  .dfl-inner {
+    overflow-y: auto;
+  }
+
+  .dfl-board,
+  .dfl-layout {
+    flex: 0 0 auto;
+  }
+
+  .dfl-layout {
+    grid-template-columns: minmax(0, 1fr);
+    grid-auto-rows: auto;
+  }
+
+  .dfl-rail,
+  .dfl-table,
+  .dfl-tbody {
+    overflow: visible;
+  }
+
+  /* The body must size to its rows here; a 0 flex-basis collapses it to
+     nothing once the table is no longer a fixed-height column. */
+  .dfl-tbody {
+    flex: 0 0 auto;
+  }
+}
+
+@media (max-width: 860px) {
+  .dfl-inner {
+    padding: 16px 14px 14px;
+  }
+
+  .dfl-masthead {
+    flex-direction: column;
+    gap: 16px;
+    padding: 20px 18px 18px;
+  }
+
+  .dfl-meta {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .dfl-meta__cell:nth-child(3) {
+    border-left: 0;
+  }
+
+  .dfl-meta__cell:nth-child(n + 3) {
+    border-top: 1px solid var(--dfl-line-soft);
+  }
+
+  /*
+   * Phones reflow the row onto two lines rather than dropping columns: the
+   * three margin bars are the point of the board, so they stay reachable.
+   */
+  .dfl-row-grid {
+    grid-template-columns: 34px minmax(0, 1fr) 78px;
+    gap: 4px 10px;
+    padding: 0 14px;
+  }
+
+  .dfl-row {
+    padding: 12px 14px;
+    grid-template-areas:
+      "rank racer set"
+      "rank games finished";
+  }
+
+  .dfl-rank { grid-area: rank; align-self: start; }
+  .dfl-racer { grid-area: racer; }
+  .dfl-set { grid-area: set; }
+  .dfl-games { grid-area: games; gap: 6px; }
+  .dfl-finished { grid-area: finished; align-self: end; }
+
+  .dfl-thead {
+    grid-template-areas: none;
+  }
+
+  .dfl-thead__games,
+  .dfl-thead__finished {
+    display: none;
+  }
+
+  .dfl-game__score {
+    font-size: 9.5px;
+  }
+}

--- a/client/src/dailyFritz/setStory.test.ts
+++ b/client/src/dailyFritz/setStory.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest';
+import { describeSetStory } from './setStory';
+import type { DailyFritzLeaderboardRow } from './api';
+
+type Game = NonNullable<DailyFritzLeaderboardRow['games']>[number];
+
+function game(over: Partial<Game> & Pick<Game, 'gameNumber' | 'playerWon'>): Game {
+  return {
+    playerScore: over.playerWon ? 60 : 40,
+    fritzScore: over.playerWon ? 40 : 60,
+    pointDiff: over.playerWon ? 20 : -20,
+    ...over,
+  } as Game;
+}
+
+describe('describeSetStory', () => {
+  it('calls a 2-0 win a clean sweep', () => {
+    expect(
+      describeSetStory({
+        won: true,
+        finalScore: 2,
+        opponentScore: 0,
+        games: [game({ gameNumber: 1, playerWon: true }), game({ gameNumber: 2, playerWon: true })],
+      }),
+    ).toEqual({ label: 'Clean sweep', tone: 'neutral' });
+  });
+
+  it('calls a 2-1 win the decider', () => {
+    expect(
+      describeSetStory({ won: true, finalScore: 2, opponentScore: 1, games: [] }).label,
+    ).toBe('Won the decider');
+  });
+
+  it('calls a 1-2 loss going the distance', () => {
+    expect(
+      describeSetStory({ won: false, finalScore: 1, opponentScore: 2, games: [] }).label,
+    ).toBe('Went the distance');
+  });
+
+  it('calls a 0-2 loss a sweep by Fritz', () => {
+    expect(
+      describeSetStory({ won: false, finalScore: 0, opponentScore: 2, games: [] }).label,
+    ).toBe('Swept by Fritz');
+  });
+
+  it('promotes a winning skunk over the sweep wording', () => {
+    expect(
+      describeSetStory({
+        won: true,
+        finalScore: 2,
+        opponentScore: 0,
+        games: [
+          game({ gameNumber: 1, playerWon: true }),
+          game({ gameNumber: 2, playerWon: true, fritzScore: 12, skunk: true, skunkBy: 'player' }),
+        ],
+      }),
+    ).toEqual({ label: 'Skunk finish', tone: 'skunk' });
+  });
+
+  it('promotes a losing skunk over the sweep wording', () => {
+    expect(
+      describeSetStory({
+        won: false,
+        finalScore: 0,
+        opponentScore: 2,
+        games: [
+          game({ gameNumber: 1, playerWon: false, playerScore: 0, skunk: true, skunkBy: 'fritz' }),
+        ],
+      }),
+    ).toEqual({ label: 'Skunked by Fritz', tone: 'skunked' });
+  });
+
+  it('ignores a skunk that runs against the set result', () => {
+    // Skunked in game 1, then won the set: the skunk is not this racer's story.
+    expect(
+      describeSetStory({
+        won: true,
+        finalScore: 2,
+        opponentScore: 1,
+        games: [
+          game({ gameNumber: 1, playerWon: false, playerScore: 8, skunk: true, skunkBy: 'fritz' }),
+          game({ gameNumber: 2, playerWon: true }),
+          game({ gameNumber: 3, playerWon: true }),
+        ],
+      }).label,
+    ).toBe('Won the decider');
+  });
+
+  it('infers the skunk side from the game winner when skunkBy is absent', () => {
+    expect(
+      describeSetStory({
+        won: true,
+        finalScore: 2,
+        opponentScore: 0,
+        games: [game({ gameNumber: 1, playerWon: true, fritzScore: 4, skunk: true })],
+      }).tone,
+    ).toBe('skunk');
+  });
+});

--- a/client/src/dailyFritz/setStory.ts
+++ b/client/src/dailyFritz/setStory.ts
@@ -1,0 +1,39 @@
+/**
+ * Daily Fritz set stories — the one-line description under a racer's name on
+ * the leaderboard. Reads the shape of the set (sweep / decider / skunk) rather
+ * than restating the score, which is already in the column beside it.
+ *
+ * Skunk rules: docs/daily-fritz-skunk-source-of-truth.md
+ */
+import type { DailyFritzLeaderboardRow } from './api';
+
+export type DailyFritzSetStoryTone = 'skunk' | 'skunked' | 'neutral';
+
+export interface DailyFritzSetStory {
+  label: string;
+  tone: DailyFritzSetStoryTone;
+}
+
+type SetStoryInput = Pick<DailyFritzLeaderboardRow, 'won' | 'finalScore' | 'opponentScore' | 'games'>;
+
+function skunkSide(row: SetStoryInput): 'player' | 'fritz' | null {
+  const skunkGame = row.games?.find((game) => game.skunk);
+  if (!skunkGame) return null;
+  return skunkGame.skunkBy ?? (skunkGame.playerWon ? 'player' : 'fritz');
+}
+
+export function describeSetStory(row: SetStoryInput): DailyFritzSetStory {
+  const skunk = skunkSide(row);
+  if (row.won && skunk === 'player') return { label: 'Skunk finish', tone: 'skunk' };
+  if (!row.won && skunk === 'fritz') return { label: 'Skunked by Fritz', tone: 'skunked' };
+
+  const games = `${row.finalScore}-${row.opponentScore}`;
+  if (row.won) {
+    if (games === '2-0') return { label: 'Clean sweep', tone: 'neutral' };
+    if (games === '2-1') return { label: 'Won the decider', tone: 'neutral' };
+    return { label: 'Took the set', tone: 'neutral' };
+  }
+  if (games === '0-2') return { label: 'Swept by Fritz', tone: 'neutral' };
+  if (games === '1-2') return { label: 'Went the distance', tone: 'neutral' };
+  return { label: 'Lost the set', tone: 'neutral' };
+}

--- a/client/src/puzzleRush/PuzzleRushLeaderboardScreen.tsx
+++ b/client/src/puzzleRush/PuzzleRushLeaderboardScreen.tsx
@@ -1,28 +1,30 @@
 import { useEffect, useMemo, useState } from 'react';
 import { GlobalNav } from '../components';
-import { PlayerInitialsAvatar } from '../components/hub';
 import FilterPills from '../social/hub/FilterPills';
+import { avatarHue, getInitials } from '../components/hub/playerInitialsAvatarUtils';
 import { formatCountdownHms, secondsUntilNextPacificMidnight } from '../dailyFritz/format';
 import type { AppMode } from '../types';
 import { fetchPuzzleRushLeaderboard } from './api';
 import type { PuzzleRushLeaderboardEntry, PuzzleRushLeaderboardResponse } from './types';
-// Fritz's leaderboard depends on all three, in this order: tokens the dflb
+// Fritz's board depends on all three, in this order: the tokens the dfl-*
 // rules reference, then the rh-hub-* page/panel/FilterPills layout, then the
-// board rules themselves. Importing only the last one left rh-hub-screen /
-// rh-hub-shell / rh-hub-panel completely unstyled, which collapsed the page
-// and put the back button somewhere unclickable.
+// board rules themselves. Importing only the last one leaves rh-hub-screen /
+// rh-hub-shell completely unstyled, which collapses the page.
 import '../components/hub/hubDesignTokens.css';
 import '../social/hub/hubShared.css';
-import '../dailyFritz/dailyFritzLeaderboardScreen.css';
+import '../dailyFritz/dailyFritzLeaderboardBoard.css';
 import './puzzleRush.css';
 
 /**
- * Puzzle Rush leaderboard, built on Daily Fritz's leaderboard structure.
+ * Puzzle Rush leaderboard, built on Daily Fritz's leaderboard.
  *
- * Reuses its `dflb-*` classes wholesale — command header with meta chips,
- * podium, insight stats, "your position" strip, and the ranked table — so the
- * two daily modes read as one product. Only the columns differ, because Rush's
- * data is score/solved/time rather than result/set/margin.
+ * Reuses its `dfl-*` board wholesale — masthead, meta strip, ranked table and
+ * rail — so the two daily modes read as one product. Only the columns differ,
+ * because Rush's data is score/solved/time rather than result/set/margin.
+ *
+ * Fritz's three per-game bars have no equivalent here: a Rush entry carries a
+ * total and a solved count, not a per-puzzle breakdown, so that column is
+ * dropped rather than filled with something the data can't support.
  *
  * Two boards, as a filter pill rather than tabs, matching Fritz's own
  * Global/Friends/Top-Rated control: **Today** is official runs only (one per
@@ -39,25 +41,6 @@ const FILTER_OPTIONS = [
 
 type Filter = (typeof FILTER_OPTIONS)[number]['id'];
 
-function RankIcon({ rank }: { rank: 1 | 2 | 3 }) {
-  if (rank === 1) {
-    return (
-      <span className="dflb-crown" aria-hidden="true">
-        <svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor">
-          <path d="M3.5 8.5 8.5 13l3.5-7 3.5 7 5-4.5-1.8 9H5.3l-1.8-9Z" />
-        </svg>
-      </span>
-    );
-  }
-  return (
-    <span className="dflb-crown" aria-hidden="true">
-      <svg viewBox="0 0 24 24" width="14" height="14" fill="currentColor">
-        <path d="M7 4h10v5a5 5 0 0 1-10 0V4Zm2 13h6v3H9v-3Z" />
-      </svg>
-    </span>
-  );
-}
-
 function formatDateLabel(dateKey: string): string {
   const parsed = new Date(`${dateKey}T00:00:00`);
   if (Number.isNaN(parsed.getTime())) return dateKey;
@@ -71,83 +54,93 @@ function formatAchievedAt(iso: string | null): string {
   return parsed.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' });
 }
 
-function PodiumSlot({
-  rank,
-  row,
-}: {
-  rank: 1 | 2 | 3;
-  row: PuzzleRushLeaderboardEntry | undefined;
-}) {
-  const crown = rank === 1 ? <span className="dflb-podium-crown-badge" aria-hidden="true"><RankIcon rank={1} /></span> : null;
+function ordinalSuffix(rank: number): string {
+  const tens = rank % 100;
+  if (tens >= 11 && tens <= 13) return 'th';
+  const ones = rank % 10;
+  if (ones === 1) return 'st';
+  if (ones === 2) return 'nd';
+  if (ones === 3) return 'rd';
+  return 'th';
+}
 
-  if (!row) {
-    return (
-      <div className={`dflb-podium-slot place-${rank} is-empty`}>
-        {crown}
-        <span className="dflb-podium-avatar dflb-podium-avatar--empty" aria-hidden="true">
-          <span className="dflb-podium-avatar__glyph">+</span>
-        </span>
-        <span className="dflb-podium-name">—</span>
-        <span className="dflb-podium-empty-hint">Unclaimed</span>
-      </div>
-    );
-  }
-
+function PlayerAvatar({ username }: { username: string }) {
+  const hue = avatarHue(username);
   return (
-    <div className={`dflb-podium-slot place-${rank}${rank === 1 ? ' is-featured' : ''}`}>
-      {crown}
-      <PlayerInitialsAvatar
-        username={row.username}
-        size={rank === 1 ? 'lg' : 'md'}
-        ring={rank === 1 ? 'gold' : rank === 2 ? 'silver' : 'bronze'}
-      />
-      <span className="dflb-podium-name">{row.username}</span>
-      <span className="dflb-podium-score">{row.totalScore}</span>
-      <span className="dflb-podium-margin">{row.puzzlesSolved} solved</span>
-    </div>
+    <span
+      className="dfl-avatar"
+      aria-hidden="true"
+      style={{
+        background: `linear-gradient(145deg, hsl(${hue} 42% 38%), hsl(${(hue + 48) % 360} 48% 24%))`,
+      }}
+    >
+      {getInitials(username)}
+    </span>
   );
 }
 
-function LeaderboardRow({
-  row,
-  isSelf,
-}: {
-  row: PuzzleRushLeaderboardEntry;
-  isSelf: boolean;
-}) {
-  const topRank = row.rank <= 3 ? (row.rank as 1 | 2 | 3) : null;
+function CrownGlyph() {
   return (
-    <article
-      className={[
-        'dflb-row',
-        'pr-lb-row',
-        topRank ? `dflb-row--rank-${topRank}` : '',
-        isSelf ? 'dflb-row--self' : '',
-      ]
-        .filter(Boolean)
-        .join(' ')}
-    >
-      <div className="dflb-rank">
-        {topRank ? <RankIcon rank={topRank} /> : null}
-        <strong className={`dflb-rank-num${topRank ? ` is-${topRank}` : ''}`}>{row.rank}</strong>
+    <span className="dfl-rank__crown" aria-hidden="true">
+      <svg viewBox="0 0 24 24" width="13" height="13" fill="currentColor">
+        <path d="M5 16L3 5l5.5 5L12 4l3.5 6L21 5l-2 11H5zm14 3c0 .6-.4 1-1 1H6c-.6 0-1-.4-1-1v-1h14v1z" />
+      </svg>
+    </span>
+  );
+}
+
+function LeaderboardRow({ row, isSelf }: { row: PuzzleRushLeaderboardEntry; isSelf: boolean }) {
+  return (
+    <article className={`dfl-row dfl-row-grid${isSelf ? ' dfl-row--self' : ''}`}>
+      <div className="dfl-rank">
+        {row.rank === 1 ? <CrownGlyph /> : null}
+        <span>{row.rank}</span>
       </div>
-      <div className="dflb-player">
-        <PlayerInitialsAvatar
-          username={row.username}
-          size="md"
-          ring={topRank === 1 ? 'gold' : topRank === 2 ? 'silver' : topRank === 3 ? 'bronze' : 'none'}
-        />
-        <div className="dflb-player-copy">
-          <strong>
-            {row.username}
-            {isSelf ? <span className="dflb-you-tag">You</span> : null}
-          </strong>
+
+      <div className="dfl-racer">
+        <PlayerAvatar username={row.username} />
+        <div className="dfl-racer__copy">
+          <div className="dfl-racer__name">
+            <span className="dfl-racer__handle">{row.username}</span>
+            {isSelf ? <span className="dfl-you">YOU</span> : null}
+          </div>
         </div>
       </div>
-      <div className="dflb-cell dflb-set-score pr-lb-score">{row.totalScore}</div>
-      <div className="dflb-cell">{row.puzzlesSolved}</div>
-      <div className="dflb-cell dflb-finished">{formatAchievedAt(row.achievedAt)}</div>
+
+      <div className="dfl-set">
+        <div className="dfl-set__games pr-board__score">{row.totalScore}</div>
+      </div>
+
+      <div className="dfl-solved">
+        {row.puzzlesSolved}
+        {/* The Solved header is dropped on phones, so the value labels itself. */}
+        <span className="pr-board__solved-unit"> solved</span>
+      </div>
+
+      <div className="dfl-finished">{formatAchievedAt(row.achievedAt)}</div>
     </article>
+  );
+}
+
+function RecordRow({
+  label,
+  name,
+  value,
+  tone,
+}: {
+  label: string;
+  name: string | null;
+  value: string;
+  tone?: 'win' | 'accent';
+}) {
+  return (
+    <div className="dfl-record">
+      <div className="dfl-record__copy">
+        <span className="dfl-record__label">{label}</span>
+        <span className="dfl-record__name">{name ?? '—'}</span>
+      </div>
+      <span className={`dfl-record__value${tone ? ` is-${tone}` : ''}`}>{value}</span>
+    </div>
   );
 }
 
@@ -194,7 +187,6 @@ export function PuzzleRushLeaderboardScreen({
     () => (filter === 'today' ? data?.daily : data?.leaderboard) ?? [],
     [data, filter],
   );
-  const podium = [rows[0], rows[1], rows[2]];
   const selfRow = currentUsername
     ? rows.find((row) => row.username.toLowerCase() === currentUsername.toLowerCase()) ?? null
     : null;
@@ -205,122 +197,134 @@ export function PuzzleRushLeaderboardScreen({
   );
 
   return (
-    <div className="rh-hub-screen dflb-page pr-leaderboard-page">
+    <div className="rh-hub-screen dfl-page pr-board">
       <div className="rh-hub-shell">
         <GlobalNav currentMode="puzzleRush" onNavigate={onNavigate} activeColor="var(--tier-standard)" />
 
-        <div className="dflb-inner">
-          <header className="dflb-command">
-            <div className="dflb-command-hero">
-              <div className="dflb-command__brand">
-                <span className="rh-hub-tag dflb-eyebrow">Puzzle Rush</span>
-                <h1 className="dflb-command__title">Leaderboard</h1>
-                <p className="dflb-command__sub">
-                  Today&apos;s official runs · and the all-time best ever posted.
-                </p>
-              </div>
-              <div className="dflb-command__aside">
-                <div className="dflb-command__actions">
-                  <button type="button" className="dflb-back-link rh-back-button" onClick={onBack}>
+        <div className="rh-hub-body">
+          <div className="rh-hub-inner dfl-inner">
+            <div className="dfl-board">
+              <header className="dfl-masthead">
+                <div>
+                  <span className="dfl-eyebrow">Puzzle Rush</span>
+                  <h1 className="dfl-title">
+                    Leaderboard<span className="dfl-title__dot">.</span>
+                  </h1>
+                  <p className="dfl-tagline">
+                    Today&apos;s official runs · and the all-time best ever posted.
+                  </p>
+                </div>
+                <div className="dfl-masthead__actions">
+                  <button type="button" className="dfl-btn" onClick={onBack}>
                     <span aria-hidden>←</span>
-                    Back to Puzzle Rush
+                    Puzzle Rush
                   </button>
                 </div>
-                <div className="dflb-command__meta" aria-label="Daily board status">
-                  <div className="dflb-meta-chip">
-                    <span className="dflb-meta-chip__label">Date</span>
-                    <span className="dflb-meta-chip__value">
-                      {data ? formatDateLabel(data.runDate) : '—'}
-                    </span>
-                  </div>
-                  <div className="dflb-meta-chip dflb-meta-chip--board">
-                    <span className="dflb-meta-chip__label">Board</span>
-                    <span className="dflb-meta-chip__value">
-                      {rows.length} {rows.length === 1 ? 'player' : 'players'}
-                    </span>
-                  </div>
-                  <div className="dflb-meta-chip dflb-meta-chip--reset">
-                    <span className="dflb-meta-chip__label">Resets in</span>
-                    <span className="dflb-meta-chip__value is-cyan">
-                      {formatCountdownHms(resetSeconds)}
-                    </span>
-                  </div>
+              </header>
+
+              <div className="dfl-meta" aria-label="Daily board status">
+                <div className="dfl-meta__cell">
+                  <span className="dfl-meta__label">Date</span>
+                  <span className="dfl-meta__value">
+                    {data ? formatDateLabel(data.runDate) : '—'}
+                  </span>
+                </div>
+                <div className="dfl-meta__cell">
+                  <span className="dfl-meta__label">Players</span>
+                  <span className="dfl-meta__value">{rows.length}</span>
+                </div>
+                <div className="dfl-meta__cell">
+                  <span className="dfl-meta__label">Top score</span>
+                  <span className="dfl-meta__value is-accent">
+                    {topScore ? topScore.totalScore : '—'}
+                  </span>
+                </div>
+                <div className="dfl-meta__cell">
+                  <span className="dfl-meta__label">Resets in</span>
+                  <span className="dfl-meta__value">{formatCountdownHms(resetSeconds)}</span>
                 </div>
               </div>
-            </div>
-            <div className="dflb-command__bar">
+
               <FilterPills
                 options={[...FILTER_OPTIONS]}
                 value={filter}
                 onChange={setFilter}
                 ariaLabel="Leaderboard filters"
               />
-            </div>
-          </header>
 
-          <div className="dflb-layout">
-            <aside className="dflb-insights" aria-label="Board highlights">
-              <div className="rh-hub-panel dflb-insights-panel">
-                <section className="dflb-insights__section" aria-label="Podium">
-                  <h3 className="dflb-insights__label">
-                    {filter === 'today' ? "Today's podium" : 'All-time podium'}
-                  </h3>
-                  <div className="dflb-podium-stage">
-                    <div className="dflb-podium">
-                      <PodiumSlot rank={2} row={podium[1]} />
-                      <PodiumSlot rank={1} row={podium[0]} />
-                      <PodiumSlot rank={3} row={podium[2]} />
-                    </div>
+              <div className="dfl-layout">
+                <section className="dfl-table" aria-label="Puzzle Rush standings">
+                  <div className="dfl-thead dfl-row-grid" aria-hidden="true">
+                    <span>Rank</span>
+                    <span>Player</span>
+                    <span>Score</span>
+                    <span className="pr-board__thead-solved">Solved</span>
+                    <span className="dfl-thead__finished">Finished</span>
                   </div>
-                </section>
 
-                <div className="dflb-insights__divider" aria-hidden="true" />
-
-                <section className="dflb-insights__section dflb-insights__stats" aria-label="Records">
-                  <div className="dflb-insight-stat">
-                    <span className="dflb-insight-stat__label">Top score</span>
-                    <span className="dflb-insight-stat__name">{topScore?.username ?? '—'}</span>
-                    <span className="dflb-insight-stat__value is-gold">
-                      {topScore ? topScore.totalScore : '—'}
-                    </span>
-                  </div>
-                  <div className="dflb-insight-stat">
-                    <span className="dflb-insight-stat__label">Most solved</span>
-                    <span className="dflb-insight-stat__name">{mostSolved?.username ?? '—'}</span>
-                    <span className="dflb-insight-stat__value is-blue">
-                      {mostSolved ? `${mostSolved.puzzlesSolved}` : '—'}
-                    </span>
-                  </div>
-                </section>
-
-                <div className="dflb-insights__divider" aria-hidden="true" />
-
-                <section className="dflb-insights__section dflb-insights__you" aria-label="Your position">
-                  <h3 className="dflb-insights__label">Your position</h3>
-                  {selfRow ? (
-                    <div className="dflb-you-strip">
-                      <div className="dflb-you-strip__rank">
-                        <span className="dflb-you-strip__hash">#</span>
-                        <span className="dflb-you-strip__num">{selfRow.rank}</span>
+                  <div className="dfl-tbody">
+                    {loading ? <p className="dfl-state">Loading leaderboard…</p> : null}
+                    {error ? (
+                      <p className="dfl-state dfl-state--error" role="alert">
+                        {error}
+                      </p>
+                    ) : null}
+                    {!loading && !error && rows.length === 0 ? (
+                      <div className="dfl-state" data-ui="rush-leaderboard-empty">
+                        <p style={{ margin: 0 }}>
+                          {filter === 'today'
+                            ? 'No official runs today yet.'
+                            : 'No completed runs yet.'}
+                        </p>
+                        <p className="dfl-state__hint">
+                          Finish today&apos;s Puzzle Rush run to claim the first spot.
+                        </p>
                       </div>
-                      <dl className="dflb-you-strip__stats">
-                        <div>
-                          <dt>Score</dt>
-                          <dd>{selfRow.totalScore}</dd>
+                    ) : null}
+                    {rows.map((row) => (
+                      <LeaderboardRow
+                        key={row.runId}
+                        row={row}
+                        isSelf={
+                          currentUsername != null &&
+                          row.username.toLowerCase() === currentUsername.toLowerCase()
+                        }
+                      />
+                    ))}
+                  </div>
+                </section>
+
+                <aside className="dfl-rail" aria-label="Board highlights">
+                  <section className="dfl-card dfl-card--accent" aria-label="Your position">
+                    <h2 className="dfl-card__head">Your position</h2>
+                    {selfRow ? (
+                      <>
+                        <div className="dfl-position">
+                          <span className="dfl-position__rank">
+                            {selfRow.rank}
+                            <span className="dfl-position__suffix">{ordinalSuffix(selfRow.rank)}</span>
+                          </span>
+                          <span className="dfl-position__of">
+                            of {rows.length} {rows.length === 1 ? 'player' : 'players'}
+                          </span>
                         </div>
-                        <div>
-                          <dt>Solved</dt>
-                          <dd>{selfRow.puzzlesSolved}</dd>
-                        </div>
-                        <div>
-                          <dt>Finished</dt>
-                          <dd>{formatAchievedAt(selfRow.achievedAt)}</dd>
-                        </div>
-                      </dl>
-                    </div>
-                  ) : data?.personalBest ? (
-                    <div className="dflb-you-strip" data-ui="rush-leaderboard-you">
-                      <dl className="dflb-you-strip__stats">
+                        <dl className="dfl-position__stats">
+                          <div>
+                            <dt>Score</dt>
+                            <dd>{selfRow.totalScore}</dd>
+                          </div>
+                          <div>
+                            <dt>Solved</dt>
+                            <dd>{selfRow.puzzlesSolved}</dd>
+                          </div>
+                          <div>
+                            <dt>Finished</dt>
+                            <dd>{formatAchievedAt(selfRow.achievedAt)}</dd>
+                          </div>
+                        </dl>
+                      </>
+                    ) : data?.personalBest ? (
+                      <dl className="dfl-position__stats" data-ui="rush-leaderboard-you">
                         <div>
                           <dt>Your best</dt>
                           <dd>{data.personalBest.totalScore}</dd>
@@ -330,55 +334,30 @@ export function PuzzleRushLeaderboardScreen({
                           <dd>{data.personalBest.puzzlesSolved}</dd>
                         </div>
                       </dl>
-                    </div>
-                  ) : (
-                    <div className="dflb-you-empty">Finish a run to claim a spot.</div>
-                  )}
-                </section>
-              </div>
-            </aside>
+                    ) : (
+                      <p className="dfl-position__empty">Finish a run to claim a spot.</p>
+                    )}
+                  </section>
 
-            <section className="dflb-standings" aria-label="Puzzle Rush standings">
-              <div className="rh-hub-panel dflb-standings-panel">
-                <div className="dflb-table-head pr-lb-row" aria-hidden="true">
-                  <span>Rank</span>
-                  <span>Player</span>
-                  <span>Score</span>
-                  <span>Solved</span>
-                  <span>Time</span>
-                </div>
-                <div className="dflb-table-body">
-                  {loading ? <p className="dflb-state">Loading leaderboard…</p> : null}
-                  {error ? (
-                    <p className="dflb-state dflb-state--error" role="alert">
-                      {error}
-                    </p>
-                  ) : null}
-                  {!loading && !error && rows.length === 0 ? (
-                    <div className="dflb-empty-board" data-ui="rush-leaderboard-empty">
-                      <p className="dflb-state">
-                        {filter === 'today'
-                          ? 'No official runs today yet.'
-                          : 'No completed runs yet.'}
-                      </p>
-                      <p className="dflb-empty-hint">
-                        Finish today&apos;s Puzzle Rush run to claim the first spot.
-                      </p>
-                    </div>
-                  ) : null}
-                  {rows.map((row) => (
-                    <LeaderboardRow
-                      key={row.runId}
-                      row={row}
-                      isSelf={
-                        currentUsername != null &&
-                        row.username.toLowerCase() === currentUsername.toLowerCase()
-                      }
+                  <section className="dfl-card" aria-label="Records">
+                    <h2 className="dfl-card__head">
+                      {filter === 'today' ? "Today's records" : 'All-time records'}
+                    </h2>
+                    <RecordRow
+                      label="Top score"
+                      name={topScore?.username ?? null}
+                      value={topScore ? String(topScore.totalScore) : '—'}
+                      tone="accent"
                     />
-                  ))}
-                </div>
+                    <RecordRow
+                      label="Most solved"
+                      name={mostSolved?.username ?? null}
+                      value={mostSolved ? String(mostSolved.puzzlesSolved) : '—'}
+                    />
+                  </section>
+                </aside>
               </div>
-            </section>
+            </div>
           </div>
         </div>
       </div>

--- a/client/src/puzzleRush/puzzleRush.css
+++ b/client/src/puzzleRush/puzzleRush.css
@@ -658,26 +658,79 @@
   .pr-hud-stage__position { display: none; }
 }
 
-/* ── Leaderboard: Fritz's dflb-* chrome, Rush's five columns ── */
-/* Fritz's grid is 7 columns (result/set/margin/time/games). Rush shows
-   rank / player / score / solved / time, so only the template changes —
-   every other dflb-* rule is inherited as-is. */
+/* ── Leaderboard: Fritz's dfl-* board, Rush's columns ── */
+/*
+ * Fritz's grid is rank / racer / set·margin / three games / finished. Rush has
+ * no per-puzzle breakdown, so the games column is dropped and the remaining
+ * four are rank / player / score / solved / finished. Only the template and
+ * the score accent change here; every other dfl-* rule is inherited as-is.
+ */
 
-.pr-leaderboard-page .dflb-table-head.pr-lb-row,
-.pr-leaderboard-page .dflb-row.pr-lb-row {
-  grid-template-columns: 72px minmax(150px, 1.4fr) 92px 80px minmax(90px, 0.8fr);
+/*
+ * Rush is a blue mode — its hub, HUD and Start button all run on
+ * --tier-standard — so the board takes the same accent rather than Fritz's
+ * gold. Retinting the accent block is all it takes; every accented element on
+ * the board reads from it.
+ */
+.pr-board {
+  --dfl-accent: var(--tier-standard);
+  --dfl-accent-rgb: 59, 130, 246;
+  --dfl-accent-ink: var(--bg-obsidian);
 }
 
-.pr-leaderboard-page .pr-lb-score {
+.pr-board .dfl-row-grid {
+  grid-template-columns: 64px minmax(0, 1fr) 104px 88px 92px;
+}
+
+.pr-board .pr-board__score {
+  color: var(--dfl-accent);
+}
+
+/* Rush rows are one line (no story under the name), so they can sit tighter. */
+.pr-board .dfl-row {
+  min-height: 52px;
+}
+
+.pr-board__solved-unit {
+  display: none;
+}
+
+.pr-board .dfl-solved {
   font-family: var(--font-display);
-  font-size: 20px;
-  color: var(--tier-elite);
+  font-size: 16px;
+  font-weight: 700;
+  color: var(--dfl-ink);
+  font-variant-numeric: tabular-nums;
 }
 
-@media (max-width: 900px) {
-  .pr-leaderboard-page .dflb-table-head.pr-lb-row,
-  .pr-leaderboard-page .dflb-row.pr-lb-row {
-    grid-template-columns: 56px minmax(110px, 1fr) 72px 60px;
+@media (max-width: 860px) {
+  .pr-board .dfl-row-grid {
+    grid-template-columns: 34px minmax(0, 1fr) 78px;
   }
-  .pr-leaderboard-page .dflb-finished { display: none; }
+
+  .pr-board .dfl-row {
+    grid-template-areas:
+      "rank player score"
+      "rank solved finished";
+  }
+
+  .pr-board .dfl-rank { grid-area: rank; }
+  .pr-board .dfl-racer { grid-area: player; }
+  .pr-board .dfl-set { grid-area: score; }
+  .pr-board .dfl-solved { grid-area: solved; font-size: 13px; }
+
+  .pr-board__solved-unit {
+    display: inline;
+    color: var(--dfl-muted);
+    font-family: var(--font-body);
+    font-size: 11px;
+    font-weight: 600;
+  }
+
+  /* The header is a plain 3-column row here, so the columns that moved onto
+     the second line lose their labels rather than wrapping the header. */
+  .pr-board .pr-board__thead-solved {
+    display: none;
+  }
+  .pr-board .dfl-finished { grid-area: finished; }
 }


### PR DESCRIPTION
Rebuilds the Daily Fritz leaderboard to the new mock, then ports the same board to Puzzle Rush.

## Daily Fritz

Per-row cards and result chips are gone. The board is now tabular: hairline rules, square corners, one accent bar on your own row, and scores in a column so ranks and margins line up.

- **RANK · RACER · SET · MARGIN · THE THREE GAMES · FINISHED**
- Each game is a solid bar — green if you took it, red if Fritz did, grey when a third game wasn't played. So a row reads as a colour sequence before any number does: `green green grey` is a sweep, `green red green` won the decider.
- A one-line story under each name (`describeSetStory()`): "Skunk finish", "Clean sweep", "Won the decider", "Went the distance", "Skunked by Fritz". Gold and red are reserved for skunk outcomes.
- Meta strip condensed to a single 35px line: Date · Racers · Skunks today · Resets in.
- Rail: "Your position" and "Today's records".

New: `dailyFritzLeaderboardBoard.css` (`dfl-` namespace) and `setStory.ts`. The old `dailyFritzLeaderboardScreen.css` is untouched — the Daily Puzzle Ladder still depends on its `dflb-` classes.

## Puzzle Rush

Same board, mapped to Rush's data: **RANK · PLAYER · SCORE · SOLVED · FINISHED**. Fritz's three-bar column is dropped rather than filled — a Rush entry carries a total and a solved count, with no per-puzzle breakdown, so there was nothing honest to draw there.

Rush is a blue mode (its hub, HUD and Start button all run on `--tier-standard`), so the board takes that accent instead of Fritz's gold. The board CSS was hardcoding gold in several places; it now funnels everything through one `--dfl-accent` block, making a retint three lines.

## Notes

- On phones, rows reflow to two lines rather than dropping columns — the margin bars are the point of the board and stay reachable. Verified no overlap or horizontal overflow at 1440 / 1024 / 390.
- Accessibility: each bar carries an `aria-label` with the game's scores, since colour alone carries the result.

## Verification

- `tsc -b` clean
- Full client suite: **185 files, 1278 tests, all passing**
- Lint: 401 warnings / **0 errors**, unchanged from baseline
- New tests: 8 for `describeSetStory` (sweep/decider/distance wording, skunk promotion, and that a skunk running against the set result is ignored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)