### PR TITLE
feat(rush): share a finished Puzzle Rush run

### DIFF
--- a/client/src/puzzleRush/RushResultsView.tsx
+++ b/client/src/puzzleRush/RushResultsView.tsx
@@ -1,7 +1,9 @@
+import { useCallback, useMemo, useState } from 'react';
 import { Button } from '../components/primitives';
 import { AnimatedScore } from '../components/AnimatedScore';
 import type { PuzzleRushCompleteResponse, PuzzleRushStage, RushPuzzleResult } from './types';
 import { stageProgress } from './rushScoring';
+import { buildRushShareText } from './rushShareCard';
 
 /**
  * End-of-run results.
@@ -54,41 +56,105 @@ export function RushResultsView({
     [...stages].reverse().find((stage) => stageProgress(stage, completedOrdinals).done > 0) ?? null;
   const secondsBanked = results.reduce((sum, result) => sum + (result.bonusSeconds || 0), 0);
 
+  const stageRows = useMemo(
+    () =>
+      stages.map((stage) => ({
+        stage,
+        ...stageProgress(stage, completedOrdinals),
+      })),
+    // completedOrdinals is rebuilt each render from `results`; key off that.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [stages, results],
+  );
+
+  // A run the server rejected, or never scored, has no score worth sharing.
+  const shareable = serverScore !== null && !invalidated && !completeError;
+  const shareText = useMemo(
+    () =>
+      shareable
+        ? buildRushShareText({
+            score: serverScore,
+            solved,
+            stages: stageRows.map(({ stage, done, total }) => ({
+              label: stage.label,
+              done,
+              total,
+            })),
+            secondsBanked,
+            playedAt: completion?.run.endedAt ?? completion?.run.startedAt ?? null,
+          })
+        : '',
+    [shareable, serverScore, solved, stageRows, secondsBanked, completion],
+  );
+
+  const [shareDone, setShareDone] = useState(false);
+  const handleShare = useCallback(() => {
+    if (!shareText) return;
+    const markShared = (): void => {
+      setShareDone(true);
+      window.setTimeout(() => setShareDone(false), 2000);
+    };
+    if (typeof navigator !== 'undefined' && typeof navigator.share === 'function') {
+      void navigator
+        .share({ title: 'Puzzle Rush', text: shareText })
+        .then(markShared)
+        .catch(() => {
+          /* user dismissed native share */
+        });
+      return;
+    }
+    void navigator.clipboard.writeText(shareText).then(markShared);
+  }, [shareText]);
+
   return (
     <div className="pr-results" data-ui="rush-results">
       <header className="pr-results__head">
-        <span className="pr-results__eyebrow">Run complete</span>
-        <div className="pr-results__score" data-ui="rush-final-score">
-          {serverScore == null ? (
-            <span className="pr-results__score-value">—</span>
-          ) : (
-            <AnimatedScore value={serverScore} from={0} className="pr-results__score-value" />
-          )}
-          <span className="pr-results__score-suffix">PTS</span>
+        <div className="pr-results__head-copy">
+          <span className="pr-results__eyebrow">Run complete</span>
+          <div className="pr-results__score" data-ui="rush-final-score">
+            {serverScore == null ? (
+              <span className="pr-results__score-value">—</span>
+            ) : (
+              <AnimatedScore value={serverScore} from={0} className="pr-results__score-value" />
+            )}
+            <span className="pr-results__score-suffix">PTS</span>
+          </div>
+          <span className="pr-results__solved">
+            {solved === null
+              ? 'Solves unavailable'
+              : `${solved} puzzle${solved === 1 ? '' : 's'} solved`}
+          </span>
         </div>
-        <span className="pr-results__solved">
-          {solved === null ? 'Solves unavailable' : `${solved} puzzle${solved === 1 ? '' : 's'} solved`}
-        </span>
+        {shareable ? (
+          <button
+            type="button"
+            className="pr-results__share"
+            onClick={handleShare}
+            data-ui="rush-share"
+          >
+            {shareDone ? 'Copied' : 'Share result'}
+          </button>
+        ) : null}
       </header>
 
       {/* Three facts the run earned, all derived from what the client already
           holds — no invented stats. */}
-      <div className="pr-results__tiles">
+      <dl className="pr-results__tiles">
         <div className="pr-results__tile">
-          <span className="pr-results__tile-value">{solved ?? '—'}</span>
-          <span className="pr-results__tile-key">Solved</span>
+          <dd className="pr-results__tile-value">{solved ?? '—'}</dd>
+          <dt className="pr-results__tile-key">Solved</dt>
         </div>
         <div className="pr-results__tile">
-          <span className="pr-results__tile-value">{deepestStage?.label ?? '—'}</span>
-          <span className="pr-results__tile-key">Furthest stage</span>
+          <dd className="pr-results__tile-value">{deepestStage?.label ?? '—'}</dd>
+          <dt className="pr-results__tile-key">Furthest stage</dt>
         </div>
         <div className="pr-results__tile">
-          <span className="pr-results__tile-value">
+          <dd className="pr-results__tile-value">
             {secondsBanked > 0 ? `+${secondsBanked}s` : '—'}
-          </span>
-          <span className="pr-results__tile-key">Time banked</span>
+          </dd>
+          <dt className="pr-results__tile-key">Time banked</dt>
         </div>
-      </div>
+      </dl>
 
       {completeError && (
         <p className="pr-results__error" role="alert" data-ui="rush-complete-error">
@@ -120,8 +186,7 @@ export function RushResultsView({
 
       <div className="pr-results__section-label">Stages</div>
       <ul className="pr-results__stages">
-        {stages.map((stage) => {
-          const { done, total } = stageProgress(stage, completedOrdinals);
+        {stageRows.map(({ stage, done, total }) => {
           const pct = total === 0 ? 0 : Math.round((done / total) * 100);
           return (
             <li key={stage.key} className="pr-results__stage-row" data-stage={stage.key}>

--- a/client/src/puzzleRush/puzzleRush.css
+++ b/client/src/puzzleRush/puzzleRush.css
@@ -263,10 +263,46 @@
 
 .pr-results__head {
   display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  padding-bottom: 20px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.pr-results__head-copy {
+  display: flex;
   flex-direction: column;
   gap: 6px;
-  padding-bottom: 22px;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  min-width: 0;
+}
+
+/* Share lives with the score, so the footer keeps its two ways out. */
+.pr-results__share {
+  flex-shrink: 0;
+  height: 32px;
+  padding: 0 14px;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 3px;
+  background: transparent;
+  color: rgba(255, 255, 255, 0.6);
+  font-family: var(--font-body);
+  font-size: 12px;
+  font-weight: 600;
+  white-space: nowrap;
+  cursor: pointer;
+  transition:
+    color 120ms cubic-bezier(0.2, 0, 0, 1),
+    border-color 120ms cubic-bezier(0.2, 0, 0, 1);
+}
+
+.pr-results__share:hover {
+  color: var(--tier-standard);
+  border-color: var(--tier-standard);
+}
+
+.pr-results__share:active {
+  transform: scale(0.97);
 }
 
 .pr-results__eyebrow {
@@ -304,25 +340,31 @@
 
 /* ── Run facts ── */
 
+/* One strip divided by hairlines rather than three boxed cards — the same
+   stat row the leaderboard rail uses, so the two screens read as one system. */
 .pr-results__tiles {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 8px;
-  margin-top: 22px;
+  margin: 0;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
 }
 
 .pr-results__tile {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 3px;
   min-width: 0;
-  padding: 12px 14px;
-  border-radius: 12px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  background: rgba(255, 255, 255, 0.03);
+  padding: 14px 16px 16px;
+  border-left: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.pr-results__tile:first-child {
+  border-left: 0;
+  padding-left: 0;
 }
 
 .pr-results__tile-value {
+  margin: 0;
   font-family: var(--font-display);
   font-size: 20px;
   font-weight: 700;
@@ -371,10 +413,9 @@
 }
 
 .pr-results__stages {
-  margin-top: 10px;
+  margin: 4px 0 0;
   display: flex;
   flex-direction: column;
-  gap: 8px;
   list-style: none;
   padding: 0;
 }
@@ -382,14 +423,16 @@
 .pr-results__stage-row {
   display: flex;
   flex-direction: column;
-  gap: 8px;
-  padding: 11px 14px;
-  border-radius: 12px;
-  border: 1px solid rgba(255, 255, 255, 0.06);
-  background: rgba(255, 255, 255, 0.03);
+  gap: 7px;
+  padding: 10px 0 12px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
   font-family: var(--font-display);
   font-size: 15px;
   color: rgba(255, 255, 255, 0.95);
+}
+
+.pr-results__stage-row:last-child {
+  border-bottom: 0;
 }
 
 .pr-results__stage-top {
@@ -412,16 +455,16 @@
 .pr-results__stage-total { color: rgba(255, 255, 255, 0.35); }
 
 .pr-results__stage-meter {
-  height: 6px;
-  border-radius: 3px;
+  height: 3px;
+  border-radius: 1px;
   overflow: hidden;
-  background: rgba(255, 255, 255, 0.09);
+  background: rgba(255, 255, 255, 0.1);
 }
 
 .pr-results__stage-fill {
   display: block;
   height: 100%;
-  border-radius: 3px;
+  border-radius: 1px;
   /* Per-stage colour matches the in-run HUD meter. */
   background: var(--tier-standard);
 }

--- a/client/src/puzzleRush/puzzleRushRun.test.tsx
+++ b/client/src/puzzleRush/puzzleRushRun.test.tsx
@@ -404,6 +404,56 @@ describe('results', () => {
     }
   });
 
+  it('offers a share only once the server has scored the run', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+
+    const { unmount } = renderSettled(
+      <RushResultsView
+        completion={completion(870)}
+        completeError={null}
+        clientTally={870}
+        results={[result(1), result(2)]}
+        stages={STAGES}
+        reportFailures={0}
+        onPlayAgain={() => {}}
+        onBack={() => {}}
+      />,
+    );
+
+    const share = document.querySelector('[data-ui="rush-share"]') as HTMLButtonElement | null;
+    expect(share).not.toBeNull();
+    await act(async () => {
+      share!.click();
+    });
+    expect(writeText).toHaveBeenCalledTimes(1);
+    expect(writeText.mock.calls[0][0]).toContain('870 pts');
+    unmount();
+  });
+
+  it('withholds the share when the run was flagged or failed to save', () => {
+    for (const props of [
+      { completion: completion(870, { invalidated: true }), completeError: null },
+      { completion: completion(870), completeError: 'Network error.' },
+      { completion: null, completeError: null },
+    ]) {
+      const { unmount } = renderSettled(
+        <RushResultsView
+          completion={props.completion}
+          completeError={props.completeError}
+          clientTally={870}
+          results={[result(1)]}
+          stages={STAGES}
+          reportFailures={0}
+          onPlayAgain={() => {}}
+          onBack={() => {}}
+        />,
+      );
+      expect(document.querySelector('[data-ui="rush-share"]')).toBeNull();
+      unmount();
+    }
+  });
+
   it('discloses an over-claim rather than silently swapping the number', () => {
     render(
       <RushResultsView

--- a/client/src/puzzleRush/rushShareCard.test.ts
+++ b/client/src/puzzleRush/rushShareCard.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { buildRushShareText } from './rushShareCard';
+import { SITE_DOMAIN } from '../lib/siteUrl';
+
+const STAGES = [
+  { label: 'Warm-Up', done: 2, total: 3 },
+  { label: 'Building', done: 0, total: 5 },
+  { label: 'Master', done: 0, total: 7 },
+];
+
+describe('buildRushShareText', () => {
+  it('leads with the score and solved count, then every stage', () => {
+    const text = buildRushShareText({
+      score: 250,
+      solved: 2,
+      stages: STAGES,
+      secondsBanked: 2,
+      playedAt: '2026-08-27T22:12:00.000Z',
+    });
+    expect(text).toContain('250 pts · 2 solved');
+    expect(text).toContain('Warm-Up 2/3');
+    expect(text).toContain('Building 0/5');
+    expect(text).toContain('Master 0/7');
+    expect(text).toContain('+2s banked');
+    expect(text.endsWith(SITE_DOMAIN)).toBe(true);
+  });
+
+  it('omits the solve count when the server did not report one', () => {
+    const text = buildRushShareText({ score: 250, solved: null, stages: STAGES, secondsBanked: 0 });
+    expect(text).toContain('250 pts');
+    expect(text).not.toContain('solved');
+  });
+
+  it('drops the banked line when nothing was banked', () => {
+    const text = buildRushShareText({ score: 250, solved: 2, stages: STAGES, secondsBanked: 0 });
+    expect(text).not.toContain('banked');
+  });
+
+  it('falls back to a bare title when the run has no usable timestamp', () => {
+    for (const playedAt of [null, undefined, 'not-a-date']) {
+      const text = buildRushShareText({ score: 10, solved: 1, stages: [], secondsBanked: 0, playedAt });
+      expect(text.split('\n')[0]).toBe('Puzzle Rush');
+    }
+  });
+
+  it('omits stages that served no puzzles in this run', () => {
+    const text = buildRushShareText({
+      score: 250,
+      solved: 2,
+      stages: [...STAGES, { label: 'Unused', done: 0, total: 0 }],
+      secondsBanked: 0,
+    });
+    expect(text).not.toContain('Unused');
+  });
+});

--- a/client/src/puzzleRush/rushShareCard.ts
+++ b/client/src/puzzleRush/rushShareCard.ts
@@ -1,0 +1,56 @@
+import { SITE_DOMAIN } from '../lib/siteUrl';
+/**
+ * Share text for a finished Puzzle Rush run.
+ *
+ * Mirrors Daily Fritz's share card (see dailyFritz/shareCard.ts): the headline
+ * facts, then the per-stage breakdown, then the site. Only what the run
+ * actually earned goes in — a line is dropped rather than padded with a dash.
+ */
+
+export interface RushShareStage {
+  label: string;
+  done: number;
+  total: number;
+}
+
+export interface RushShareInput {
+  /** The server's replayed total. The only score worth sharing. */
+  score: number;
+  /** Null when the server did not report a solve count for the run. */
+  solved: number | null;
+  stages: RushShareStage[];
+  secondsBanked: number;
+  /** ISO timestamp the run ended, for the date line. */
+  playedAt?: string | null;
+}
+
+function formatShareDate(iso: string | null | undefined): string | null {
+  if (!iso) return null;
+  const parsed = new Date(iso);
+  if (Number.isNaN(parsed.getTime())) return null;
+  return parsed.toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+}
+
+export function buildRushShareText(input: RushShareInput): string {
+  const date = formatShareDate(input.playedAt);
+  const stageLines = input.stages
+    .filter((stage) => stage.total > 0)
+    .map((stage) => `${stage.label} ${stage.done}/${stage.total}`)
+    .join('\n');
+
+  const lines = [
+    date ? `Puzzle Rush · ${date}` : 'Puzzle Rush',
+    input.solved === null
+      ? `${input.score} pts`
+      : `${input.score} pts · ${input.solved} solved`,
+    stageLines,
+    input.secondsBanked > 0 ? `+${input.secondsBanked}s banked` : '',
+    SITE_DOMAIN,
+  ].filter(Boolean);
+
+  return lines.join('\n');
+}


### PR DESCRIPTION
Adds a **Share Result** control to the Puzzle Rush run-complete screen, plus a small restyle of the results card.

## What's here

- **`rushShareCard.ts`** — mirrors Daily Fritz's share card: headline facts, per-stage breakdown, then the site. Native share where available, clipboard otherwise, with a "Copied" confirmation.
- **Results card restyle** — the header becomes a two-column row so share sits with the score; the three boxed stat tiles become one hairline-divided strip; stage rows lose their individual card borders and the meter thins to 3px.

```
Puzzle Rush · Aug 27, 2026
250 pts · 2 solved
Warm-Up 2/3
Building 0/5
Master 0/7
+2s banked
racehorsedoms.vercel.app
```

## The share is withheld when there's nothing honest to share

A flagged run, a run whose save failed, or one the server never scored. Sharing an unverified number is the one thing this screen is carefully built *not* to do — the whole component exists to headline the server's total rather than the client's.

## Resolved against two changes that landed while this sat

This work predates #57 and #62, both of which touched `RushResultsView`:

- **#57** made `puzzlesSolved` nullable. The share text now drops the solved clause entirely rather than claiming a count it doesn't have — with a test for it. The "Solves unavailable" copy is preserved in the restructured header.
- **#62** wired `AnimatedScore` into the headline score. The count-up is kept, now living inside the restructured `head-copy` wrapper.

The test file conflicted badly enough that I took main's version whole and re-applied the two share tests cleanly on top, rather than hand-splicing interleaved hunks.

## Verification

- `tsc -b` clean
- Full client suite: **190 files, 1313 tests, all passing**
- Lint: 401 warnings / **0 errors**, unchanged from baseline
- 7 tests for the share: text shape, dropped banked line, missing timestamp, unused stages, missing solve count, plus the appears/withheld behaviour on the card

🤖 Generated with [Claude Code](https://claude.com/claude-code)