### PR TITLE
fix(seo): give crawlers something to follow

### DIFF
--- a/client/scripts/prerender.mjs
+++ b/client/scripts/prerender.mjs
@@ -1,4 +1,5 @@
 import { readFile, writeFile } from 'node:fs/promises';
+import { NOINDEX, crawlTargets, isIndexable, navLabel } from './prerenderNav.mjs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -183,7 +184,20 @@ function replaceMeta(html, selector, value) {
 function renderRoute(template, route) {
   const url = `${siteOrigin}${route.path}`;
   const image = `${siteOrigin}${route.image}`;
-  const content = `<main class="prerendered-page" aria-hidden="true"><p>Racehorse Dominoes</p><h1>${escapeHtml(route.heading)}</h1><p>${escapeHtml(route.body)}</p><p><a href="/">Explore Racehorse Dominoes</a></p></main>`;
+  // Every indexable route links to every other, so a crawler reaching any page
+  // can walk the whole site. Not aria-hidden: React replaces this on hydrate,
+  // but until it does this nav is the only way through the site without JS.
+  const links = crawlTargets(routes, route.path)
+    .map((other) => `<li><a href="${other.path}">${escapeHtml(navLabel(other))}</a></li>`)
+    .join('');
+
+  const content =
+    `<main class="prerendered-page">` +
+    `<p>Racehorse Dominoes</p>` +
+    `<h1>${escapeHtml(route.heading)}</h1>` +
+    `<p>${escapeHtml(route.body)}</p>` +
+    `<nav aria-label="Racehorse Dominoes pages"><ul>${links}</ul></nav>` +
+    `</main>`;
 
   let html = template
     .replace(/<title>[^<]*<\/title>/, `<title>${escapeHtml(route.title)}</title>`)
@@ -219,10 +233,7 @@ for (const route of routes) {
  * all.
  */
 
-/** Routes whose content is per-user or per-match, so not worth indexing. */
-const NOINDEX = new Set(['/players', '/tournament/detail', '/tournament/result', '/multiplayer/private']);
-
-const indexable = routes.filter((route) => !NOINDEX.has(route.path));
+const indexable = routes.filter(isIndexable);
 
 const sitemap = [
   '<?xml version="1.0" encoding="UTF-8"?>',

--- a/client/scripts/prerenderNav.mjs
+++ b/client/scripts/prerenderNav.mjs
@@ -1,0 +1,39 @@
+/**
+ * The crawl navigation injected into every prerendered page.
+ *
+ * Search engines discover pages by following links. Before this existed the
+ * prerendered shell carried exactly one anchor — pointing at itself — so the
+ * sitemap listed fourteen URLs that nothing linked to and the routing fix
+ * produced no crawlable surface at all (growth assessment, Issue 3).
+ *
+ * Extracted from prerender.mjs so it can be tested without running the build.
+ */
+
+/** Routes whose content is per-user or per-match, so not worth indexing. */
+export const NOINDEX = new Set([
+  '/players',
+  '/tournament/detail',
+  '/tournament/result',
+  '/multiplayer/private',
+]);
+
+export function isIndexable(route) {
+  return !NOINDEX.has(route.path);
+}
+
+/**
+ * Anchor text. Titles read "Page | Racehorse Dominoes", so the first segment
+ * is the descriptive half; the titles without a separator are already
+ * page-specific and pass through whole.
+ */
+export function navLabel(route) {
+  return route.title.split('|')[0].trim();
+}
+
+/**
+ * Every indexable route except the current one, so a crawler landing on any
+ * page can reach the rest and no page wastes a link on itself.
+ */
+export function crawlTargets(routes, currentPath) {
+  return routes.filter((route) => isIndexable(route) && route.path !== currentPath);
+}

--- a/client/scripts/prerenderNav.test.ts
+++ b/client/scripts/prerenderNav.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Guards the crawl navigation.
+ *
+ * Issue 3 in the growth assessment was a prerendered shell whose only anchor
+ * pointed at itself — a placeholder that stayed. These assertions are about
+ * counts and targets, so the same thing cannot quietly happen again.
+ */
+import { describe, it, expect } from 'vitest';
+// @ts-expect-error — build script module, not part of the app's TS program.
+import { NOINDEX, crawlTargets, isIndexable, navLabel } from './prerenderNav.mjs';
+
+type Route = { path: string; title: string };
+
+const routes: Route[] = [
+  { path: '/', title: 'Racehorse Dominoes | Daily Strategy Game' },
+  { path: '/daily-fritz', title: 'Daily Fritz | Racehorse Dominoes' },
+  { path: '/learn/how-to-play', title: 'How to Play Racehorse Dominoes' },
+  { path: '/players', title: 'Player Profile | Racehorse Dominoes' },
+  { path: '/multiplayer/private', title: 'Private Match | Racehorse Dominoes' },
+];
+
+describe('crawl navigation', () => {
+  it('links every indexable route except the one being rendered', () => {
+    const targets = crawlTargets(routes, '/daily-fritz') as Route[];
+    expect(targets.map((route) => route.path)).toEqual(['/', '/learn/how-to-play']);
+  });
+
+  it('never links a per-user or per-match page', () => {
+    for (const path of ['/', '/daily-fritz']) {
+      const targets = crawlTargets(routes, path) as Route[];
+      expect(targets.filter((route) => NOINDEX.has(route.path))).toEqual([]);
+    }
+  });
+
+  it('gives every page more than the single self-link it used to have', () => {
+    // The regression this exists to catch: one anchor, pointing home.
+    const targets = crawlTargets(routes, '/') as Route[];
+    expect(targets.length).toBeGreaterThan(1);
+    expect(targets.some((route) => route.path === '/')).toBe(false);
+  });
+
+  it('uses the descriptive half of the title as anchor text', () => {
+    expect(navLabel(routes[1])).toBe('Daily Fritz');
+    // No separator: the whole title is already page-specific.
+    expect(navLabel(routes[2])).toBe('How to Play Racehorse Dominoes');
+  });
+
+  it('agrees with the sitemap on what is indexable', () => {
+    expect(routes.filter(isIndexable as (r: Route) => boolean).map((r) => r.path)).toEqual([
+      '/', '/daily-fritz', '/learn/how-to-play',
+    ]);
+  });
+});


### PR DESCRIPTION
Growth assessment **Issue 3** — and the last Phase 0 prerequisite.

## The problem

The prerendered shell carried exactly one anchor, and it pointed at the site root:

```html
<p><a href="/">Explore Racehorse Dominoes</a></p>
```

Search engines discover pages by following links. #68 fixed `robots.txt` and shipped a sitemap listing 14 URLs — but nothing linked to any of them. We invited the crawlers in and gave them nowhere to go.

## The fix

Every prerendered page now links to every other indexable route.

| | Before | After |
|---|---|---|
| Links per page | 1 (self) | **13** |
| Self-links | 1 | 0 |
| Unindexable routes linked | — | 0 |

Anchor text is the descriptive half of each page title — "Daily Fritz", "How to Play Racehorse Dominoes" — rather than a generic "click here". The two titles without a `|` separator are already page-specific and pass through whole.

Exclusions match `sitemap.xml` and `robots.txt` **exactly**, from the same `NOINDEX` set, so the three can't disagree about what's indexable.

## Two judgement calls

**The nav is no longer `aria-hidden="true"`.** React replaces this shell on hydrate, but until it does, this nav is the only way through the site without JavaScript. Hiding it from assistive technology while showing it to everyone else was the wrong side of that trade — and it's real content now, not a placeholder.

**The logic is extracted to `prerenderNav.mjs`** so it's testable without running a build. `prerender.mjs` has top-level `await` and writes files on import, so it can't be imported from a test directly.

## The guard

The regression this exists to catch is specific and already happened once: *a placeholder link that nobody noticed had stayed*. So the tests assert counts and targets, not presence.

I verified they fail by reinstating the old behaviour:

```
AssertionError: expected [ '/' ] to deeply equal [ '/', '/learn/how-to-play' ]
AssertionError: expected 1 to be greater than 1
```

## Verification

- `tsc -b` clean · **1339 tests passing** · lint 401 warnings / **0 errors**
- Built and inspected `dist/`: 13 links on the homepage, 13 on `/daily-fritz`, zero self-links, zero links to `/players`, `/tournament/detail`, `/tournament/result` or `/multiplayer/private`

After deploy, the report's §2.3 step 3 applies: submit the sitemap in Search Console and set the indexation baseline. It expects movement in two to three weeks.

**This completes Phase 0.** Remaining from the assessment: the how-to-play page still serves 80 words against a Phase 1 item asking for long-form, and the "Fritz" naming risk (§7, HIGH) is still unaddressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)