### PR TITLE
feat(design): a radius rule based on what the surface is for

### DIFF
--- a/client/CLAUDE.md
+++ b/client/CLAUDE.md
@@ -41,7 +41,10 @@ Current tokens:
 --tier-elite:    #E7B64A;      /* Gold   — prestige, achievement, mastery */
 --tier-master:   #A855F7;      /* Purple — elite competition, premium modes */
 
---radius-card:   24px;         /* Standard card corner radius */
+--radius-record:  3px;        /* Records and tables: leaderboards, dossiers */
+--radius-control: 4px;        /* Buttons, chips, inputs */
+--radius-pill:   999px;       /* Avatars, status dots, badges only */
+--radius-card:   24px;        /* Legacy — see the radius rule below */
 --hud-lift:      20px;         /* Standard shadow elevation for lifted panels */
 
 --font-display: 'Barlow Condensed', sans-serif;   /* HUD labels, headers, stats */
@@ -72,6 +75,35 @@ The Racehorse color system is dark, atmospheric, and restrained:
 Accent colors come from the tier system only. Blue for gameplay/interaction, Gold for prestige/achievement, Purple for elite/premium, Green for streaks/success.
 
 **Avoid gradients across the app.** Use matte solid surfaces, crisp borders, subtle shadows, and restrained accent colors—not `linear-gradient` / `radial-gradient` fills on panels, cards, buttons, or page backgrounds. Gradients make the product feel less premium and less aligned with the Play vs Fritz identity. Also avoid bright saturated fills and pure white sections.
+
+### 3b. Corner Radius — By What the Surface Is For
+
+Two shapes are allowed, because the split encodes something real. It is not
+"cards are round" or "cards are square" — it is what the surface is doing.
+
+**Square — `var(--radius-record)`**
+Records and tables: leaderboards, result dossiers, stat grids, anything
+tabular or receipt-like. These are dense, scanned rather than read, and
+carry no imagery. Precision is the point, and hairline rules with sharp
+corners deliver it.
+
+**Rounded — the existing `--pvf-radius-*` scale**
+Hubs and landing surfaces: the Daily Fritz / Puzzle Rush / Ladder hubs, and
+anything media-led. These are spacious, image-led and invitational. Rounded
+corners sit with photography and with the circular icons these screens use;
+square corners fight both and read blocky at low density.
+
+**Controls — `var(--radius-control)`**
+Buttons, chips, inputs, everywhere. The slight rounding is the signal that a
+thing is pressable.
+
+**`var(--radius-pill)`** is for avatars, status dots and badges only.
+
+Don't invent a radius. If a value isn't from one of these, it's wrong. The
+codebase carries a long tail of hardcoded radii (89 distinct values at last
+count) — convert them as you touch the files, and don't add new ones.
+
+---
 
 ### 4. The Glass Surface Pattern
 

--- a/client/src/dailyFritz/dailyFritzLeaderboardBoard.css
+++ b/client/src/dailyFritz/dailyFritzLeaderboardBoard.css
@@ -32,7 +32,7 @@
   --dfl-grid: rgba(255, 255, 255, 0.03);
   --dfl-glass: rgba(10, 16, 28, 0.6);
   --dfl-surface: rgba(255, 255, 255, 0.015);
-  --dfl-radius: 3px;
+  --dfl-radius: var(--radius-record);
 }
 
 .dfl-inner {

--- a/client/src/dailyFritz/dailyFritzModalDossier.css
+++ b/client/src/dailyFritz/dailyFritzModalDossier.css
@@ -19,7 +19,7 @@
 
   width: min(100%, 420px);
   border: 1px solid rgba(231, 182, 74, 0.22);
-  border-radius: 4px;
+  border-radius: var(--radius-record);
   overflow: hidden;
   background-color: var(--df-card);
   /* A faint plan grid, so the card reads as a record rather than a panel. */

--- a/client/src/styles/home-hub.css
+++ b/client/src/styles/home-hub.css
@@ -980,7 +980,7 @@
   justify-content: center;
   gap: 8px;
   padding: 11px 18px;
-  border-radius: 8px;
+  border-radius: var(--radius-control);
   border: 1px solid rgba(255, 255, 255, 0.12);
   background: rgba(11, 18, 31, 0.72);
   color: rgba(255, 255, 255, 0.7);

--- a/client/src/styles/tokens.css
+++ b/client/src/styles/tokens.css
@@ -51,6 +51,16 @@
   --shadow-lg: 0 24px 64px rgba(0, 0, 0, 0.60);
 
   /* ── Spatial ─────────────────────────────────────── */
+  /* ── Radius by role ────────────────────────────────
+     --radius-record   records and tables: leaderboards, result dossiers,
+                       stat grids. Square because precision is the point.
+     --radius-control  buttons, chips, inputs. The slight rounding is what
+                       marks a thing as pressable.
+     Rounded hub and landing surfaces keep the existing --pvf-radius-* scale;
+     don't invent a new value for them. */
+  --radius-record:  3px;
+  --radius-control: 4px;
+
   --radius-sm:   8px;
   --radius-md:   14px;
   --radius-lg:   12px;


### PR DESCRIPTION
Names the two shapes the app already uses well, so the split is deliberate rather than accidental. **No screen changes shape** — this codifies what's already working and fixes one hardcoded outlier.

## The rule

| | Token | Where |
|---|---|---|
| **Square** | `--radius-record: 3px` | Leaderboards, result dossiers, stat grids — anything tabular or receipt-like |
| **Rounded** | existing `--pvf-radius-*` | Hubs and landing surfaces — spacious, media-led |
| **Controls** | `--radius-control: 4px` | Buttons, chips, inputs |
| **Pill** | `--radius-pill` | Avatars, status dots, badges only |

Two shapes are allowed because the split **encodes something real** — not "cards are round" or "cards are square", but what the surface is *doing*:

- **Records are square** because they're dense, scanned rather than read, and carry no imagery. Precision is the point, and hairline rules with sharp corners deliver it.
- **Hubs are rounded** because they're spacious and image-led. Rounded corners sit with the photography and the circular icons those screens use; square fights both and reads blocky at low density.

## What's in the diff

- The two tokens, plus the rule written into `client/CLAUDE.md`.
- The board and dossier already used `3px` literally — they now read `--radius-record`, so the token is real rather than aspirational. No visual change beyond 1px on the dossier card.
- **The back button.** It was a hardcoded `8px` sitting behind a `.rh-back-button.rh-back-button.rh-back-button` triple-class specificity hack that beat every scoped rule. It's a control, so it takes the control token — across the 29 screens using it. That's the only visible change.

## What changed from the first version of this PR

The original converted the Daily Fritz hub to square. Side by side against the rounded hub, rounded was clearly better — image-led layout, prominent circular icons, low density — so that conversion is **dropped** and the hub is untouched. The reasoning is now written into the rule so the next person doesn't repeat the mistake.

That also means the original framing ("surfaces square, controls rounded") was too blunt. The line isn't surface-vs-control, it's record-vs-hub.

## Verification

- `tsc -b` clean · stylelint clean
- Full client suite: **190 files, 1306 tests, all passing**
- Lint: 401 warnings / **0 errors**, unchanged from baseline
- Confirmed `dailyFritz.css` is not in the diff — the hub is untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)