### PR TITLE
feat(daily-fritz): rebuild the set result and next-game modals as dossiers

### DIFF
--- a/client/src/bot/BotDailyFritzSetOverlay.tsx
+++ b/client/src/bot/BotDailyFritzSetOverlay.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { GameOverlayPortal } from '../components/GameOverlayPortal';
 import { DailyFritzFinalResultOverlay } from '../dailyFritz/DailyFritzFinalResultOverlay';
 import type { DailyFritzSetOverlayViewModel } from '../dailyFritz/setOverlayViewModel';
+import '../dailyFritz/dailyFritzModalDossier.css';
 
 export interface BotDailyFritzSetOverlayProps {
   overlay: DailyFritzSetOverlayViewModel | null;
@@ -10,6 +11,11 @@ export interface BotDailyFritzSetOverlayProps {
   showPostGameOverlays: boolean;
 }
 
+/**
+ * Between-games interstitial, in the same dossier language as the result card
+ * but landscape: the game just finished on the left, where the set stands on
+ * the right, so the decision and the standing are read together.
+ */
 export const BotDailyFritzSetOverlay: React.FC<BotDailyFritzSetOverlayProps> = ({
   overlay,
   shareCopied,
@@ -30,82 +36,79 @@ export const BotDailyFritzSetOverlay: React.FC<BotDailyFritzSetOverlayProps> = (
     );
   }
 
+  const marginTone =
+    overlay.marginTone === 'win' ? 'is-win' : overlay.marginTone === 'loss' ? 'is-loss' : '';
+
   return (
     <GameOverlayPortal>
-      <div className="game-over-overlay daily-fritz-set-overlay" role="dialog" aria-label="Daily Fritz set interstitial">
-        <div className="game-over-card daily-fritz-set-overlay-card" onClick={(event) => event.stopPropagation()}>
-          <div className="daily-fritz-set-overlay-hero">
-            <span className="daily-fritz-set-overlay-kicker">{overlay.eyebrow}</span>
-            {overlay.skunkBadge ? (
-              <span className="daily-fritz-skunk-badge" aria-label="Skunk result">
-                {overlay.skunkBadge}
-              </span>
-            ) : null}
-            <h2 className="daily-fritz-set-overlay-title" tabIndex={-1} autoFocus>{overlay.headline}</h2>
-            <p className="daily-fritz-set-overlay-copy">{overlay.subheadline}</p>
+      <div
+        className="game-over-overlay daily-fritz-set-overlay"
+        role="dialog"
+        aria-label="Daily Fritz set interstitial"
+      >
+        <div className="dfd dfd--wide" onClick={(event) => event.stopPropagation()}>
+          <div className="dfd__strip">
+            <span className="dfd__run">
+              {overlay.runId ? `${overlay.runId} · Set in progress` : 'Set in progress'}
+            </span>
+            <span className="dfd__provenance">{overlay.standing ?? ''}</span>
           </div>
 
-          <div className="daily-fritz-set-overlay-stats" aria-label="Daily Fritz set summary">
-            <div className="daily-fritz-set-overlay-stat">
-              <span>{overlay.gameScoreLabel || 'This game'}</span>
-              <strong>{overlay.gameScoreValue || '—'}</strong>
-            </div>
-            <div className={`daily-fritz-set-overlay-stat${overlay.statsPending ? ' is-pending' : ''}`}>
-              <span>Set Score</span>
-              <strong className={overlay.statsPending ? 'is-pending' : undefined}>
-                {overlay.setScoreValue || '—'}
-              </strong>
-            </div>
-            <div className={`daily-fritz-set-overlay-stat${overlay.statsPending ? ' is-pending' : ''}`}>
-              <span>Set Margin</span>
-              <strong className={`is-${overlay.marginTone}${overlay.statsPending ? ' is-pending' : ''}`}>
-                {overlay.marginValue || '—'}
-              </strong>
-            </div>
-          </div>
+          <div className="dfd__split">
+            <div>
+              <span className="dfd__eyebrow">{overlay.gameScoreLabel || 'This game'} · Final</span>
+              <h2 className="dfd__headline" tabIndex={-1} autoFocus>
+                {overlay.headline}
+              </h2>
+              <p className="dfd__sub">{overlay.subheadline}</p>
 
-          <div className="daily-fritz-set-overlay-tracker" aria-label="Best of three tracker">
-            {overlay.tracker.map((item) => (
-              <div key={item.gameNumber} className={`daily-fritz-set-overlay-step is-${item.tone}`}>
-                <span>Game {item.gameNumber}</span>
-                <strong>{item.label}</strong>
+              <dl className="dfd__pair">
+                <div>
+                  <dt>{overlay.gameScoreLabel || 'This game'}</dt>
+                  <dd className={marginTone}>{overlay.gameScoreValue || '—'}</dd>
+                </div>
+                <div>
+                  <dt>Set margin</dt>
+                  <dd className={marginTone}>{overlay.marginValue || '—'}</dd>
+                </div>
+              </dl>
+
+              {overlay.errorMessage ? (
+                <p className="dfd__note" role="alert">
+                  {overlay.errorMessage}
+                </p>
+              ) : null}
+              {overlay.practiceHint ? <p className="dfd__note">{overlay.practiceHint}</p> : null}
+            </div>
+
+            <div>
+              <span className="dfd__progress-label">Set progress</span>
+              {overlay.tracker.map((step) => (
+                <div key={step.gameNumber} className="dfd__step">
+                  <span className="dfd__step-no">G{step.gameNumber}</span>
+                  <span className="dfd__step-track">
+                    <span className={`dfd__step-fill is-${step.tone}`} />
+                  </span>
+                  <span className={`dfd__step-state is-${step.tone}`}>{step.label}</span>
+                </div>
+              ))}
+
+              <div className="dfd__actions">
+                <button
+                  type="button"
+                  className="dfd__btn dfd__btn--primary"
+                  onClick={overlay.onPrimary}
+                  disabled={overlay.primaryDisabled}
+                >
+                  {overlay.primaryLabel}
+                </button>
+                {overlay.secondaryLabel ? (
+                  <button type="button" className="dfd__btn" onClick={overlay.onSecondary}>
+                    {overlay.secondaryLabel}
+                  </button>
+                ) : null}
               </div>
-            ))}
-          </div>
-
-          {overlay.objective ? (
-            <div className="daily-fritz-set-overlay-objective">
-              {overlay.nextLabel ? <span>{overlay.nextLabel}</span> : null}
-              <p>{overlay.objective}</p>
             </div>
-          ) : null}
-
-          {overlay.errorMessage ? (
-            <div className="hand-over-error-zone">
-              <span className="hand-over-error-text" title={overlay.errorMessage}>
-                {overlay.errorMessage}
-              </span>
-            </div>
-          ) : null}
-
-          <div className="daily-fritz-set-overlay-actions">
-            <button
-              type="button"
-              className={`daily-fritz-set-overlay-primary is-${overlay.primaryTone}`}
-              onClick={overlay.onPrimary}
-              disabled={overlay.primaryDisabled}
-            >
-              {overlay.primaryLabel}
-            </button>
-            {overlay.secondaryLabel ? (
-              <button
-                type="button"
-                className="daily-fritz-set-overlay-secondary"
-                onClick={overlay.onSecondary}
-              >
-                {overlay.secondaryLabel}
-              </button>
-            ) : null}
           </div>
         </div>
       </div>

--- a/client/src/dailyFritz/DailyFritzFinalResultOverlay.tsx
+++ b/client/src/dailyFritz/DailyFritzFinalResultOverlay.tsx
@@ -1,5 +1,7 @@
-import type { DailyFritzSetOverlayViewModel } from './setOverlayViewModel';
 import { AnimatedScore } from '../components/AnimatedScore';
+import { buildDossierGameRows } from './dossierGameRows';
+import type { DailyFritzSetOverlayViewModel } from './setOverlayViewModel';
+import './dailyFritzModalDossier.css';
 
 export type DailyFritzFinalResultOverlayProps = {
   overlay: DailyFritzSetOverlayViewModel;
@@ -7,132 +9,125 @@ export type DailyFritzFinalResultOverlayProps = {
   onShare: () => void;
 };
 
+/**
+ * End-of-set result, as a dossier on the run.
+ *
+ * The header stamps which run this is and whether it was verified, because an
+ * unranked finish has to say so plainly rather than quietly showing a blank
+ * rank. Everything below is the same card whatever the outcome: three game
+ * rows, four stats, then the ways out.
+ */
 export function DailyFritzFinalResultOverlay({
   overlay,
   shareDone,
   onShare,
 }: DailyFritzFinalResultOverlayProps) {
-  const showMargin = Boolean(overlay.marginValue && overlay.marginValue !== '—');
+  const rows = buildDossierGameRows(overlay.games);
+  const ranked = overlay.ranked !== false;
+  const marginTone = overlay.marginTone === 'win' ? 'is-win' : overlay.marginTone === 'loss' ? 'is-loss' : '';
 
   return (
     <div className="game-over-overlay df-result-overlay" role="dialog" aria-label="Daily Fritz result">
-      <div className="game-over-card df-result-card" onClick={(event) => event.stopPropagation()}>
-        <div className="df-result-panel">
-          <header className="df-result-hero">
-            <p className="df-result-eyebrow">Daily Fritz</p>
-            {overlay.skunkBadge ? (
-              <span className="daily-fritz-skunk-badge" aria-label="Skunk result">
-                {overlay.skunkBadge}
-              </span>
-            ) : null}
-            <h2 className="df-result-title" tabIndex={-1} autoFocus>{overlay.headline}</h2>
-            <p className="df-result-subtitle">{overlay.subheadline}</p>
+      <div
+        className={`dfd${ranked ? '' : ' dfd--unranked'}`}
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="dfd__strip">
+          <span className="dfd__run">{overlay.runId ?? 'Daily Fritz'}</span>
+          <span className="dfd__provenance">{overlay.provenance ?? ''}</span>
+        </div>
+
+        <div className="dfd__body">
+          <header>
+            <span className="dfd__eyebrow">Set result</span>
+            <h2 className="dfd__headline" tabIndex={-1} autoFocus>
+              {overlay.headline}
+            </h2>
+            <p className="dfd__sub">{overlay.subheadline}</p>
           </header>
 
-          <div className="df-result-stats" aria-label="Set summary">
-            <div className={`df-result-stat${overlay.marginTone === 'win' ? ' is-victory' : overlay.marginTone === 'loss' ? ' is-defeat' : ''}`}>
-              <span className="df-result-stat-label">Result</span>
-              <strong
-                className={`df-result-stat-value${overlay.marginTone === 'win' ? ' is-win' : overlay.marginTone === 'loss' ? ' is-loss' : ''}`}
+          <div className="dfd__games" aria-label="Games in this set">
+            {rows.map((row) => (
+              <div
+                key={row.gameNumber}
+                className={`dfd__game${row.played ? '' : ' dfd__game--empty'}`}
               >
-                {overlay.resultValue ?? '—'}
-              </strong>
-            </div>
-            <div className="df-result-stat">
-              <span className="df-result-stat-label">Set</span>
-              <strong className="df-result-stat-value">{overlay.setScoreValue || '—'}</strong>
-            </div>
-            <div className="df-result-stat">
-              <span className="df-result-stat-label">{overlay.rankValue ? 'Rank' : 'Margin'}</span>
-              <strong
-                className={`df-result-stat-value${!overlay.rankValue && overlay.marginTone === 'win' ? ' is-win' : !overlay.rankValue && overlay.marginTone === 'loss' ? ' is-loss' : ''}`}
-              >
-                {overlay.rankValue ?? overlay.marginValue ?? '—'}
-              </strong>
-            </div>
+                <span className="dfd__game-no">G{row.gameNumber}</span>
+                <span className="dfd__track">
+                  {row.played ? (
+                    <span
+                      className={`dfd__fill dfd__fill--${row.tone}`}
+                      style={{ width: `${row.sharePercent}%` }}
+                    />
+                  ) : null}
+                </span>
+                {row.played && row.tone === 'skunk' ? (
+                  <span className="dfd__game-tag">Skunk</span>
+                ) : null}
+                <span className={`dfd__game-score dfd__game-score--${row.played ? row.tone : 'empty'}`}>
+                  {row.played ? row.score : 'not played'}
+                </span>
+              </div>
+            ))}
           </div>
 
-          {overlay.games.length > 0 ? (
-            <div className="df-result-games" aria-label="Per-game scores">
-              <div className="df-result-games-head">
-                <span className="df-result-games-label">Games</span>
-              </div>
-              <div className="df-result-games-well">
-                {overlay.games.map((game) => (
-                  <div key={game.gameNumber} className="df-result-game-row">
-                    <span>Game {game.gameNumber}</span>
-                    <strong className={game.tone === 'win' ? 'is-win' : 'is-loss'}>
-                      {game.skunkLabel ?? game.value}
-                    </strong>
-                  </div>
-                ))}
-              </div>
+          <dl className="dfd__stats">
+            <div className="dfd__stat">
+              <dt>Rank today</dt>
+              <dd className={ranked ? 'is-accent' : ''}>{overlay.rankShort ?? overlay.rankValue ?? '—'}</dd>
             </div>
-          ) : null}
+            <div className="dfd__stat">
+              <dt>Point margin</dt>
+              <dd className={marginTone}>{overlay.marginValue || '—'}</dd>
+            </div>
+            <div className="dfd__stat">
+              <dt>Rating</dt>
+              <dd>
+                {ranked && overlay.shareRating ? (
+                  <AnimatedScore value={overlay.shareRating} from={0} />
+                ) : (
+                  '—'
+                )}
+              </dd>
+            </div>
+            <div className="dfd__stat">
+              <dt>Streak</dt>
+              <dd>
+                {overlay.shareStreak ? <AnimatedScore value={overlay.shareStreak} from={0} /> : '—'}
+                {overlay.streakHeld ? <span className="dfd__held">held</span> : null}
+              </dd>
+            </div>
+          </dl>
 
-          {showMargin || overlay.shareRating || !!overlay.shareStreak ? (
-            <div className="df-result-meta-row">
-              {showMargin ? (
-                <div className="df-result-meta-pill">
-                  <span className="df-result-meta-label">Margin</span>
-                  <span className="df-result-meta-value">{overlay.marginValue}</span>
-                </div>
-              ) : null}
-              {overlay.shareRating ? (
-                <div className="df-result-meta-pill">
-                  <span className="df-result-meta-label">Rating</span>
-                  <AnimatedScore
-                    value={overlay.shareRating}
-                    from={0}
-                    className="df-result-meta-value"
-                  />
-                </div>
-              ) : null}
-              {overlay.shareStreak ? (
-                <div className="df-result-meta-pill">
-                  <span className="df-result-meta-label">Streak</span>
-                  <AnimatedScore
-                    value={overlay.shareStreak}
-                    from={0}
-                    className="df-result-meta-value"
-                  />
-                </div>
-              ) : null}
-            </div>
-          ) : null}
+          {overlay.note ? <p className="dfd__note">{overlay.note}</p> : null}
 
           {overlay.errorMessage ? (
-            <div className="hand-over-error-zone" role="alert">
-              <span className="hand-over-error-text" title={overlay.errorMessage}>
-                {overlay.errorMessage}
-              </span>
-            </div>
+            <p className="dfd__note" role="alert">
+              {overlay.errorMessage}
+            </p>
           ) : null}
 
-          {overlay.practiceHint ? (
-            <p className="daily-fritz-practice-hint">{overlay.practiceHint}</p>
-          ) : null}
+          {overlay.practiceHint ? <p className="dfd__note">{overlay.practiceHint}</p> : null}
 
-          <div className="df-result-actions">
-            <button
-              type="button"
-              className="df-result-primary"
-              onClick={overlay.onPrimary}
-              disabled={overlay.primaryDisabled}
-            >
-              {overlay.primaryLabel}
-            </button>
-            {overlay.secondaryLabel ? (
-              <button type="button" className="df-result-secondary" onClick={overlay.onSecondary}>
-                {overlay.secondaryLabel}
-              </button>
-            ) : null}
-            {overlay.tertiaryLabel ? (
-              <button type="button" className="df-result-secondary" onClick={overlay.onTertiary}>{overlay.tertiaryLabel}</button>
-            ) : null}
-            <button type="button" className="df-result-share-btn" onClick={onShare}>
+          <div className="dfd__actions">
+            <button type="button" className="dfd__btn dfd__btn--primary" onClick={onShare}>
               {shareDone ? 'Copied' : 'Share Result'}
             </button>
+            <div className="dfd__row">
+              <button
+                type="button"
+                className="dfd__btn"
+                onClick={overlay.onPrimary}
+                disabled={overlay.primaryDisabled}
+              >
+                {overlay.primaryLabel}
+              </button>
+              {overlay.secondaryLabel ? (
+                <button type="button" className="dfd__btn" onClick={overlay.onSecondary}>
+                  {overlay.secondaryLabel}
+                </button>
+              ) : null}
+            </div>
           </div>
         </div>
       </div>

--- a/client/src/dailyFritz/DailyFritzLeaderboardScreen.tsx
+++ b/client/src/dailyFritz/DailyFritzLeaderboardScreen.tsx
@@ -340,6 +340,7 @@ export default function DailyFritzLeaderboardScreen({
       shareRating: profileRating,
       shareStreak: today.streak ?? 0,
       canViewLeaderboard: true,
+      verificationStatus: today.verification_status,
       onPrimary: () => setResultOverlayOpen(false),
       onSecondary: () => {
         setResultOverlayOpen(false);

--- a/client/src/dailyFritz/buildDailyFritzSetOverlayViewModel.ts
+++ b/client/src/dailyFritz/buildDailyFritzSetOverlayViewModel.ts
@@ -42,6 +42,17 @@ export type BuildDailyFritzSetOverlayContext = {
   profileGlickoRating?: number | null;
 };
 
+/**
+ * The interstitial's status chip. Says where the set stands, not what just
+ * happened — the headline already carries that.
+ */
+function describeStanding(playerGamesWon: number, fritzGamesWon: number): string {
+  if (playerGamesWon === fritzGamesWon) return `All square ${playerGamesWon}-${fritzGamesWon}`;
+  return playerGamesWon > fritzGamesWon
+    ? `You lead ${playerGamesWon}-${fritzGamesWon}`
+    : `Fritz leads ${fritzGamesWon}-${playerGamesWon}`;
+}
+
 export function buildDailyFritzSetOverlayViewModel(
   setOverlay: DailyFritzOverlayState,
   actions: BuildDailyFritzSetOverlayActions,
@@ -171,6 +182,8 @@ export function buildDailyFritzSetOverlayViewModel(
     return {
       ...base,
       kind: 'between' as const,
+      runId: context.todayRunDate ? `DF-${context.todayRunDate}` : undefined,
+      standing: describeStanding(sr.playerGamesWon, sr.fritzGamesWon),
       eyebrow: skunkCopy?.eyebrow ?? base.eyebrow,
       headline: skunkCopy?.headline ??
         (Number(g.playerScore) > Number(g.fritzScore)

--- a/client/src/dailyFritz/buildFinalOverlayViewModel.test.ts
+++ b/client/src/dailyFritz/buildFinalOverlayViewModel.test.ts
@@ -1,0 +1,100 @@
+// @vitest-environment jsdom
+/**
+ * The dossier fields on the final result card.
+ *
+ * The header's provenance line and the ranked flag come from the run's
+ * verification status, not from whether the player won — an unverified win is
+ * still unranked, and that has to read honestly on the card.
+ */
+import { describe, it, expect } from 'vitest';
+import { buildDailyFritzFinalOverlayViewModel } from './buildFinalOverlayViewModel';
+import type { DailyFritzSetResult } from './api';
+
+const game = (n: number, ps: number, fz: number, skunk = false) => ({
+  gameNumber: n, seed: 's', playerWon: ps > fz, playerScore: ps, fritzScore: fz,
+  pointDiff: ps - fz, completedAt: '2026-08-28T09:36:00Z',
+  ...(skunk ? { skunk: true, skunkBy: 'player' } : {}),
+});
+
+function setResult(over: Partial<DailyFritzSetResult> = {}): DailyFritzSetResult {
+  return {
+    version: 2, format: 'best_of_3', playerGamesWon: 2, fritzGamesWon: 0,
+    totalPointDiff: 80, games: [game(1, 65, 33), game(2, 60, 12, true)],
+    setWinner: 'player', hasSkunk: true, instantSkunk: false,
+    skunkGameNumber: 2, skunkBy: 'player', ...over,
+  } as unknown as DailyFritzSetResult;
+}
+
+function build(over: Record<string, unknown> = {}) {
+  return buildDailyFritzFinalOverlayViewModel({
+    setResult: setResult(), rank: 1, runDate: '2026-08-26', fritzTier: 'elite',
+    shareRating: 1742, shareStreak: 1, canViewLeaderboard: true,
+    onPrimary: () => {}, onSecondary: () => {}, ...over,
+  } as never);
+}
+
+describe('final overlay dossier fields', () => {
+  it('stamps the run id from the run date', () => {
+    expect(build().runId).toBe('DF-2026-08-26');
+  });
+
+  it('reads verified runs as ranked, with tier and state in the header', () => {
+    const vm = build({ verificationStatus: 'verified' });
+    expect(vm.ranked).toBe(true);
+    expect(vm.provenance).toBe('Elite · Verified');
+  });
+
+  it('marks an unverified run unranked even when the set was won', () => {
+    const vm = build({ verificationStatus: 'legacy_unverified' });
+    expect(vm.ranked).toBe(false);
+    expect(vm.provenance).toBe('Unranked');
+    expect(vm.note).toMatch(/verified/i);
+  });
+
+  it('defaults to ranked when verification is not supplied, preserving old behaviour', () => {
+    expect(build().ranked).toBe(true);
+  });
+
+  it('says the streak held when a loss leaves it intact', () => {
+    const vm = build({
+      setResult: setResult({
+        playerGamesWon: 1, fritzGamesWon: 2, totalPointDiff: -10,
+        setWinner: 'fritz', hasSkunk: false,
+        games: [game(1, 60, 52), game(2, 49, 60), game(3, 53, 60)],
+      } as Partial<DailyFritzSetResult>),
+      shareStreak: 4,
+    });
+    expect(vm.streakHeld).toBe(true);
+    expect(vm.note).toMatch(/missed day/i);
+  });
+
+  it('does not claim a held streak on a win, or with no streak', () => {
+    expect(build({ shareStreak: 4 }).streakHeld).toBe(false);
+    expect(build({
+      setResult: setResult({ setWinner: 'fritz', playerGamesWon: 0, fritzGamesWon: 2 } as Partial<DailyFritzSetResult>),
+      shareStreak: 0,
+    }).streakHeld).toBe(false);
+  });
+
+  it('states the outcome in the headline rather than a generic completion', () => {
+    expect(build().headline).toBe('Skunk finish');
+    expect(build({
+      setResult: setResult({ hasSkunk: false, skunkGameNumber: undefined, skunkBy: undefined,
+        games: [game(1, 65, 33), game(2, 60, 42)] } as Partial<DailyFritzSetResult>),
+    }).headline).toBe('Set won');
+    expect(build({
+      setResult: setResult({ setWinner: 'fritz', playerGamesWon: 1, fritzGamesWon: 2,
+        hasSkunk: false, skunkGameNumber: undefined, skunkBy: undefined,
+        games: [game(1, 60, 52), game(2, 49, 60), game(3, 53, 60)] } as Partial<DailyFritzSetResult>),
+    }).headline).toBe('Fritz takes it');
+  });
+
+  it('lets the unranked headline win over the outcome', () => {
+    expect(build({ verificationStatus: 'rejected' }).headline).toBe('Finished, but unranked');
+  });
+
+  it('keeps rank and rating blank on an unranked run', () => {
+    const vm = build({ verificationStatus: 'rejected' });
+    expect(vm.rankValue).toBeNull();
+  });
+});

--- a/client/src/dailyFritz/buildFinalOverlayViewModel.ts
+++ b/client/src/dailyFritz/buildFinalOverlayViewModel.ts
@@ -1,5 +1,9 @@
-import type { DailyFritzSetGameResult, DailyFritzSetResult } from './api';
-import { formatOrdinalPlace } from './format';
+import type {
+  DailyFritzSetGameResult,
+  DailyFritzSetResult,
+  DailyFritzVerificationStatus,
+} from './api';
+import { formatOrdinal, formatOrdinalPlace } from './format';
 import {
   getDailyFritzPublishedSetScore,
   getGameSkunkChipLabel,
@@ -36,6 +40,11 @@ export type BuildFinalOverlayInput = {
   shareRating?: number;
   shareStreak?: number;
   canViewLeaderboard: boolean;
+  /**
+   * The run's verification state. Omitted by callers that don't know it, which
+   * are treated as ranked so nothing regresses to "Unranked" by accident.
+   */
+  verificationStatus?: DailyFritzVerificationStatus;
   onPrimary: () => void;
   onSecondary: () => void;
 };
@@ -49,6 +58,7 @@ export function buildDailyFritzFinalOverlayViewModel({
   shareRating,
   shareStreak,
   canViewLeaderboard,
+  verificationStatus,
   onPrimary,
   onSecondary,
 }: BuildFinalOverlayInput): DailyFritzSetOverlayViewModel {
@@ -76,10 +86,34 @@ export function buildDailyFritzFinalOverlayViewModel({
     };
   });
 
+  // Only a verified run can be ranked. A caller that doesn't know the status
+  // gets the old behaviour rather than a false "Unranked".
+  const ranked = verificationStatus === undefined || verificationStatus === 'verified';
+  // The daily streak counts consecutive days *completed*, not days won, so a
+  // lost set leaves it standing. Worth saying, because a loss reads like a break.
+  const streakHeld = !setWonPlayer && (shareStreak ?? 0) > 0;
+
+  const note = !ranked
+    ? "The set counted and your streak is intact — it just can't be ranked against players whose runs were verified."
+    : streakHeld
+      ? 'Your streak survives a loss — only a missed day breaks it.'
+      : null;
+
+  // The dossier headline states the outcome; a card that just said "Daily Fritz
+  // Complete" for a win and a loss alike made the reader hunt for the result.
+  const headline = !ranked
+    ? 'Finished, but unranked'
+    : (skunkCopy?.headline ?? (setWonPlayer ? 'Set won' : 'Fritz takes it'));
+
   return {
     kind: 'final',
+    runId: `DF-${runDate}`,
+    provenance: ranked ? `${titleCaseTier(fritzTier)} · Verified` : 'Unranked',
+    ranked,
+    streakHeld,
+    note,
     eyebrow: 'Daily Fritz',
-    headline: skunkCopy?.headline ?? 'Daily Fritz Complete',
+    headline,
     subheadline:
       skunkCopy?.subheadline ??
       (setWonPlayer
@@ -97,7 +131,8 @@ export function buildDailyFritzFinalOverlayViewModel({
     marginValue: margin,
     marginTone,
     resultValue: setWonPlayer ? 'Victory' : 'Defeat',
-    rankValue: formatOrdinalPlace(rank),
+    rankValue: ranked ? formatOrdinalPlace(rank) : null,
+    rankShort: ranked ? formatOrdinal(rank) : null,
     shareDate: formatDateLabel(runDate),
     shareTier: titleCaseTier(fritzTier),
     shareRating,

--- a/client/src/dailyFritz/dailyFritzModalDossier.css
+++ b/client/src/dailyFritz/dailyFritzModalDossier.css
@@ -1,0 +1,364 @@
+/*
+ * Daily Fritz result and interstitial — the dossier treatment.
+ *
+ * One card language for both: a run-stamped header strip, hairline-ruled game
+ * rows whose bar shows the winner's share of the points, then a square stat
+ * grid. Result cards are 420px and portrait; the interstitial is 760px and
+ * landscape, because it is a waypoint rather than an ending.
+ */
+
+.dfd {
+  --dfd-line: rgba(255, 255, 255, 0.07);
+  --dfd-line-strong: rgba(255, 255, 255, 0.14);
+  --dfd-ink: var(--df-paper);
+  --dfd-muted: rgba(255, 255, 255, 0.5);
+  --dfd-dim: rgba(255, 255, 255, 0.36);
+  --dfd-accent: var(--tier-elite);
+  --dfd-win: var(--df-win);
+  --dfd-loss: var(--df-loss);
+
+  width: min(100%, 420px);
+  border: 1px solid rgba(231, 182, 74, 0.22);
+  border-radius: 4px;
+  overflow: hidden;
+  background-color: var(--df-card);
+  /* A faint plan grid, so the card reads as a record rather than a panel. */
+  background-image:
+    linear-gradient(rgba(255, 255, 255, 0.022) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255, 255, 255, 0.022) 1px, transparent 1px);
+  background-size: 28px 28px;
+  box-shadow: 0 40px 90px -24px rgba(0, 0, 0, 0.95);
+  color: var(--dfd-ink);
+  font-family: var(--font-body);
+}
+
+.dfd--unranked {
+  border-color: var(--dfd-line-strong);
+}
+
+/* ── header strip ── */
+
+.dfd__strip {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 18px;
+  border-bottom: 1px solid rgba(231, 182, 74, 0.22);
+  background: rgba(231, 182, 74, 0.05);
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  font-variant-numeric: tabular-nums;
+}
+
+.dfd--unranked .dfd__strip {
+  border-bottom-color: var(--dfd-line-strong);
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.dfd__run { color: var(--dfd-accent); }
+.dfd--unranked .dfd__run { color: var(--dfd-muted); }
+.dfd__provenance { color: var(--dfd-dim); }
+
+.dfd__body { padding: 22px 20px 20px; }
+
+/* ── headline ── */
+
+.dfd__eyebrow {
+  display: block;
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--dfd-dim);
+}
+
+.dfd__headline {
+  margin: 8px 0 0;
+  font-family: var(--font-display);
+  font-size: 34px;
+  font-weight: 800;
+  line-height: 1;
+  letter-spacing: -0.01em;
+  color: var(--dfd-ink);
+  text-wrap: balance;
+}
+
+.dfd__headline::after {
+  content: ".";
+  color: var(--dfd-accent);
+}
+
+.dfd__sub {
+  margin: 10px 0 0;
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--dfd-muted);
+}
+
+/* ── game rows ── */
+
+.dfd__games {
+  display: flex;
+  flex-direction: column;
+  margin-top: 18px;
+}
+
+.dfd__game {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 11px 0;
+  border-top: 1px solid var(--dfd-line);
+}
+
+.dfd__game:last-child { border-bottom: 1px solid var(--dfd-line); }
+.dfd__game--empty { opacity: 0.4; }
+
+.dfd__game-no {
+  font-size: 11.5px;
+  letter-spacing: 0.06em;
+  color: var(--dfd-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.dfd__track {
+  position: relative;
+  flex: 1;
+  height: 2px;
+  background: rgba(255, 255, 255, 0.06);
+}
+
+/* The fill is the winner's share of the points, anchored to their side. */
+.dfd__fill {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+}
+
+.dfd__fill--win { left: 0; background: var(--dfd-win); }
+.dfd__fill--skunk {
+  left: 0;
+  background: var(--dfd-accent);
+  box-shadow: 0 0 10px 0 rgba(231, 182, 74, 0.7);
+}
+.dfd__fill--loss { right: 0; background: rgba(240, 160, 168, 0.75); }
+
+.dfd__game-score {
+  min-width: 58px;
+  text-align: right;
+  font-size: 13px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
+.dfd__game-score--win { color: var(--dfd-win); }
+.dfd__game-score--skunk { color: var(--dfd-accent); }
+.dfd__game-score--loss { color: var(--dfd-loss); }
+.dfd__game-score--empty { color: var(--dfd-dim); font-weight: 500; }
+
+.dfd__game-tag {
+  font-size: 9.5px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--dfd-accent);
+}
+
+/* ── stat grid ── */
+
+.dfd__stats {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  margin: 18px 0 0;
+  border: 1px solid var(--dfd-line);
+}
+
+.dfd__stat {
+  padding: 11px 14px 13px;
+  border-top: 1px solid var(--dfd-line);
+  border-left: 1px solid var(--dfd-line);
+  min-width: 0;
+}
+
+.dfd__stat:nth-child(-n + 2) { border-top: 0; }
+.dfd__stat:nth-child(odd) { border-left: 0; }
+
+.dfd__stat dt {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--dfd-dim);
+}
+
+.dfd__stat dd {
+  margin: 5px 0 0;
+  font-family: var(--font-display);
+  font-size: 22px;
+  font-weight: 700;
+  line-height: 1;
+  color: var(--dfd-ink);
+  font-variant-numeric: tabular-nums;
+}
+
+.dfd__stat dd.is-win { color: var(--dfd-win); }
+.dfd__stat dd.is-loss { color: var(--dfd-loss); }
+.dfd__stat dd.is-accent { color: var(--dfd-accent); }
+
+.dfd__held {
+  margin-left: 6px;
+  font-family: var(--font-body);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  color: var(--dfd-dim);
+  text-transform: uppercase;
+}
+
+.dfd__note {
+  margin: 14px 0 0;
+  font-size: 12px;
+  line-height: 1.55;
+  color: var(--dfd-dim);
+}
+
+/* ── actions ── */
+
+.dfd__actions {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 18px;
+}
+
+.dfd__row {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.dfd__btn {
+  height: 42px;
+  padding: 0 16px;
+  border: 1px solid var(--dfd-line-strong);
+  border-radius: 3px;
+  background: transparent;
+  color: var(--dfd-ink);
+  font-family: var(--font-body);
+  font-size: 13.5px;
+  font-weight: 600;
+  cursor: pointer;
+  transition:
+    transform 120ms cubic-bezier(0.2, 0, 0, 1),
+    box-shadow 120ms cubic-bezier(0.2, 0, 0, 1),
+    border-color 120ms cubic-bezier(0.2, 0, 0, 1);
+}
+
+.dfd__btn:hover { border-color: rgba(231, 182, 74, 0.5); transform: translateY(-1px); }
+.dfd__btn:active { transform: scale(0.97); }
+.dfd__btn:focus-visible { outline: 2px solid var(--dfd-accent); outline-offset: 2px; }
+.dfd__btn:disabled { opacity: 0.5; cursor: default; transform: none; }
+
+.dfd__btn--primary {
+  border-color: var(--dfd-accent);
+  background: var(--dfd-accent);
+  color: var(--bg-obsidian);
+  font-weight: 700;
+}
+
+.dfd__btn--primary:hover { border-color: var(--dfd-accent); filter: brightness(1.07); }
+
+/* ── interstitial: same language, landscape ── */
+
+.dfd--wide { width: min(100%, 760px); }
+
+.dfd__split {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 300px;
+}
+
+.dfd__split > * { padding: 22px 22px 24px; }
+.dfd__split > * + * { border-left: 1px solid var(--dfd-line); }
+
+.dfd__pair {
+  display: flex;
+  gap: 26px;
+  margin-top: 18px;
+}
+
+.dfd__pair dt {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--dfd-dim);
+}
+
+.dfd__pair dd {
+  margin: 5px 0 0;
+  font-family: var(--font-display);
+  font-size: 26px;
+  font-weight: 700;
+  line-height: 1;
+  font-variant-numeric: tabular-nums;
+}
+
+.dfd__progress-label {
+  display: block;
+  margin-bottom: 4px;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--dfd-dim);
+}
+
+.dfd__step {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 0;
+}
+
+.dfd__step-no {
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  color: var(--dfd-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.dfd__step-track { flex: 1; height: 2px; background: rgba(255, 255, 255, 0.06); }
+.dfd__step-fill { display: block; height: 100%; width: 100%; }
+.dfd__step-fill.is-win { background: var(--dfd-win); }
+.dfd__step-fill.is-loss { background: rgba(240, 160, 168, 0.75); }
+.dfd__step-fill.is-next { background: var(--dfd-accent); }
+.dfd__step-fill.is-idle { background: rgba(255, 255, 255, 0.12); }
+
+.dfd__step-state {
+  min-width: 58px;
+  text-align: right;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.dfd__step-state.is-win { color: var(--dfd-win); }
+.dfd__step-state.is-loss { color: var(--dfd-loss); }
+.dfd__step-state.is-next { color: var(--dfd-accent); }
+.dfd__step-state.is-idle { color: var(--dfd-dim); }
+
+.dfd__split .dfd__actions { margin-top: 20px; }
+
+@media (max-width: 720px) {
+  .dfd__split { grid-template-columns: minmax(0, 1fr); }
+  .dfd__split > * + * { border-left: 0; border-top: 1px solid var(--dfd-line); }
+  .dfd__headline { font-size: 28px; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .dfd__btn { transition: none; }
+}

--- a/client/src/dailyFritz/dossierGameRows.test.ts
+++ b/client/src/dailyFritz/dossierGameRows.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { buildDossierGameRows } from './dossierGameRows';
+import type { DailyFritzSetOverlayViewModel } from './setOverlayViewModel';
+
+type Game = DailyFritzSetOverlayViewModel['games'][number];
+const g = (n: number, ps: number, fz: number, skunk = false) =>
+  ({ gameNumber: n, value: `${ps}–${fz}`, tone: ps > fz ? 'win' : 'loss',
+     playerScore: ps, fritzScore: fz, skunk } as Game);
+
+describe('buildDossierGameRows', () => {
+  it('always returns three rows, marking an unplayed decider', () => {
+    const rows = buildDossierGameRows([g(1, 65, 33), g(2, 60, 12)]);
+    expect(rows).toHaveLength(3);
+    expect(rows[2]).toEqual({ gameNumber: 3, played: false });
+  });
+
+  it('fills the bar with the winner’s share of the points', () => {
+    const [row] = buildDossierGameRows([g(1, 65, 33)]);
+    // 65 of 98 points.
+    expect(row).toMatchObject({ sharePercent: 66, side: 'player' });
+  });
+
+  it('anchors a lost game to Fritz’s side', () => {
+    const [row] = buildDossierGameRows([g(1, 49, 60)]);
+    expect(row).toMatchObject({ side: 'fritz', tone: 'loss', sharePercent: 55 });
+  });
+
+  it('tones a won skunk gold, but never a lost one', () => {
+    expect(buildDossierGameRows([g(1, 60, 12, true)])[0]).toMatchObject({ tone: 'skunk' });
+    expect(buildDossierGameRows([g(1, 12, 60, true)])[0]).toMatchObject({ tone: 'loss' });
+  });
+
+  it('halves a scoreless game rather than dividing by zero', () => {
+    expect(buildDossierGameRows([g(1, 0, 0)])[0]).toMatchObject({ sharePercent: 50 });
+  });
+});

--- a/client/src/dailyFritz/dossierGameRows.ts
+++ b/client/src/dailyFritz/dossierGameRows.ts
@@ -1,0 +1,51 @@
+import type { DailyFritzSetGameNumber } from './api';
+import type { DailyFritzSetOverlayViewModel } from './setOverlayViewModel';
+
+export const DAILY_FRITZ_GAME_NUMBERS: DailyFritzSetGameNumber[] = [1, 2, 3];
+
+export type DossierGameRow =
+  | { gameNumber: DailyFritzSetGameNumber; played: false }
+  | {
+      gameNumber: DailyFritzSetGameNumber;
+      played: true;
+      score: string;
+      tone: 'win' | 'loss' | 'skunk';
+      /** The winner's share of the points, as a percentage of the track. */
+      sharePercent: number;
+      /** Which edge the fill is anchored to. */
+      side: 'player' | 'fritz';
+    };
+
+/**
+ * Builds the three fixed game rows on a dossier card.
+ *
+ * All three are always present — an unplayed decider is greyed rather than
+ * dropped, so the card keeps one shape whatever happened. The bar carries the
+ * winner's share of that game's points, which is why a shutout reads as a near
+ * full bar and a tight game as a near half.
+ */
+export function buildDossierGameRows(
+  games: DailyFritzSetOverlayViewModel['games'],
+): DossierGameRow[] {
+  const byNumber = new Map(games.map((game) => [game.gameNumber, game] as const));
+
+  return DAILY_FRITZ_GAME_NUMBERS.map((gameNumber) => {
+    const game = byNumber.get(gameNumber);
+    if (!game) return { gameNumber, played: false as const };
+
+    const player = Math.max(0, game.playerScore);
+    const fritz = Math.max(0, game.fritzScore);
+    const total = player + fritz;
+    const playerWon = player > fritz;
+    const winnerShare = total === 0 ? 50 : ((playerWon ? player : fritz) / total) * 100;
+
+    return {
+      gameNumber,
+      played: true as const,
+      score: `${player}–${fritz}`,
+      tone: game.skunk && playerWon ? ('skunk' as const) : playerWon ? ('win' as const) : ('loss' as const),
+      sharePercent: Math.round(winnerShare),
+      side: playerWon ? ('player' as const) : ('fritz' as const),
+    };
+  });
+}

--- a/client/src/dailyFritz/format.ts
+++ b/client/src/dailyFritz/format.ts
@@ -25,6 +25,12 @@ export function formatCountdownHms(totalSeconds: number): string {
 }
 
 /** Ordinal label for leaderboard-style rank (e.g. "12th Place"). */
+/** "1st", "2nd" — the bare ordinal, for places too tight for "1st Place". */
+export function formatOrdinal(value: number | null): string | null {
+  const place = formatOrdinalPlace(value);
+  return place === null ? null : place.replace(' Place', '');
+}
+
 export function formatOrdinalPlace(value: number | null): string | null {
   if (!value || value <= 0) return null;
   const mod100 = value % 100;

--- a/client/src/dailyFritz/setOverlayStanding.test.ts
+++ b/client/src/dailyFritz/setOverlayStanding.test.ts
@@ -1,0 +1,40 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { buildDailyFritzSetOverlayViewModel } from './buildDailyFritzSetOverlayViewModel';
+
+const game = (n: number, ps: number, fz: number) => ({
+  gameNumber: n, seed: 's', playerWon: ps > fz, playerScore: ps, fritzScore: fz,
+  pointDiff: ps - fz, completedAt: '2026-08-28T09:36:00Z',
+});
+const actions = {
+  continueSet: () => {}, submitCompletedGame: () => {}, closeEmbeddedRun: () => {},
+  loadToday: () => {}, openLeaderboardForRunDate: () => {}, clearOverlay: () => {},
+  retryFinalSubmission: () => {}, startPractice: () => {},
+} as never;
+
+function between(playerGamesWon: number, fritzGamesWon: number) {
+  return buildDailyFritzSetOverlayViewModel(
+    { kind: 'between', completedGame: game(1, 65, 33),
+      setResult: { version: 2, format: 'best_of_3', playerGamesWon, fritzGamesWon,
+        totalPointDiff: 32, games: [game(1, 65, 33)], setWinner: null,
+        hasSkunk: false, instantSkunk: false },
+      nextGameNumber: 2 } as never,
+    actions,
+    { todayRunDate: '2026-08-26' },
+  );
+}
+
+describe('interstitial standing chip', () => {
+  it('names who leads', () => {
+    expect(between(1, 0).standing).toBe('You lead 1-0');
+    expect(between(0, 1).standing).toBe('Fritz leads 1-0');
+  });
+
+  it('calls a level set all square', () => {
+    expect(between(1, 1).standing).toBe('All square 1-1');
+  });
+
+  it('stamps the run id from the day in context', () => {
+    expect(between(1, 0).runId).toBe('DF-2026-08-26');
+  });
+});

--- a/client/src/dailyFritz/setOverlayViewModel.ts
+++ b/client/src/dailyFritz/setOverlayViewModel.ts
@@ -29,6 +29,20 @@ export interface DailyFritzSetOverlayViewModel {
   resultValue: string | null;
   rankValue: string | null;
   skunkBadge: string | null;
+  /** Dossier header, left: the run being reported, e.g. "DF-2026-08-26". */
+  runId?: string;
+  /** Dossier header, right: "Elite · Verified", or "Unranked" when unverified. */
+  provenance?: string;
+  /** False when the run finished without a verified receipt. */
+  ranked?: boolean;
+  /** A lost set that still leaves the daily streak intact. */
+  streakHeld?: boolean;
+  /** Explanatory paragraph under the stat grid (loss / unranked only). */
+  note?: string | null;
+  /** Bare ordinal rank for the dossier stat grid, e.g. "1st". */
+  rankShort?: string | null;
+  /** Interstitial status chip, e.g. "You lead 1-0". */
+  standing?: string | null;
   shareDate?: string;
   shareTier?: string;
   shareRating?: number;

--- a/client/src/dailyFritz/skunk.test.ts
+++ b/client/src/dailyFritz/skunk.test.ts
@@ -221,7 +221,7 @@ describe('skunk detection and messaging', () => {
       };
       const copy = getSkunkOverlayCopy(setResult, game);
       expect(copy).not.toBeNull();
-      expect(copy!.headline).toBe('SKUNK');
+      expect(copy!.headline).toBe('Skunk');
       expect(copy!.subheadline).toContain('2–0');
       expect(copy!.primaryTone).toBe('success');
     });

--- a/client/src/dailyFritz/skunk.ts
+++ b/client/src/dailyFritz/skunk.ts
@@ -108,7 +108,7 @@ export function getSkunkOverlayCopy(
   if (completedGame.gameNumber === 1 && setResult.instantSkunk && playerWonGame && setWon) {
     return {
       eyebrow: 'Daily Fritz',
-      headline: 'SKUNK',
+      headline: 'Skunk',
       subheadline: 'You beat Fritz before he reached 30. Set won 2–0.',
       primaryTone: 'success',
     };
@@ -125,7 +125,7 @@ export function getSkunkOverlayCopy(
     const setLine = `${setResult.playerGamesWon}–${setResult.fritzGamesWon}`;
     return {
       eyebrow: 'Daily Fritz',
-      headline: 'SKUNK FINISH',
+      headline: 'Skunk finish',
       subheadline: `You skunked Fritz in game 2. Set won ${setLine}.`,
       primaryTone: 'success',
     };
@@ -142,7 +142,7 @@ export function getSkunkOverlayCopy(
   if (completedGame.gameNumber === 3 && playerWonGame && setWon) {
     return {
       eyebrow: 'Daily Fritz',
-      headline: 'DECIDER SKUNK',
+      headline: 'Decider skunk',
       subheadline: 'You crushed the deciding game before Fritz reached 30.',
       primaryTone: 'success',
     };

--- a/client/src/styles/tokens.css
+++ b/client/src/styles/tokens.css
@@ -126,6 +126,12 @@
     radial-gradient(circle at 50% 18%, rgba(0, 0, 0, 0.00) 0%, rgba(0, 0, 0, 0.10) 58%, rgba(0, 0, 0, 0.46) 100%);
 
   /* ── Typography ──────────────────────────────────── */
+  /* ── Daily Fritz result dossier ─────────────────── */
+  --df-win:   #7ee0a8;   /* muted green — a game taken */
+  --df-loss:  #f0a0a8;   /* muted rose  — a game lost */
+  --df-paper: #f2eee8;   /* warm off-white for display copy */
+  --df-card:  #070a10;   /* dossier ground, one step off obsidian */
+
   --font-display: 'Barlow Condensed', sans-serif;
   --font-body:    'Outfit', sans-serif;
 


### PR DESCRIPTION
Implements the approved **dossier** direction from the `Daily Fritz Modals` canvas for the two modals that end a game and a set. Reference: https://claude.ai/code/artifact/7f800933-2826-4b10-9033-21c773ead9de

Both cards now share one language: a run-stamped header strip, hairline-ruled game rows whose bar carries the winner's share of that game's points, then a square stat grid. The result card is 420px and portrait; the interstitial is 760px and landscape, because it's a waypoint rather than an ending.

## What changed beyond the styling

**The result card states its outcome.** It previously headlined `Daily Fritz Complete` for a win and a loss alike, which made the reader hunt for what actually happened. It now says "Set won", "Fritz takes it", "Skunk finish", or "Finished, but unranked".

**Unranked runs read honestly.** The header carries the run's verification state, and an unverified finish drops rank and rating to em dashes with a line explaining why — instead of a silent blank rank. `verification_status` was already in scope at the only call site, so this is plumbed, not invented.

**A lost set says the streak held.** I checked the rule rather than trusting the mock's copy: `getDailyFritzStreak` counts consecutive *completed* days with no win/loss condition, so a loss genuinely leaves the streak standing. Worth saying, because a loss reads like a break.

**Skunk headlines drop to sentence case.** The existing copy was already inconsistent — losses read `Skunked by Fritz` while wins shouted `SKUNK FINISH`. Sentence case matches the design and makes the set coherent. The uppercase skunk **badge** is untouched.

## Not implemented, and why

Two elements of the mock have no data behind them, so I left them out rather than faking them:

- **The rating delta chip** (`+12` / `−8`). Nothing in the Daily Fritz flow carries a rating delta — I searched for `glickoDelta`, `ratingDelta`, `rating_delta`, `ratingChange` and found none on this path.
- **The per-game "No receipt" tag.** Verification is set-level (`verification_status`); there's no per-game receipt flag on `DailyFritzSetGameResult`. The set-level Unranked state covers the same ground honestly.

## Worth a decision

The dossier draws game bars as a **proportional share of points**; the leaderboard shipped in #63 draws them as **solid win/loss**, per your call there. Same data, two treatments, one screen apart. This PR implements the design as approved — flagging it so the divergence is deliberate rather than accidental.

## Notes

- New tokens (`--df-win`, `--df-loss`, `--df-paper`, `--df-card`) rather than hardcoded hex, per `client/CLAUDE.md`. The greens and roses already existed as literals in `match-hud-polish.css`; these name them.
- Rank uses a new `formatOrdinal` ("1st") for the tight stat cell; `formatOrdinalPlace` ("1st Place") is untouched for its four other callers.
- The old `.df-result-*` rules stay — pivotal-review, PlayVsFritz and the analyzer still use them.

## Verification

- `tsc -b` clean
- Full client suite: **191 files, 1310 tests, all passing**
- Lint: 401 warnings / **0 errors**, unchanged from baseline
- 17 new tests across the dossier fields, the standing chip, and the game-row geometry
- Rendered and compared against the artboards at all four result states and both interstitial states

🤖 Generated with [Claude Code](https://claude.com/claude-code)