### PR TITLE
feat(analytics): instrument the five events the growth assessment requires

### DIFF
--- a/client/.env.example
+++ b/client/.env.example
@@ -1,2 +1,10 @@
 VITE_SENTRY_DSN=https://your-key@sentry.io/your-project-id
 VITE_APP_VERSION=0.1.0
+
+# Product analytics (PostHog cloud). Without a key every analytics call is a
+# no-op, which is what local builds and CI run with. The project API key is a
+# public client-side key by design, but it is set here rather than committed so
+# a fork does not report into this project's data.
+VITE_POSTHOG_KEY=
+# Defaults to US cloud. Set to https://eu.i.posthog.com for an EU project.
+VITE_POSTHOG_HOST=

--- a/client/package.json
+++ b/client/package.json
@@ -53,6 +53,7 @@
     "@types/canvas-confetti": "^1.9.0",
     "canvas-confetti": "^1.9.4",
     "lucide-react": "^1.16.0",
+    "posthog-js": "^1.422.5",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-router-dom": "^7.15.0",

--- a/client/public/_headers
+++ b/client/public/_headers
@@ -3,4 +3,4 @@
   X-Frame-Options: DENY
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: geolocation=(), microphone=(), camera=()
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://*.sentry.io https://*.ingest.sentry.io https://o4511656857108480.ingest.sentry.io wss: https:; worker-src 'none'; frame-src 'none'
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://*.i.posthog.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://*.i.posthog.com https://*.posthog.com https://*.supabase.co wss://*.supabase.co https://*.sentry.io https://*.ingest.sentry.io https://o4511656857108480.ingest.sentry.io wss: https:; worker-src 'none'; frame-src 'none'

--- a/client/src/auth/useAuth.ts
+++ b/client/src/auth/useAuth.ts
@@ -1,3 +1,4 @@
+import { identifyUser, resetAnalytics } from '../lib/analytics';
 import React, { createContext, useContext, useCallback, useEffect, useState } from 'react';
 import type { AuthChangeEvent, User } from '@supabase/supabase-js';
 import { getSupabaseConfigError, isSupabaseConfigured, supabase } from '../lib/supabase';
@@ -837,7 +838,32 @@ const AuthContext = createContext<AuthContextType | null>(null);
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const value = useAuthInternal();
+  useAnalyticsIdentity(value.user?.id ?? null);
   return React.createElement(AuthContext.Provider, { value }, children);
+}
+
+/**
+ * Links the anonymous person to the account, once per identity.
+ *
+ * Keyed on the id string, never the user object: #61 was an effect that
+ * re-ran on every new object reference for the same signed-in user. The
+ * lastIdentified ref makes a repeated run a no-op even if the effect fires
+ * again, which StrictMode guarantees it will in development.
+ */
+export function useAnalyticsIdentity(userId: string | null): void {
+  const lastIdentified = React.useRef<string | null>(null);
+
+  React.useEffect(() => {
+    if (userId === lastIdentified.current) return;
+    if (userId) {
+      identifyUser(userId);
+    } else if (lastIdentified.current !== null) {
+      // Signed out, rather than never signed in: unlink so a shared device
+      // does not fold two people into one person.
+      resetAnalytics();
+    }
+    lastIdentified.current = userId;
+  }, [userId]);
 }
 
 export function useAuth(): AuthContextType {

--- a/client/src/dailyFritz/DailyFritzLeaderboardScreen.tsx
+++ b/client/src/dailyFritz/DailyFritzLeaderboardScreen.tsx
@@ -1,3 +1,4 @@
+import { track } from '../lib/analytics';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { User } from '@supabase/supabase-js';
 import type { AppMode } from '../types';
@@ -360,6 +361,7 @@ export default function DailyFritzLeaderboardScreen({
 
   const handleShareResult = useCallback(() => {
     if (!resultShareText) return;
+    track('share_initiated', { mode: 'daily_fritz', run_date: runDate });
     const markShared = (): void => {
       setShareDone(true);
       window.setTimeout(() => setShareDone(false), 2000);
@@ -378,7 +380,7 @@ export default function DailyFritzLeaderboardScreen({
     void navigator.clipboard.writeText(resultShareText).then(() => {
       markShared();
     });
-  }, [resultShareText]);
+  }, [resultShareText, runDate]);
 
   useEffect(() => {
     setShareDone(false);

--- a/client/src/dailyFritz/api.ts
+++ b/client/src/dailyFritz/api.ts
@@ -1,3 +1,4 @@
+import { track } from '../lib/analytics';
 import { apiGet, apiPost, type ApiResult } from '../api/client';
 import type { BotDealSize, BotHandDeal } from '../bot/botEngine';
 import type { FritzTier } from '../bot/fritzConfig';
@@ -477,6 +478,7 @@ export async function getTodayDailyFritz(options?: {
 export async function startDailyFritz(options?: {
   timeoutMs?: number;
 }): Promise<DailyFritzStartResponse> {
+  track('game_opened', { mode: 'daily_fritz' });
   const core = await import('@racehorse/game-core');
   const response = throwApiResult(
     await timedApiPost<DailyFritzStartResponse>('/api/daily-fritz/start', {
@@ -791,6 +793,7 @@ export async function completeDailyFritz(input: {
   moveLog: unknown;
   setResult?: DailyFritzSetResult | null;
 }): Promise<DailyFritzCompleteResponse> {
+  track('game_completed', { mode: 'daily_fritz' });
   return throwApiResult(
     await timedApiPost<DailyFritzCompleteResponse>('/api/daily-fritz/complete', {
       attempt_id: input.attemptId,

--- a/client/src/dailyPuzzle/DailyPuzzleLadderLeaderboardScreen.tsx
+++ b/client/src/dailyPuzzle/DailyPuzzleLadderLeaderboardScreen.tsx
@@ -1,3 +1,4 @@
+import { track } from '../lib/analytics';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import type { User } from '@supabase/supabase-js';
 import type { AppMode } from '../types';
@@ -427,6 +428,7 @@ export default function DailyPuzzleLadderLeaderboardScreen({
 
   const handleShareResult = useCallback(() => {
     if (!ladderShareText) return;
+    track('share_initiated', { mode: 'daily_puzzle_ladder' });
     invokeLadderShareResult(ladderShareText, () => {
       setShareDone(true);
       window.setTimeout(() => setShareDone(false), 2000);

--- a/client/src/dailyPuzzle/DailyPuzzleLadderScreen.tsx
+++ b/client/src/dailyPuzzle/DailyPuzzleLadderScreen.tsx
@@ -1,3 +1,4 @@
+import { track } from '../lib/analytics';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { User } from '@supabase/supabase-js';
 import type { UserProfile } from '../auth/useAuth';
@@ -368,6 +369,7 @@ export default function DailyPuzzleLadderScreen({
 
   const handleShareLadderResult = useCallback(
     (text: string) => {
+      track('share_initiated', { mode: 'daily_puzzle_ladder' });
       invokeLadderShareResult(text, () => {
         setShareDone(true);
         window.setTimeout(() => setShareDone(false), 2000);

--- a/client/src/dailyPuzzle/api.ts
+++ b/client/src/dailyPuzzle/api.ts
@@ -1,3 +1,4 @@
+import { track } from '../lib/analytics';
 import { hydrateBoardForOpenEnds } from '../game/openEndsGeometry';
 import { apiGet, apiPost } from '../api/client';
 import { logger } from '../utils/logger';
@@ -657,6 +658,7 @@ export async function getTodayDailyPuzzleLadder(): Promise<DailyPuzzleTodayRespo
 }
 
 export async function startDailyPuzzleLadder(runDate?: string): Promise<DailyPuzzleStartResponse> {
+  track('game_opened', { mode: 'daily_puzzle_ladder' });
   return requestServerJson<DailyPuzzleStartResponse>('/api/daily-puzzle/start', {
     method: 'POST',
     body: runDate ? { runDate } : {},
@@ -676,6 +678,7 @@ export async function completeDailyPuzzleLadder(input: {
   attemptId: string;
   puzzleDate: string;
 }): Promise<DailyPuzzleCompleteResponse> {
+  track('game_completed', { mode: 'daily_puzzle_ladder' });
   return requestServerJson<DailyPuzzleCompleteResponse>('/api/daily-puzzle/complete', {
     method: 'POST',
     body: input,

--- a/client/src/lib/analytics.test.ts
+++ b/client/src/lib/analytics.test.ts
@@ -1,0 +1,68 @@
+/**
+ * The events have to fire once each, at a real trigger.
+ *
+ * This repo shipped #61 for an effect that re-fired on an object reference
+ * rather than an identity, and StrictMode double-invokes effects in
+ * development. Every assertion below is about count, not just presence —
+ * a test that only checked "did it fire" would pass while double-counting
+ * every session and halving every retention number.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  track,
+  identifyUser,
+  resetAnalytics,
+  __setAnalyticsTransport,
+  type AnalyticsTransport,
+} from './analytics';
+
+function fakeTransport() {
+  const capture = vi.fn();
+  const identify = vi.fn();
+  const reset = vi.fn();
+  const transport: AnalyticsTransport = { capture, identify, reset };
+  __setAnalyticsTransport(transport);
+  return { capture, identify, reset };
+}
+
+/** track() is fire-and-forget, so let its promise settle before asserting. */
+const settle = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe('analytics transport', () => {
+  beforeEach(() => __setAnalyticsTransport(null));
+
+  it('records an event once per call', async () => {
+    const { capture } = fakeTransport();
+    track('session_start');
+    await settle();
+    expect(capture).toHaveBeenCalledTimes(1);
+    expect(capture).toHaveBeenCalledWith('session_start', undefined);
+  });
+
+  it('carries the mode rather than fragmenting the event name', async () => {
+    const { capture } = fakeTransport();
+    track('game_opened', { mode: 'daily_fritz' });
+    track('game_opened', { mode: 'puzzle_rush' });
+    await settle();
+    expect(capture.mock.calls.map(([event]) => event)).toEqual(['game_opened', 'game_opened']);
+    expect(capture.mock.calls.map(([, props]) => props?.mode)).toEqual([
+      'daily_fritz',
+      'puzzle_rush',
+    ]);
+  });
+
+  it('is a no-op with no transport, rather than throwing into product code', async () => {
+    __setAnalyticsTransport(null);
+    expect(() => track('session_start')).not.toThrow();
+    await settle();
+  });
+
+  it('identifies and resets through the transport', async () => {
+    const { identify, reset } = fakeTransport();
+    identifyUser('user-1');
+    resetAnalytics();
+    await settle();
+    expect(identify).toHaveBeenCalledWith('user-1', undefined);
+    expect(reset).toHaveBeenCalledTimes(1);
+  });
+});

--- a/client/src/lib/analytics.ts
+++ b/client/src/lib/analytics.ts
@@ -1,0 +1,101 @@
+/**
+ * Product analytics.
+ *
+ * Deliberately instrumented at the API and bootstrap layer rather than in
+ * React effects. This repo has shipped a fix for an effect that re-fired on an
+ * object reference rather than an identity (#61), and StrictMode double-invokes
+ * effects in development, so an effect-based `session_start` would over-count
+ * by construction. Every call site here is either outside React entirely (the
+ * bootstrap, the mode APIs) or a user-gesture callback.
+ *
+ * The client is loaded lazily so PostHog stays out of the entry bundle, and
+ * every call is a no-op when no key is configured — which is the case in tests
+ * and in any local build without the env var.
+ */
+
+export type AnalyticsMode =
+  | 'daily_fritz'
+  | 'daily_puzzle_ladder'
+  | 'puzzle_rush'
+  | 'multiplayer';
+
+export type AnalyticsEvent =
+  /** Once per page load. Retention is derived from this plus the person id. */
+  | 'session_start'
+  /** A run of any mode began. Distinguished by `mode`, not by event name. */
+  | 'game_opened'
+  /** A run of any mode finished. */
+  | 'game_completed'
+  /** The share action was tapped. Report §6.1's headline metric. */
+  | 'share_initiated';
+
+export type AnalyticsProps = Record<string, string | number | boolean | null | undefined>;
+
+/** What the module needs from PostHog. Narrow, so tests can stand in for it. */
+export interface AnalyticsTransport {
+  capture(event: AnalyticsEvent, props?: AnalyticsProps): void;
+  identify(distinctId: string, props?: AnalyticsProps): void;
+  reset(): void;
+}
+
+const KEY = import.meta.env.VITE_POSTHOG_KEY as string | undefined;
+const HOST = (import.meta.env.VITE_POSTHOG_HOST as string | undefined) ?? 'https://us.i.posthog.com';
+
+let transportPromise: Promise<AnalyticsTransport | null> | null = null;
+/** Set by tests. Also the reason init is idempotent under StrictMode and HMR. */
+let injected: AnalyticsTransport | null = null;
+
+async function loadTransport(): Promise<AnalyticsTransport | null> {
+  if (injected) return injected;
+  if (!KEY) return null;
+  try {
+    const { default: posthog } = await import('posthog-js');
+    posthog.init(KEY, {
+      api_host: HOST,
+      // Retention has to include people who never sign up, so anonymous
+      // visitors need person profiles too. The SDK default of
+      // 'identified_only' would drop them and understate day-1 and day-7.
+      person_profiles: 'always',
+      capture_pageview: false,
+      capture_pageleave: true,
+      autocapture: false,
+    });
+    return {
+      capture: (event, props) => posthog.capture(event, props),
+      identify: (distinctId, props) => posthog.identify(distinctId, props),
+      reset: () => posthog.reset(),
+    };
+  } catch {
+    // Analytics must never take the app down with it.
+    return null;
+  }
+}
+
+function transport(): Promise<AnalyticsTransport | null> {
+  transportPromise ??= loadTransport();
+  return transportPromise;
+}
+
+/** Records an event. Fire-and-forget: never awaited by product code. */
+export function track(event: AnalyticsEvent, props?: AnalyticsProps): void {
+  void transport().then((client) => client?.capture(event, props));
+}
+
+/**
+ * Links the anonymous person to a real account, so a visitor who plays for
+ * days before signing up keeps one retention history rather than two.
+ */
+export function identifyUser(userId: string, props?: AnalyticsProps): void {
+  void transport().then((client) => client?.identify(userId, props));
+}
+
+/** Unlinks on sign-out, so a shared device does not merge two people. */
+export function resetAnalytics(): void {
+  void transport().then((client) => client?.reset());
+}
+
+/** Test seam. Not for product code. */
+export function __setAnalyticsTransport(next: AnalyticsTransport | null): void {
+  injected = next;
+  transportPromise = next ? Promise.resolve(next) : null;
+}

--- a/client/src/lib/analyticsIdentity.test.tsx
+++ b/client/src/lib/analyticsIdentity.test.tsx
@@ -1,0 +1,81 @@
+// @vitest-environment jsdom
+/**
+ * The identify effect, under the exact conditions that broke #61.
+ *
+ * A new object reference for the same signed-in user must not re-identify, and
+ * StrictMode's double invocation must not double-identify. Both are asserted
+ * on call count.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { StrictMode } from 'react';
+import { render } from '@testing-library/react';
+import { __setAnalyticsTransport, type AnalyticsTransport } from './analytics';
+// The real hook, imported rather than re-declared: a local copy would pass
+// while the shipped effect regressed.
+import { useAnalyticsIdentity } from '../auth/useAuth';
+
+const settle = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+function Harness({ user }: { user: { id: string } | null }) {
+  useAnalyticsIdentity(user?.id ?? null);
+  return null;
+}
+
+describe('identify effect', () => {
+  let identify: ReturnType<typeof vi.fn>;
+  let reset: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    identify = vi.fn();
+    reset = vi.fn();
+    __setAnalyticsTransport({ capture: vi.fn(), identify, reset } as AnalyticsTransport);
+  });
+
+  it('identifies once for a signed-in user', async () => {
+    render(<Harness user={{ id: 'user-1' }} />);
+    await settle();
+    expect(identify).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not re-identify when the user object is a new reference', async () => {
+    const { rerender } = render(<Harness user={{ id: 'user-1' }} />);
+    await settle();
+    // A fresh object for the same person — the #61 failure mode exactly.
+    rerender(<Harness user={{ id: 'user-1' }} />);
+    rerender(<Harness user={{ id: 'user-1' }} />);
+    await settle();
+    expect(identify).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not double-identify under StrictMode', async () => {
+    render(
+      <StrictMode>
+        <Harness user={{ id: 'user-1' }} />
+      </StrictMode>,
+    );
+    await settle();
+    expect(identify).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-identifies only when the person actually changes', async () => {
+    const { rerender } = render(<Harness user={{ id: 'user-1' }} />);
+    await settle();
+    rerender(<Harness user={{ id: 'user-2' }} />);
+    await settle();
+    expect(identify).toHaveBeenCalledTimes(2);
+    expect(identify.mock.calls.map(([id]) => id)).toEqual(['user-1', 'user-2']);
+  });
+
+  it('resets on sign-out, but not for a visitor who never signed in', async () => {
+    const { rerender } = render(<Harness user={{ id: 'user-1' }} />);
+    await settle();
+    rerender(<Harness user={null} />);
+    await settle();
+    expect(reset).toHaveBeenCalledTimes(1);
+
+    reset.mockClear();
+    render(<Harness user={null} />);
+    await settle();
+    expect(reset).not.toHaveBeenCalled();
+  });
+});

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -20,6 +20,7 @@ if (import.meta.env.DEV && !import.meta.env.VITE_SENTRY_DSN) {
 }
 
 import { StrictMode } from 'react';
+import { track } from './lib/analytics';
 import { createRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import { consumeSupabaseRecoveryHash } from './auth/recoveryHash';
@@ -75,6 +76,10 @@ async function bootstrap() {
   // old HashRouter route. Legacy "#/…" bookmarks are then promoted to real paths.
   await consumeSupabaseRecoveryHash();
   migrateLegacyHashRoute();
+
+  // Outside React on purpose: one page load, one session_start. An effect here
+  // would fire twice under StrictMode in development.
+  track('session_start');
 
   createRoot(document.getElementById('root')!).render(
     <StrictMode>

--- a/client/src/multiplayer/multiplayerGameSnapshot.ts
+++ b/client/src/multiplayer/multiplayerGameSnapshot.ts
@@ -1,3 +1,4 @@
+import { track } from '../lib/analytics';
 import type { Dispatch, RefObject, SetStateAction } from 'react';
 import type { BoardHandle } from '../components';
 import type { GameState, Move, Tile } from '../types';
@@ -224,12 +225,17 @@ export function publishGameSnapshot(next: MultiplayerGameSnapshot): void {
   const gameOver = next.liveGameOver;
   if (gameOver !== lastPublishedGameOver) {
     lastPublishedGameOver = gameOver;
+    // Only the entry into game-over is a completion; the reset back out is not.
+    if (gameOver) track('game_completed', { mode: 'multiplayer' });
     notifyGameOverListeners();
   }
 
   const hasState = next.hasState;
   if (hasState !== lastPublishedHasState) {
     lastPublishedHasState = hasState;
+    // A multiplayer game becomes real when live state first arrives; the
+    // teardown back to no-state is not a second opening.
+    if (hasState) track('game_opened', { mode: 'multiplayer' });
     notifyHasStateListeners();
   }
 }

--- a/client/src/puzzleRush/RushResultsView.tsx
+++ b/client/src/puzzleRush/RushResultsView.tsx
@@ -1,3 +1,4 @@
+import { track } from '../lib/analytics';
 import { useCallback, useMemo, useState } from 'react';
 import { Button } from '../components/primitives';
 import { AnimatedScore } from '../components/AnimatedScore';
@@ -90,6 +91,7 @@ export function RushResultsView({
   const [shareDone, setShareDone] = useState(false);
   const handleShare = useCallback(() => {
     if (!shareText) return;
+    track('share_initiated', { mode: 'puzzle_rush' });
     const markShared = (): void => {
       setShareDone(true);
       window.setTimeout(() => setShareDone(false), 2000);

--- a/client/src/puzzleRush/api.ts
+++ b/client/src/puzzleRush/api.ts
@@ -1,3 +1,4 @@
+import { track } from '../lib/analytics';
 import { apiGet, apiPost } from '../api/client';
 import { hydrateBoardForOpenEnds } from '../game/openEndsGeometry';
 import type {
@@ -38,6 +39,7 @@ function hydratePuzzle(puzzle: PuzzleRushPuzzle): PuzzleRushPuzzle {
  * round trip between puzzles would be felt on the clock.
  */
 export async function startPuzzleRush(): Promise<PuzzleRushStartResponse> {
+  track('game_opened', { mode: 'puzzle_rush' });
   const response = await postJson<PuzzleRushStartResponse>('/api/puzzle-rush/start', {});
   return { ...response, puzzles: (response.puzzles ?? []).map(hydratePuzzle) };
 }
@@ -57,6 +59,7 @@ export async function completePuzzleRush(input: {
   runId: string;
   clientReportedScore: number;
 }): Promise<PuzzleRushCompleteResponse> {
+  track('game_completed', { mode: 'puzzle_rush' });
   return postJson<PuzzleRushCompleteResponse>('/api/puzzle-rush/complete', input);
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@types/canvas-confetti": "^1.9.0",
         "canvas-confetti": "^1.9.4",
         "lucide-react": "^1.16.0",
+        "posthog-js": "^1.422.5",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "react-router-dom": "^7.15.0",
@@ -1838,6 +1839,31 @@
         "node": ">=18"
       }
     },
+    "node_modules/@posthog/browser-common": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@posthog/browser-common/-/browser-common-0.7.0.tgz",
+      "integrity": "sha512-Kr6j9sH7NisT3fC3w7jZlonYeCFjPXZrDwHl3usFpjNEdgbHUrxPAmekEkTt+zRAa2huldFPIAmibZ3KC4hXoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@posthog/core": "^1.49.2",
+        "@posthog/types": "^1.407.1"
+      }
+    },
+    "node_modules/@posthog/core": {
+      "version": "1.49.2",
+      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.49.2.tgz",
+      "integrity": "sha512-AXHDo/4nisUg7OPG1TQNgREK7n+chBQXLQyttp7bDTDsDg2k9lV06TmnpvuNbwJs53q9mP9hjezKEZu4fYadfg==",
+      "license": "MIT",
+      "dependencies": {
+        "@posthog/types": "^1.407.1"
+      }
+    },
+    "node_modules/@posthog/types": {
+      "version": "1.407.1",
+      "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.407.1.tgz",
+      "integrity": "sha512-WhbkXPC2rgylXqmxHqv70ffI3k+KxyR6s7DBIfr5NvIqHkxp6v0pk31D/jbz0DNVbzwkLjyll2pxr4FNbJiYzg==",
+      "license": "MIT"
+    },
     "node_modules/@racehorse/game-core": {
       "resolved": "packages/game-core",
       "link": true
@@ -3115,6 +3141,13 @@
       "integrity": "sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/use-sync-external-store": {
       "version": "0.0.6",
@@ -4736,6 +4769,20 @@
         "node": ">=6.6.0"
       }
     },
+    "node_modules/core-js": {
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.50.0.tgz",
+      "integrity": "sha512-BRWgOLKkFeCgRudR6zrs8p9XJZcE14grzKMMssoYrk6krtuEZ7MTKPIY5RzOnqsEKIR9kst7wNzphttraT+Yqw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/cors": {
       "version": "2.8.6",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
@@ -5229,6 +5276,15 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.14",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.14.tgz",
+      "integrity": "sha512-dVoH9z+MY+C9IilgGCk3YfFqjLi3fChm2OiKJMzh6axrJ5qwxqWaZamgmHrpv22CN/KdbZJuGEGgfQoL00LTdg==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -6284,6 +6340,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.9.tgz",
+      "integrity": "sha512-zdxgIEddhfsyCaWpJ2SdXEP8ZMrKJ6+5jl4OupODcywU0IhRk6gdXuVGcPICyfx2H97hVK7xmJtRLPjkxAX8Vw==",
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
@@ -9069,6 +9131,60 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/posthog-js": {
+      "version": "1.422.5",
+      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.422.5.tgz",
+      "integrity": "sha512-p1CLXsGoHwNkdElxXtd1KzNP/df8sIrp8CRII+lAPRhaHdpi1HfNxrybqLSzWvJLw2w5Nou5vpXfGABUI5BVwA==",
+      "license": "(Apache-2.0 AND MIT)",
+      "dependencies": {
+        "@posthog/browser-common": "^0.7.0",
+        "@posthog/core": "^1.49.2",
+        "@posthog/types": "^1.407.1",
+        "core-js": "^3.49.0",
+        "dompurify": "^3.4.13",
+        "fflate": "^0.4.8",
+        "preact": "^10.29.3",
+        "query-selector-shadow-dom": "^1.0.1",
+        "web-vitals": "^5.3.0",
+        "web-vitals-soft-navs": "npm:web-vitals@6.0.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8.0",
+        "react": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/posthog-js/node_modules/web-vitals": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.3.0.tgz",
+      "integrity": "sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/preact": {
+      "version": "10.29.8",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.8.tgz",
+      "integrity": "sha512-ej2aVZ+vZ8WO7tvlQWRM9N63A0KzF9q4mWJfDUHgYaIofWY9hu74QdnQrjoPMmZi2/nZ5gN0bJCQF49xQqx09Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      },
+      "peerDependencies": {
+        "preact-render-to-string": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "preact-render-to-string": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -9240,6 +9356,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/query-selector-shadow-dom": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/query-selector-shadow-dom/-/query-selector-shadow-dom-1.0.1.tgz",
+      "integrity": "sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==",
+      "license": "MIT"
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -11917,6 +12039,13 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-6.1.0.tgz",
       "integrity": "sha512-ZNoJ/MbU6aaR2WjKrFVUvy5WQx+G96YvXQFSsmKTz3A/0VlAFywjUcxl00hc/S6wef2stfgQ4yWYIJCWCNudkA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/web-vitals-soft-navs": {
+      "name": "web-vitals",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-6.0.0.tgz",
+      "integrity": "sha512-Guaibvy/+uNtL6Bsu4jmMJGzuSl91oeRH5iO9pPRbYftnFUr3yqT1TUNX/OE4o9HexuEMU3Kb/Wg7iKhlffZUA==",
       "license": "Apache-2.0"
     },
     "node_modules/webidl-conversions": {

--- a/vercel.json
+++ b/vercel.json
@@ -11,7 +11,7 @@
         { "key": "Permissions-Policy", "value": "camera=(), microphone=(), geolocation=()" },
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data: blob: https:; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://racehorse.onrender.com wss://racehorse.onrender.com https://sentry.io https://*.sentry.io https://o*.ingest.sentry.io; worker-src 'self' blob:; frame-ancestors 'none'; base-uri 'self'; form-action 'self';"
+          "value": "default-src 'self'; script-src 'self' https://*.i.posthog.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data: blob: https:; connect-src 'self' https://*.i.posthog.com https://*.posthog.com https://*.supabase.co wss://*.supabase.co https://racehorse.onrender.com wss://racehorse.onrender.com https://sentry.io https://*.sentry.io https://o*.ingest.sentry.io; worker-src 'self' blob:; frame-ancestors 'none'; base-uri 'self'; form-action 'self';"
         }
       ]
     },


### PR DESCRIPTION
Report §2.2 Issue 1 — the assessment's only **CRITICAL**, and its one true blocker on spending: *"Without event tracking, \$500 produces a click count and no decision."*

## Phase 1 findings

**No analytics existed.** The report allowed that a client-side injection could have been missed by a static HTML audit, so I checked the served runtime rather than the source: fetched the production entry bundle and grepped it — zero occurrences of posthog, plausible, gtag, mixpanel, amplitude or segment (the two apparent hits were a URL-decoding error string and a false positive). One `<script>` tag on the page, the app bundle. Confirmed absent.

## What's wired, and where

| Event | Location | React? |
|---|---|---|
| `session_start` | `main.tsx` `bootstrap()` | **No** — outside React |
| `game_opened { mode }` | `startDailyFritz`, `startPuzzleRush`, `startDailyPuzzleLadder`, multiplayer snapshot | **No** — api modules |
| `game_completed { mode }` | `completeDailyFritz`, `completePuzzleRush`, `completeDailyPuzzleLadder`, multiplayer snapshot | **No** |
| `share_initiated { mode, run_date }` | the four share tap handlers | callback only |
| `identify` / `reset` | auth identity change | one effect, guarded |

Modes ride as a property (`daily_fritz`, `daily_puzzle_ladder`, `puzzle_rush`, `multiplayer`), not as separate event names, as specified.

## Retention needs no fifth event — but it did need a config decision

PostHog derives day-1/day-7 from `session_start` plus a stable person, so no distinct event. Two things make that actually work:

- **`identify()` on login** links the anonymous person to the account, so someone who plays for days before signing up keeps one retention history instead of two.
- **`person_profiles: 'always'`**. The SDK default is `identified_only`, which creates no profile for signed-out visitors — retention would have silently excluded everyone pre-signup and understated both numbers. This is the kind of default that looks like it's working while reporting the wrong thing.

## The render-loop failure mode, addressed structurally

Given #61 and StrictMode's double-invocation, I instrumented **outside React wherever possible** — `session_start` in `bootstrap()`, mode events in the api modules. Those cannot double-fire from a re-render because they aren't in the render path at all.

The single effect is the identify hook, keyed on the **user id string** (never the user object — that was #61 exactly) and additionally ref-guarded. Five tests assert **call counts**, not just presence:

- identifies once for a signed-in user
- **does not re-identify when the user object is a new reference** ← #61
- **does not double-identify under StrictMode**
- re-identifies only when the person actually changes
- resets on sign-out, but not for a visitor who never signed in

The test imports the **real hook** from `useAuth.ts` rather than re-declaring it — my first draft copied the hook into the test, which would have passed while the shipped effect regressed. I verified it can fail by removing the ref guard: `expected 1 times, but got 2 times`.

Multiplayer events hang off the snapshot publisher, which already fires only on transition, narrowed further to the *entry* into each state — the reset back out is not a second open or a second completion.

## Consent — needs your decision, not mine

There is no consent UI anywhere in the repo today. Assessment §5.2 puts the primary audience as **US 30–65** (no opt-in requirement; CCPA is opt-out) but the secondary as **US / UK / Canada** — and UK GDPR + PECR require consent before setting analytics cookies.

Day-1/day-7 retention needs a persistent identifier, so cookieless mode would defeat the purpose. **I have not built a banner** — it wasn't in scope and you're pre-launch with a US-primary hypothesis. But this is not compliant for a UK push as written, and that's a decision to make deliberately rather than discover later.

## Notes

- **CSP updated** in `vercel.json` *and* `public/_headers`. Without it every PostHog request would have been blocked in production while working perfectly in local dev — a silent no-data failure.
- **posthog-js is lazily imported**: entry bundle 460.50 → **460.61 kB** (+0.11 kB).
- Key comes from `VITE_POSTHOG_KEY`; every call is a no-op without it, which is how tests and CI run. The key is **not committed** — `.env.example` documents it blank.
- `VITE_POSTHOG_HOST` defaults to US cloud; set it for an EU project.

## Verification

- `tsc -b` clean · **1326 tests passing** · lint 401 warnings / **0 errors**
- Not verified against live PostHog data, per your instruction — that needs the real key in a deploy.

One caught in review: adding `run_date` to the Fritz share callback introduced a **missing `useCallback` dependency**, pushing lint to 402 and failing the budget. Fixed. Worth noting it was precisely the stale-closure class this PR is otherwise defending against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)