### PR TITLE
fix(share): sign shared results with playracehorse.com

### DIFF
--- a/client/src/dailyFritz/shareCard.ts
+++ b/client/src/dailyFritz/shareCard.ts
@@ -1,3 +1,4 @@
+import { SITE_DOMAIN } from '../lib/siteUrl';
 import type { DailyFritzSetOverlayViewModel } from './setOverlayViewModel';
 
 export function buildShareText(vm: DailyFritzSetOverlayViewModel): string {
@@ -25,7 +26,7 @@ export function buildShareText(vm: DailyFritzSetOverlayViewModel): string {
     gameLines,
     `${margin} margin${rating ? ' · ' + rating : ''}`,
     streak,
-    'racehorsedoms.vercel.app',
+    SITE_DOMAIN,
   ].filter(Boolean);
 
   return lines.join('\n');

--- a/client/src/dailyPuzzle/ladderShareCard.ts
+++ b/client/src/dailyPuzzle/ladderShareCard.ts
@@ -1,3 +1,4 @@
+import { SITE_DOMAIN } from '../lib/siteUrl';
 import { getDailyPuzzleStepPresentation } from './presentation';
 import type { DailyPuzzleAttempt } from './types';
 import { DAILY_PUZZLE_SLOT_INDICES } from './types';
@@ -59,7 +60,7 @@ export function buildLadderShareText(data: DailyPuzzleLadderShareData): string {
     rankPart,
     data.slotLines.join(' · '),
     meta,
-    'racehorsedoms.vercel.app',
+    SITE_DOMAIN,
   ].filter(Boolean);
 
   return lines.join('\n');

--- a/client/src/ghost/share.ts
+++ b/client/src/ghost/share.ts
@@ -1,3 +1,4 @@
+import { SITE_DOMAIN } from '../lib/siteUrl';
 export async function shareGhostResultCard(params: {
   playerScore: number;
   ghostScore: number;
@@ -27,7 +28,7 @@ export async function shareGhostResultCard(params: {
       <rect width="100%" height="100%" fill="url(#bg)" />
       <rect x="84" y="72" rx="30" ry="30" width="1032" height="486" fill="url(#card)" stroke="rgba(255,255,255,0.16)" />
       <text x="120" y="138" fill="#f7f6ff" font-size="42" font-family="Arial, sans-serif" font-weight="700">Ghost Mode</text>
-      <text x="120" y="180" fill="#cdd4ea" font-size="24" font-family="Arial, sans-serif">racehorsedoms.vercel.app</text>
+      <text x="120" y="180" fill="#cdd4ea" font-size="24" font-family="Arial, sans-serif">${SITE_DOMAIN}</text>
       <text x="120" y="260" fill="#eef2ff" font-size="28" font-family="Arial, sans-serif">YOU</text>
       <text x="300" y="260" fill="#eef2ff" font-size="34" font-family="Arial, sans-serif" font-weight="700">${params.playerScore} pts</text>
       <rect x="520" y="232" width="420" height="24" rx="12" fill="rgba(255,255,255,0.09)" />

--- a/client/src/lib/siteUrl.test.ts
+++ b/client/src/lib/siteUrl.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Every share carries the site's domain into whatever feed it lands in, so a
+ * stale host here is a growth bug, not a cosmetic one: between launch and the
+ * commit that added SITE_DOMAIN, every shared result advertised a preview URL.
+ *
+ * The source scan is the part that would actually have caught it — the ghost
+ * card builds an SVG rather than returning text, so no output assertion covers
+ * it.
+ */
+import { describe, it, expect } from 'vitest';
+import { SITE_DOMAIN } from './siteUrl';
+import { buildShareText } from '../dailyFritz/shareCard';
+import { buildLadderShareText } from '../dailyPuzzle/ladderShareCard';
+import type { DailyFritzSetOverlayViewModel } from '../dailyFritz/setOverlayViewModel';
+
+const DEPLOY_HOST = /[a-z0-9-]+\.vercel\.app/i;
+
+describe('share domain', () => {
+  it('is the brand domain, not a deploy host', () => {
+    expect(SITE_DOMAIN).toBe('playracehorse.com');
+    expect(DEPLOY_HOST.test(SITE_DOMAIN)).toBe(false);
+  });
+
+  it('signs the Daily Fritz share', () => {
+    const text = buildShareText({
+      shareDate: 'August 26, 2026',
+      resultValue: 'Won',
+      shareTier: 'Elite',
+      marginValue: '+80',
+      games: [],
+    } as unknown as DailyFritzSetOverlayViewModel);
+    expect(text).toContain(SITE_DOMAIN);
+    expect(text).not.toMatch(DEPLOY_HOST);
+  });
+
+  it('signs the Daily Puzzle Ladder share', () => {
+    const text = buildLadderShareText({
+      shareDate: 'August 26, 2026',
+      totalScore: 420,
+      rank: 3,
+      slotLines: ['A ✓', 'B ✓'],
+      shareStreak: 7,
+      shareRating: 2230,
+    } as Parameters<typeof buildLadderShareText>[0]);
+    expect(text).toContain(SITE_DOMAIN);
+    expect(text).not.toMatch(DEPLOY_HOST);
+  });
+
+  it('no share module hardcodes a deploy host', () => {
+    // Vite reads these at build time, so the scan needs no node builtins and
+    // stays inside the client tsconfig.
+    const sources = import.meta.glob('../**/*[sS]hare*.ts', {
+      query: '?raw',
+      import: 'default',
+      eager: true,
+    }) as Record<string, string>;
+
+    const scanned = Object.keys(sources).filter((file) => !/\.test\./.test(file));
+    // A scan that matched nothing would pass silently and guard nothing.
+    expect(scanned.length).toBeGreaterThan(0);
+
+    const offenders = scanned.filter((file) => DEPLOY_HOST.test(sources[file]));
+    expect(offenders).toEqual([]);
+  });
+});

--- a/client/src/lib/siteUrl.ts
+++ b/client/src/lib/siteUrl.ts
@@ -1,0 +1,16 @@
+/**
+ * The site's public identity.
+ *
+ * Shared results carry this domain into every feed they land in, so it has to
+ * be the brand domain rather than whichever deploy host happened to be current
+ * when the share text was written. Defined once because it drifted before:
+ * every share built between launch and this commit advertised a stale
+ * preview URL.
+ *
+ * This is display copy. Host allowlists that must keep recognising older
+ * origins — auth redirects, game-server resolution — deliberately keep their
+ * own lists and should not read from here.
+ */
+export const SITE_DOMAIN = 'playracehorse.com';
+
+export const SITE_ORIGIN = `https://${SITE_DOMAIN}`;


### PR DESCRIPTION
Item 1 from the growth assessment follow-up. Small fix, but it's been undermining the one growth mechanism the report rates highest.

## The bug

Every share the app builds signed off with **`racehorsedoms.vercel.app`** — the old deploy host, not the brand domain. Three places:

| Surface | File |
|---|---|
| Daily Fritz result | `dailyFritz/shareCard.ts` |
| Daily Puzzle Ladder | `dailyPuzzle/ladderShareCard.ts` |
| Ghost result card (SVG) | `ghost/share.ts` |

So every result anyone has shared since the domain moved has pointed traffic at a preview URL. Report §6.1 calls the shareable result "worth more than the entire first allocation and plausibly more than the first several" — it was signing the wrong address.

## The fix

The domain now lives in one place, `lib/siteUrl.ts`, because it drifted before.

**Deliberately untouched:** `auth/authRedirect.ts` and `lib/gameServerUrl.ts` also reference `racehorsedoms.vercel.app`, but as *host allowlists* that must keep recognising the older origin. Those are functional, not display copy, and changing them would break auth redirects from the old domain.

## The guard

Two output assertions on the text builders, plus a **source scan** over every share module — which is the part that actually covers the Ghost card, since it builds an SVG rather than returning text, so no output assertion reaches it.

The scan asserts it matched files *before* checking them, so it can't pass by scanning nothing. I verified it genuinely fails by putting the old host back — 2 tests caught it — then reverted.

One note: my first version of the scan used `node:fs`, which vitest happily transpiled but `tsc -b` rejected (node builtins aren't in the client tsconfig). Rewritten with `import.meta.glob`, so it needs no builtins.

## Still outstanding from the assessment

- **Item 2** — `robots.txt`, `sitemap.xml` and `homeOG.png` don't exist; all three 200 as `text/html` via the SPA fallback. Not the prerender interception the report diagnosed.
- **Item 3** — the share text still isn't a visually distinctive grid (report §6.1).
- PR #66 adds `rushShareCard.ts` with the same hardcoded host; it needs this treatment before it merges.

## Verification

- `tsc -b` clean
- Full client suite: **1310 tests passing**
- Lint: 401 warnings / **0 errors**, unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)