### PR TITLE
feat(seo): give /learn/how-to-play a real article

### DIFF
--- a/client/scripts/howToPlayArticle.test.ts
+++ b/client/scripts/howToPlayArticle.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Guards the How to Play article.
+ *
+ * The page this replaced served ~80 words, which is why it ranked behind
+ * hobbyist pages from 2001 (growth assessment, Phase 1 item 1). The
+ * assertions below are about substance and accuracy, so a future edit cannot
+ * quietly hollow it back out or contradict the engine.
+ */
+import { describe, it, expect } from 'vitest';
+import { HOW_TO_PLAY_ARTICLE as article } from '../src/learn/howToPlay/howToPlayArticleContent.mjs';
+
+const words = (text: string) => text.trim().split(/\s+/).length;
+
+const allText = [
+  article.standfirst,
+  ...article.sections.flatMap((section) => [section.heading, ...section.paragraphs]),
+].join(' ');
+
+describe('how to play article', () => {
+  it('is genuinely long-form', () => {
+    // The report asks for 800+; falling under that is the regression.
+    expect(words(allText)).toBeGreaterThan(800);
+  });
+
+  it('is broken into scannable sections with real headings', () => {
+    expect(article.sections.length).toBeGreaterThanOrEqual(6);
+    for (const section of article.sections) {
+      expect(section.heading.length).toBeGreaterThan(0);
+      expect(section.paragraphs.length).toBeGreaterThan(0);
+      // A heading with one thin paragraph under it is not a section.
+      expect(words(section.paragraphs.join(' '))).toBeGreaterThan(30);
+    }
+  });
+
+  it('gives every section a unique anchor for the contents list', () => {
+    const ids = article.sections.map((section) => section.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    for (const id of ids) expect(id).toMatch(/^[a-z0-9-]+$/);
+  });
+
+  it('states the rules this variant actually uses', () => {
+    // Each of these is a number or rule taken from the engine, not from
+    // generic dominoes. If the engine changes, this page has to change too.
+    expect(allText).toContain('double-six');
+    expect(allText).toContain('seven tiles');
+    expect(allText).toMatch(/60 points|race to 60/);
+    expect(allText).toMatch(/multiple of five/);
+    expect(allText).toMatch(/divided by five/);
+    expect(allText).toMatch(/under 30/);          // the skunk threshold
+    expect(allText).toMatch(/best-of-three/);     // the Daily Fritz set
+    expect(allText).toMatch(/cannot be a double/); // the go-out restriction
+  });
+
+  it('reads as prose rather than keyword filler', () => {
+    // Naming the product on every other line is the failure mode the brief
+    // warned about; a handful of mentions across 1200 words is normal.
+    const mentions = (allText.match(/Racehorse/g) ?? []).length;
+    expect(mentions).toBeLessThan(words(allText) / 100);
+  });
+});

--- a/client/scripts/prerender.mjs
+++ b/client/scripts/prerender.mjs
@@ -1,5 +1,6 @@
 import { readFile, writeFile } from 'node:fs/promises';
 import { NOINDEX, crawlTargets, isIndexable, navLabel } from './prerenderNav.mjs';
+import { HOW_TO_PLAY_ARTICLE } from '../src/learn/howToPlay/howToPlayArticleContent.mjs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -166,6 +167,11 @@ const routes = [
   },
 ];
 
+/** Routes whose prerendered shell carries a full article rather than a lede. */
+const ARTICLES = {
+  '/learn/how-to-play': HOW_TO_PLAY_ARTICLE,
+};
+
 function escapeHtml(value) {
   return value
     .replaceAll('&', '&amp;')
@@ -191,11 +197,27 @@ function renderRoute(template, route) {
     .map((other) => `<li><a href="${other.path}">${escapeHtml(navLabel(other))}</a></li>`)
     .join('');
 
+  // Routes with long-form content serve it in the shell too, so the served
+  // HTML carries the same words the hydrated page shows. Everything else
+  // keeps its short lede.
+  const article = ARTICLES[route.path];
+  const bodyHtml = article
+    ? `<p>${escapeHtml(article.standfirst)}</p>` +
+      article.sections
+        .map(
+          (section) =>
+            `<section id="${section.id}"><h2>${escapeHtml(section.heading)}</h2>` +
+            section.paragraphs.map((text) => `<p>${escapeHtml(text)}</p>`).join('') +
+            `</section>`,
+        )
+        .join('')
+    : `<p>${escapeHtml(route.body)}</p>`;
+
   const content =
     `<main class="prerendered-page">` +
     `<p>Racehorse Dominoes</p>` +
     `<h1>${escapeHtml(route.heading)}</h1>` +
-    `<p>${escapeHtml(route.body)}</p>` +
+    bodyHtml +
     `<nav aria-label="Racehorse Dominoes pages"><ul>${links}</ul></nav>` +
     `</main>`;
 

--- a/client/src/learn/LearnHowToPlayRacehorse.tsx
+++ b/client/src/learn/LearnHowToPlayRacehorse.tsx
@@ -5,10 +5,7 @@ import { LearnActionButton } from './academy/LearnActionButton';
 import { LearnCoachPanel } from './academy/LearnCoachPanel';
 import { LearnShell } from './academy/LearnShell';
 import { HowToPlayArticle } from './howToPlay/HowToPlayArticle';
-import {
-  HOW_TO_PLAY_MODULES,
-  HOW_TO_PLAY_MODULE_COUNT,
-} from './howToPlay/howToPlayModules';
+import { HOW_TO_PLAY_MODULES, HOW_TO_PLAY_MODULE_COUNT } from './howToPlay/howToPlayModules';
 
 export interface LearnHowToPlayRacehorseProps {
   onBack: () => void;
@@ -63,34 +60,44 @@ export default function LearnHowToPlayRacehorse({
   ) : undefined;
 
   return (
-    <>
-      <LearnShell
-        page={page}
-        modules={HOW_TO_PLAY_MODULES}
-        onGoTo={goTo}
-        onBack={onBack}
-        onPrev={goPrev}
-        onNext={goNext}
-        onNavigate={onNavigate}
-        isFirst={isFirst}
-        coach={
-          <LearnCoachPanel
-            stepLabel={module.stepLabel}
-            title={module.title}
-            lede={module.lede}
-            beats={module.beats}
-            momentumNote={module.runNote}
-            takeaway={module.takeaway}
-            footer={finalFooter}
-            final={module.isFinal}
-          />
-        }
-        stage={<AcademyVisuals visual={module.visual} />}
-      />
+    // `.app` is `100dvh; overflow: hidden`, and the lesson shell is built to
+    // fill it exactly. The article cannot be a bare sibling of that — it wins
+    // the flex fight, crushes the shell to zero height and then gets clipped.
+    // One scroll container instead: the lesson keeps a full viewport, the
+    // article lives below it and is reached by scrolling.
+    <div className="rh-htp-page">
+      <div className="rh-htp-page__lesson">
+        <LearnShell
+          page={page}
+          modules={HOW_TO_PLAY_MODULES}
+          onGoTo={goTo}
+          onBack={onBack}
+          onPrev={goPrev}
+          onNext={goNext}
+          onNavigate={onNavigate}
+          isFirst={isFirst}
+          coach={
+            <LearnCoachPanel
+              stepLabel={module.stepLabel}
+              title={module.title}
+              lede={module.lede}
+              beats={module.beats}
+              momentumNote={module.runNote}
+              takeaway={module.takeaway}
+              footer={finalFooter}
+              final={module.isFinal}
+            />
+          }
+          stage={<AcademyVisuals visual={module.visual} />}
+        />
+        <a className="rh-htp-page__jump" href="#what-makes-it-different">
+          Read the full written rules
+        </a>
+      </div>
       {/* The written rules sit below the interactive tutorial: the same words
           the prerendered page serves, so a reader and a crawler get one
           version rather than two. */}
       <HowToPlayArticle />
-    </>
+    </div>
   );
 }

--- a/client/src/learn/LearnHowToPlayRacehorse.tsx
+++ b/client/src/learn/LearnHowToPlayRacehorse.tsx
@@ -4,6 +4,7 @@ import { AcademyVisuals } from './academy/AcademyVisuals';
 import { LearnActionButton } from './academy/LearnActionButton';
 import { LearnCoachPanel } from './academy/LearnCoachPanel';
 import { LearnShell } from './academy/LearnShell';
+import { HowToPlayArticle } from './howToPlay/HowToPlayArticle';
 import {
   HOW_TO_PLAY_MODULES,
   HOW_TO_PLAY_MODULE_COUNT,
@@ -62,28 +63,34 @@ export default function LearnHowToPlayRacehorse({
   ) : undefined;
 
   return (
-    <LearnShell
-      page={page}
-      modules={HOW_TO_PLAY_MODULES}
-      onGoTo={goTo}
-      onBack={onBack}
-      onPrev={goPrev}
-      onNext={goNext}
-      onNavigate={onNavigate}
-      isFirst={isFirst}
-      coach={
-        <LearnCoachPanel
-          stepLabel={module.stepLabel}
-          title={module.title}
-          lede={module.lede}
-          beats={module.beats}
-          momentumNote={module.runNote}
-          takeaway={module.takeaway}
-          footer={finalFooter}
-          final={module.isFinal}
-        />
-      }
-      stage={<AcademyVisuals visual={module.visual} />}
-    />
+    <>
+      <LearnShell
+        page={page}
+        modules={HOW_TO_PLAY_MODULES}
+        onGoTo={goTo}
+        onBack={onBack}
+        onPrev={goPrev}
+        onNext={goNext}
+        onNavigate={onNavigate}
+        isFirst={isFirst}
+        coach={
+          <LearnCoachPanel
+            stepLabel={module.stepLabel}
+            title={module.title}
+            lede={module.lede}
+            beats={module.beats}
+            momentumNote={module.runNote}
+            takeaway={module.takeaway}
+            footer={finalFooter}
+            final={module.isFinal}
+          />
+        }
+        stage={<AcademyVisuals visual={module.visual} />}
+      />
+      {/* The written rules sit below the interactive tutorial: the same words
+          the prerendered page serves, so a reader and a crawler get one
+          version rather than two. */}
+      <HowToPlayArticle />
+    </>
   );
 }

--- a/client/src/learn/howToPlay/HowToPlayArticle.tsx
+++ b/client/src/learn/howToPlay/HowToPlayArticle.tsx
@@ -1,0 +1,41 @@
+import { HOW_TO_PLAY_ARTICLE } from './howToPlayArticleContent.mjs';
+import './howToPlayArticle.css';
+
+/**
+ * The written rules, below the interactive tutorial.
+ *
+ * Rendered from the same data the prerender script uses, so the served HTML
+ * and the hydrated page say the same thing — a reader and a crawler get one
+ * version of the rules, not two.
+ */
+export function HowToPlayArticle() {
+  const { title, standfirst, sections } = HOW_TO_PLAY_ARTICLE;
+
+  return (
+    <article className="rh-htp-article">
+      <h1 className="rh-htp-article__title">{title}</h1>
+      <p className="rh-htp-article__standfirst">{standfirst}</p>
+
+      <nav className="rh-htp-article__toc" aria-label="On this page">
+        <ul>
+          {sections.map((section) => (
+            <li key={section.id}>
+              <a href={`#${section.id}`}>{section.heading}</a>
+            </li>
+          ))}
+        </ul>
+      </nav>
+
+      {sections.map((section) => (
+        <section key={section.id} id={section.id} className="rh-htp-article__section">
+          <h2>{section.heading}</h2>
+          {section.paragraphs.map((paragraph, index) => (
+            <p key={index}>{paragraph}</p>
+          ))}
+        </section>
+      ))}
+    </article>
+  );
+}
+
+export default HowToPlayArticle;

--- a/client/src/learn/howToPlay/howToPlayArticle.css
+++ b/client/src/learn/howToPlay/howToPlayArticle.css
@@ -1,0 +1,83 @@
+/*
+ * The written rules. A reading surface rather than a game surface: measured
+ * line length, generous leading, and the body face throughout — the display
+ * face is for HUD labels, not for paragraphs someone reads end to end.
+ */
+
+.rh-htp-article {
+  max-width: 68ch;
+  margin: 0 auto;
+  padding: 48px 24px 96px;
+  color: rgba(255, 255, 255, 0.86);
+  font-family: var(--font-body);
+  font-size: 16px;
+  line-height: 1.7;
+}
+
+.rh-htp-article__title {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: clamp(34px, 6vw, 52px);
+  font-weight: 800;
+  line-height: 1.02;
+  color: rgba(255, 255, 255, 0.95);
+  text-wrap: balance;
+}
+
+.rh-htp-article__standfirst {
+  margin: 16px 0 0;
+  font-size: 18px;
+  line-height: 1.6;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.rh-htp-article__toc {
+  margin: 32px 0 8px;
+  padding: 18px 20px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: var(--radius-record);
+  background: rgba(255, 255, 255, 0.015);
+}
+
+.rh-htp-article__toc ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 6px;
+}
+
+.rh-htp-article__toc a {
+  color: rgba(255, 255, 255, 0.6);
+  font-size: 14.5px;
+  text-decoration: none;
+}
+
+.rh-htp-article__toc a:hover,
+.rh-htp-article__toc a:focus-visible {
+  color: var(--tier-elite);
+  text-decoration: underline;
+}
+
+.rh-htp-article__section {
+  margin-top: 40px;
+  /* Anchors from the contents list must not land under any sticky chrome. */
+  scroll-margin-top: 24px;
+}
+
+.rh-htp-article__section h2 {
+  margin: 0 0 12px;
+  font-family: var(--font-display);
+  font-size: 27px;
+  font-weight: 700;
+  line-height: 1.15;
+  color: rgba(255, 255, 255, 0.95);
+}
+
+.rh-htp-article__section p {
+  margin: 0 0 14px;
+}
+
+.rh-htp-article__section p:last-child {
+  margin-bottom: 0;
+}

--- a/client/src/learn/howToPlay/howToPlayArticle.css
+++ b/client/src/learn/howToPlay/howToPlayArticle.css
@@ -1,16 +1,71 @@
 /*
- * The written rules. A reading surface rather than a game surface: measured
- * line length, generous leading, and the body face throughout — the display
- * face is for HUD labels, not for paragraphs someone reads end to end.
+ * How to Play: the interactive lesson, then the written rules below it.
+ *
+ * `.app` is `100dvh; overflow: hidden` and the lesson shell fills it exactly,
+ * so the route needs its own scrollport — otherwise the article competes with
+ * the shell for flex space and everything past the first viewport is clipped.
+ *
+ * The article itself is a reading surface rather than a game surface: measured
+ * line length, generous leading, and the body face for anything read end to
+ * end. The display face stays on headings, where it works as it does in the
+ * rest of the HUD.
  */
+
+.rh-htp-page {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  overflow-x: hidden;
+  background: var(--bg-primary);
+  scroll-behavior: smooth;
+}
+
+/* The lesson keeps a full viewport to itself, exactly as it had before the
+   article existed. `height` rather than `min-height`: the shell measures
+   itself against a definite box. */
+.rh-htp-page__lesson {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+/* Without this the article below the fold is undiscoverable — the lesson ends
+   on its own controls and nothing suggests there is more page. */
+.rh-htp-page__jump {
+  flex: 0 0 auto;
+  display: block;
+  padding: 14px var(--space-md);
+  border-top: 1px solid var(--border-subtle);
+  color: var(--text-dim);
+  font-family: var(--font-display);
+  font-size: 14px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-align: center;
+  text-transform: uppercase;
+  text-decoration: none;
+  transition: color 120ms cubic-bezier(0.2, 0, 0, 1);
+}
+
+.rh-htp-page__jump::after {
+  content: ' ↓';
+}
+
+.rh-htp-page__jump:hover,
+.rh-htp-page__jump:focus-visible {
+  color: var(--text-primary);
+}
+
+/* ---- the article ---- */
 
 .rh-htp-article {
   max-width: 68ch;
   margin: 0 auto;
-  padding: 48px 24px 96px;
-  color: rgba(255, 255, 255, 0.86);
+  padding: var(--space-xl) var(--space-md) 96px;
+  color: var(--text-primary);
   font-family: var(--font-body);
-  font-size: 16px;
+  font-size: 17px;
+  font-weight: 400;
   line-height: 1.7;
 }
 
@@ -20,64 +75,105 @@
   font-size: clamp(34px, 6vw, 52px);
   font-weight: 800;
   line-height: 1.02;
-  color: rgba(255, 255, 255, 0.95);
+  letter-spacing: 0.01em;
+  color: var(--text-primary);
   text-wrap: balance;
 }
 
 .rh-htp-article__standfirst {
-  margin: 16px 0 0;
-  font-size: 18px;
+  margin: var(--space-sm) 0 0;
+  font-size: 19px;
   line-height: 1.6;
-  color: rgba(255, 255, 255, 0.6);
+  color: var(--text-secondary);
+  text-wrap: pretty;
 }
 
+/* Contents: a record of what the page covers, so the square corners and
+   hairline border of the leaderboards rather than a rounded card. */
 .rh-htp-article__toc {
-  margin: 32px 0 8px;
-  padding: 18px 20px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  margin: var(--space-lg) 0 0;
+  padding: var(--space-md);
+  border: 1px solid var(--border-subtle);
   border-radius: var(--radius-record);
-  background: rgba(255, 255, 255, 0.015);
+  background: var(--bg-card);
 }
 
 .rh-htp-article__toc ul {
+  display: grid;
+  gap: 10px var(--space-md);
   margin: 0;
   padding: 0;
   list-style: none;
-  display: grid;
-  gap: 6px;
+}
+
+@media (min-width: 640px) {
+  .rh-htp-article__toc ul {
+    grid-template-columns: 1fr 1fr;
+  }
 }
 
 .rh-htp-article__toc a {
-  color: rgba(255, 255, 255, 0.6);
-  font-size: 14.5px;
+  color: var(--text-secondary);
+  font-size: 15px;
+  line-height: 1.35;
   text-decoration: none;
+  transition: color 120ms cubic-bezier(0.2, 0, 0, 1);
 }
 
 .rh-htp-article__toc a:hover,
 .rh-htp-article__toc a:focus-visible {
   color: var(--tier-elite);
-  text-decoration: underline;
 }
 
+/* A hairline per section — the same rule-between-records language the
+   leaderboard and dossier use, which is what stops eight headings reading as
+   one undifferentiated column of text. */
 .rh-htp-article__section {
-  margin-top: 40px;
-  /* Anchors from the contents list must not land under any sticky chrome. */
-  scroll-margin-top: 24px;
+  margin-top: var(--space-lg);
+  padding-top: var(--space-lg);
+  border-top: 1px solid var(--border-subtle);
+  /* Anchors from the contents list land inside `.rh-htp-page`, not the
+     document, so the offset is measured against that scrollport. */
+  scroll-margin-top: var(--space-md);
 }
 
 .rh-htp-article__section h2 {
-  margin: 0 0 12px;
+  margin: 0 0 var(--space-sm);
   font-family: var(--font-display);
-  font-size: 27px;
+  font-size: clamp(25px, 4vw, 30px);
   font-weight: 700;
   line-height: 1.15;
-  color: rgba(255, 255, 255, 0.95);
+  letter-spacing: 0.01em;
+  color: var(--text-primary);
+  text-wrap: balance;
 }
 
 .rh-htp-article__section p {
-  margin: 0 0 14px;
+  margin: 0 0 var(--space-sm);
+  text-wrap: pretty;
 }
 
 .rh-htp-article__section p:last-child {
   margin-bottom: 0;
+}
+
+@media (max-width: 600px) {
+  .rh-htp-article {
+    padding: var(--space-lg) var(--space-md) var(--space-xl);
+    font-size: 16px;
+  }
+
+  .rh-htp-article__standfirst {
+    font-size: 17px;
+  }
+
+  .rh-htp-article__toc {
+    padding: var(--space-sm);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .rh-htp-page {
+    scroll-behavior: auto;
+  }
 }

--- a/client/src/learn/howToPlay/howToPlayArticle.css
+++ b/client/src/learn/howToPlay/howToPlayArticle.css
@@ -5,10 +5,16 @@
  * so the route needs its own scrollport — otherwise the article competes with
  * the shell for flex space and everything past the first viewport is clipped.
  *
- * The article itself is a reading surface rather than a game surface: measured
- * line length, generous leading, and the body face for anything read end to
- * end. The display face stays on headings, where it works as it does in the
- * rest of the HUD.
+ * The surface treatment is the academy's, reused rather than reinvented: the
+ * accent-tinted panel from `.learn-academy__beats` / `__momentum`, the icon
+ * card from `.learn-academy__rhythm-card`, and the dotted accent label from
+ * `.learn-academy__kicker`. Panels alternate mint and gold across the page the
+ * way the rhythm grid does.
+ *
+ * The one deliberate departure: the tutorial's cards hold three to six words,
+ * these hold whole paragraphs. Tints, glows and borders are therefore carried
+ * at a lower strength here — the same recipe, dialled back to the point where
+ * 1,300 words stay comfortable to read.
  */
 
 .rh-htp-page {
@@ -16,7 +22,10 @@
   min-height: 0;
   overflow-y: auto;
   overflow-x: hidden;
-  background: var(--bg-primary);
+  /* The lesson sits on the obsidian ground. `--bg-primary` here left a visible
+     tonal step at the seam, which is most of what made the article read as a
+     different page pasted underneath. */
+  background: var(--bg-obsidian);
   scroll-behavior: smooth;
 }
 
@@ -29,36 +38,55 @@
   height: 100%;
 }
 
-/* Without this the article below the fold is undiscoverable — the lesson ends
-   on its own controls and nothing suggests there is more page. */
+/* The seam between the lesson and the rules. Styled as the academy's own
+   accent label so it reads as the next section of this page rather than the
+   top edge of a different one. */
 .rh-htp-page__jump {
   flex: 0 0 auto;
-  display: block;
-  padding: 14px var(--space-md);
-  border-top: 1px solid var(--border-subtle);
-  color: var(--text-dim);
-  font-family: var(--font-display);
-  font-size: 14px;
-  font-weight: 600;
-  letter-spacing: 0.08em;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  padding: 16px var(--space-md);
+  border-top: 1px solid color-mix(in srgb, var(--accent-green) 22%, var(--border-subtle));
+  background: color-mix(in srgb, var(--accent-green) 5%, transparent);
+  color: var(--accent-green);
+  font-family: var(--font-body);
+  font-size: 12px;
+  font-weight: 800;
+  letter-spacing: 0.2em;
   text-align: center;
   text-transform: uppercase;
   text-decoration: none;
-  transition: color 120ms cubic-bezier(0.2, 0, 0, 1);
+  transition:
+    background 120ms cubic-bezier(0.2, 0, 0, 1),
+    color 120ms cubic-bezier(0.2, 0, 0, 1);
+}
+
+.rh-htp-page__jump::before {
+  content: '';
+  width: 7px;
+  height: 7px;
+  flex-shrink: 0;
+  border-radius: 50%;
+  background: var(--accent-green);
 }
 
 .rh-htp-page__jump::after {
-  content: ' ↓';
+  content: '↓';
+  letter-spacing: 0;
 }
 
 .rh-htp-page__jump:hover,
 .rh-htp-page__jump:focus-visible {
-  color: var(--text-primary);
+  background: color-mix(in srgb, var(--accent-green) 10%, transparent);
+  color: #fff;
 }
 
 /* ---- the article ---- */
 
 .rh-htp-article {
+  counter-reset: htp-section;
   max-width: 68ch;
   margin: 0 auto;
   padding: var(--space-xl) var(--space-md) 96px;
@@ -77,6 +105,7 @@
   line-height: 1.02;
   letter-spacing: 0.01em;
   color: var(--text-primary);
+  text-shadow: 0 0 36px rgba(160, 200, 255, 0.1);
   text-wrap: balance;
 }
 
@@ -88,56 +117,154 @@
   text-wrap: pretty;
 }
 
-/* Contents: a record of what the page covers, so the square corners and
-   hairline border of the leaderboards rather than a rounded card. */
+/* ---- contents: the rhythm grid, at TOC scale ---- */
+
 .rh-htp-article__toc {
   margin: var(--space-lg) 0 0;
-  padding: var(--space-md);
-  border: 1px solid var(--border-subtle);
-  border-radius: var(--radius-record);
-  background: var(--bg-card);
 }
 
 .rh-htp-article__toc ul {
+  counter-reset: htp-toc;
   display: grid;
-  gap: 10px var(--space-md);
+  gap: 10px;
   margin: 0;
   padding: 0;
   list-style: none;
 }
 
-@media (min-width: 640px) {
+@media (min-width: 620px) {
   .rh-htp-article__toc ul {
     grid-template-columns: 1fr 1fr;
   }
 }
 
 .rh-htp-article__toc a {
-  color: var(--text-secondary);
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  height: 100%;
+  padding: 12px 14px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: var(--pvf-radius-md);
+  background: rgba(255, 255, 255, 0.03);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.06),
+    0 8px 24px rgba(0, 0, 0, 0.28);
+  color: var(--text-primary);
   font-size: 15px;
-  line-height: 1.35;
+  font-weight: 600;
+  line-height: 1.3;
   text-decoration: none;
-  transition: color 120ms cubic-bezier(0.2, 0, 0, 1);
+  transition:
+    transform 120ms cubic-bezier(0.2, 0, 0, 1),
+    box-shadow 120ms cubic-bezier(0.2, 0, 0, 1);
+}
+
+/* The numeral ring, echoing `.learn-academy__rhythm-icon` at list scale. */
+.rh-htp-article__toc a::before {
+  counter-increment: htp-toc;
+  content: counter(htp-toc, decimal-leading-zero);
+  display: grid;
+  place-items: center;
+  width: 30px;
+  height: 30px;
+  flex-shrink: 0;
+  border: 1.5px solid var(--htp-ring-border, rgba(255, 255, 255, 0.2));
+  border-radius: var(--radius-pill);
+  background: var(--htp-ring-bg, rgba(255, 255, 255, 0.04));
+  box-shadow: 0 0 18px color-mix(in srgb, var(--htp-accent, var(--accent-green)) 22%, transparent);
+  color: var(--htp-accent, var(--accent-green));
+  font-family: var(--font-display);
+  font-size: 13px;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+}
+
+/* Alternating mint and gold, as the rhythm grid alternates its four cards. */
+.rh-htp-article__toc li:nth-child(odd) a {
+  --htp-accent: var(--accent-green);
+  --htp-ring-border: color-mix(in srgb, var(--accent-green) 45%, transparent);
+  --htp-ring-bg: color-mix(in srgb, var(--accent-green) 10%, transparent);
+
+  border-color: color-mix(in srgb, var(--accent-green) 38%, rgba(255, 255, 255, 0.1));
+  background: color-mix(in srgb, var(--accent-green) 7%, rgba(255, 255, 255, 0.02));
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.07),
+    inset 0 0 32px color-mix(in srgb, var(--accent-green) 8%, transparent),
+    0 8px 28px rgba(0, 0, 0, 0.3);
+}
+
+.rh-htp-article__toc li:nth-child(even) a {
+  --htp-accent: var(--tier-elite);
+  --htp-ring-border: color-mix(in srgb, var(--tier-elite) 45%, transparent);
+  --htp-ring-bg: color-mix(in srgb, var(--tier-elite) 10%, transparent);
+
+  border-color: color-mix(in srgb, var(--tier-elite) 42%, rgba(255, 255, 255, 0.1));
+  background: color-mix(in srgb, var(--tier-elite) 8%, rgba(255, 255, 255, 0.02));
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.07),
+    inset 0 0 32px color-mix(in srgb, var(--tier-elite) 8%, transparent),
+    0 8px 28px rgba(0, 0, 0, 0.3);
 }
 
 .rh-htp-article__toc a:hover,
 .rh-htp-article__toc a:focus-visible {
-  color: var(--tier-elite);
+  transform: translateY(-1px);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.1),
+    inset 0 0 32px color-mix(in srgb, var(--htp-accent, var(--accent-green)) 14%, transparent),
+    0 12px 32px rgba(0, 0, 0, 0.4);
 }
 
-/* A hairline per section — the same rule-between-records language the
-   leaderboard and dossier use, which is what stops eight headings reading as
-   one undifferentiated column of text. */
+/* ---- sections: the academy's accent panel, carried at reading strength ---- */
+
 .rh-htp-article__section {
-  margin-top: var(--space-lg);
-  padding-top: var(--space-lg);
-  border-top: 1px solid var(--border-subtle);
+  margin-top: var(--space-md);
+  padding: var(--space-md);
+  border: 1px solid color-mix(in srgb, var(--htp-accent) 26%, rgba(255, 255, 255, 0.1));
+  border-radius: var(--pvf-radius-md);
+  background: color-mix(in srgb, var(--htp-accent) 5%, rgba(0, 0, 0, 0.22));
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.07),
+    0 0 28px color-mix(in srgb, var(--htp-accent) 7%, transparent);
   /* Anchors from the contents list land inside `.rh-htp-page`, not the
      document, so the offset is measured against that scrollport. */
   scroll-margin-top: var(--space-md);
 }
 
+.rh-htp-article__section:nth-of-type(odd) {
+  --htp-accent: var(--accent-green);
+}
+
+.rh-htp-article__section:nth-of-type(even) {
+  --htp-accent: var(--tier-elite);
+}
+
+.rh-htp-article__section:first-of-type {
+  margin-top: var(--space-lg);
+}
+
+/* The numeral eyebrow. On the section rather than inside the heading, so the
+   count stays out of the h2's accessible name — and the sequence is real:
+   these run setup, turn, scoring, ending, winning, the way the lesson above
+   runs step 1 of 5. */
+.rh-htp-article__section::before {
+  counter-increment: htp-section;
+  content: 'Section ' counter(htp-section, decimal-leading-zero);
+  display: block;
+  margin-bottom: 10px;
+  color: var(--htp-accent);
+  font-family: var(--font-body);
+  font-size: 12px;
+  font-weight: 800;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+}
+
 .rh-htp-article__section h2 {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
   margin: 0 0 var(--space-sm);
   font-family: var(--font-display);
   font-size: clamp(25px, 4vw, 30px);
@@ -148,8 +275,21 @@
   text-wrap: balance;
 }
 
+/* The academy kicker's dot, tying the heading to its panel accent. */
+.rh-htp-article__section h2::before {
+  content: '';
+  width: 7px;
+  height: 7px;
+  flex-shrink: 0;
+  align-self: center;
+  border-radius: 50%;
+  background: var(--htp-accent);
+  box-shadow: 0 0 12px color-mix(in srgb, var(--htp-accent) 55%, transparent);
+}
+
 .rh-htp-article__section p {
   margin: 0 0 var(--space-sm);
+  color: rgba(255, 255, 255, 0.92);
   text-wrap: pretty;
 }
 
@@ -167,7 +307,7 @@
     font-size: 17px;
   }
 
-  .rh-htp-article__toc {
+  .rh-htp-article__section {
     padding: var(--space-sm);
   }
 }
@@ -175,5 +315,14 @@
 @media (prefers-reduced-motion: reduce) {
   .rh-htp-page {
     scroll-behavior: auto;
+  }
+
+  .rh-htp-article__toc a {
+    transition: none;
+  }
+
+  .rh-htp-article__toc a:hover,
+  .rh-htp-article__toc a:focus-visible {
+    transform: none;
   }
 }

--- a/client/src/learn/howToPlay/howToPlayArticleContent.d.mts
+++ b/client/src/learn/howToPlay/howToPlayArticleContent.d.mts
@@ -1,0 +1,13 @@
+export interface HowToPlayArticleSection {
+  id: string;
+  heading: string;
+  paragraphs: string[];
+}
+
+export interface HowToPlayArticle {
+  title: string;
+  standfirst: string;
+  sections: HowToPlayArticleSection[];
+}
+
+export declare const HOW_TO_PLAY_ARTICLE: HowToPlayArticle;

--- a/client/src/learn/howToPlay/howToPlayArticleContent.mjs
+++ b/client/src/learn/howToPlay/howToPlayArticleContent.mjs
@@ -2,7 +2,7 @@
  * The long-form How to Play article.
  *
  * Plain data in .mjs so the React page and scripts/prerender.mjs render the
- * same words. The served HTML and the hydrated page must agree — content that
+ * same words. The served HTML and the hydrated page must agree. Content that
  * only crawlers see is cloaking, and content only users see is invisible to
  * search, which is the whole point of writing this (growth assessment,
  * Phase 1 item 1).
@@ -17,14 +17,14 @@
 export const HOW_TO_PLAY_ARTICLE = {
   title: 'How to Play Racehorse Dominoes',
   standfirst:
-    'Racehorse is a scoring variant of dominoes built around a race to 60. If you have played Fives before, you already know most of it — but the forced play, the chained turns and the skunk rule make it a different game to sit down to.',
+    'Racehorse is a scoring variant of dominoes built around a race to 60. If you have played Fives before, you already know most of it. The forced play, the chained turns and the skunk rule still make it a different game to sit down to.',
   sections: [
     {
       id: 'what-makes-it-different',
       heading: 'What makes Racehorse different',
       paragraphs: [
-        'Most dominoes you meet online is a blocking game: play out your hand, and whoever runs out first wins. Racehorse is a scoring game. You are not really racing to empty your hand — you are racing to 60 points, and points come from the shape of the board rather than from going out.',
-        'Three rules do most of the work in making it feel unlike standard dominoes. You are never allowed to pass when you have a legal play. Scoring does not end your turn — it extends it. And a heavy enough loss counts double in a Daily Fritz set, which means a game can end before it looks finished.',
+        'Most dominoes you meet online is a blocking game: play out your hand, and whoever runs out first wins. Racehorse is a scoring game. You are not really racing to empty your hand. You are racing to 60 points, and points come from the shape of the board rather than from going out.',
+        'Three rules do most of the work in making it feel unlike standard dominoes. You are never allowed to pass when you have a legal play. Scoring does not end your turn. It extends it. And a heavy enough loss counts double in a Daily Fritz set, which means a set can end before it looks finished.',
         'The effect is a game with real momentum. One player can chain three or four scoring plays in a row and take a game from level to won in a single turn. That is the part regular players get hooked on, and the part new players usually miss on their first few hands.',
       ],
     },
@@ -33,7 +33,7 @@ export const HOW_TO_PLAY_ARTICLE = {
       heading: 'Setting up',
       paragraphs: [
         'Racehorse uses the standard double-six set: 28 tiles, from the blank-blank up to the six-six. Each player draws seven tiles. The rest form the boneyard.',
-        'Two tiles in the boneyard are dead. They are never dealt and never drawn, which means the pile can lock while tiles are still sitting in it. That matters more than it sounds — it is what stops a blocked player drawing forever, and it is why some hands end with both players still holding tiles.',
+        'Two random tiles in the boneyard are dead each hand. They are never dealt and never drawn, which means the pile can lock while tiles are still sitting in it. That matters more than it sounds. It is what stops a blocked player drawing forever, and it is why some hands end with both players still holding tiles.',
       ],
     },
     {
@@ -41,16 +41,16 @@ export const HOW_TO_PLAY_ARTICLE = {
       heading: 'Taking a turn',
       paragraphs: [
         'A turn has the same shape every time, and it is worth learning that shape before anything else.',
-        'First: if you can play, you must play. There is no passing to keep a good tile back, and no holding a double for a better moment. If a legal placement exists, you are making one. This single rule removes most of the stalling that slows down casual dominoes, and it means the board moves fast.',
+        'First: if you can play, you must play. There is no passing to keep a good tile back. If a legal placement exists, you are making one. This single rule removes most of the stalling that slows down casual dominoes, and it means the board moves fast.',
         'Second: if that play scores, or if it was a double, your turn continues. You play again. This is where games are won. A well-set-up board can let you score, play again, score again, and keep going while your opponent watches.',
-        'Third: if you cannot play, Racehorse draws for you automatically. You keep drawing until you find a tile you can place, or until the pile locks down to its two dead tiles. If you are still stuck when it locks, your turn passes automatically. You never have to decide whether to draw or pass — the game handles both.',
+        'Third: if you cannot play, Racehorse draws for you automatically. You keep drawing until you find a tile you can place, or until the pile locks down to its two dead tiles. If you are still stuck when it locks, your turn passes automatically. You never have to decide whether to draw or pass. The game handles both.',
       ],
     },
     {
       id: 'scoring',
       heading: 'How scoring works',
       paragraphs: [
-        'Points come from the open count: the total of every exposed end currently active on the board. Add those ends together, and if the total is a multiple of five — and not zero — you score.',
+        'Points come from the open count: the total of every exposed end currently active on the board. Add those ends together, and if the total is a multiple of five, you score.',
         'The points you receive are that total divided by five. An open count of 20 is worth 4 points. A count of 35 is worth 7. Since a game runs to 60, a single strong count is a meaningful chunk of it, and two or three chained together can decide a game.',
         'This is why Racehorse rewards reading the board before you commit. The question on every turn is not "which tile do I want to get rid of" but "what does the board total become after I place this, and can I land it on a five".',
       ],
@@ -61,16 +61,16 @@ export const HOW_TO_PLAY_ARTICLE = {
       paragraphs: [
         'Doubles are the most misread part of the game, and they behave in two distinct stages.',
         'While a double is open, it counts its full value toward the open count. An open six-six adds 12, not 6. That makes doubles enormously powerful for setting up a score, and it is the fastest way for a new player to find their first big count.',
-        'Once a double has been crossed on both sides, it drops out of the count entirely and opens new branches instead. Play onto a branch and that new end joins the total. So the same double is first a large contributor, then nothing, then the root of two new ends you can build from. Tracking which stage each double is in is most of what separates a strong Racehorse player from a beginner.',
+        'Once a double has been crossed on both sides, it drops out of the count entirely and opens new branches instead. Play onto a branch and that new end joins the total. So the same double is first a large contributor, then nothing, then the root of two new ends you can build from.',
       ],
     },
     {
       id: 'ending-a-hand',
       heading: 'Ending a hand',
       paragraphs: [
-        'To go out, you play your last tile — but it has to be a dead play. Your final tile cannot be a double, and it cannot score. If your last tile would score, you cannot use it to finish, and the hand continues.',
+        'To go out, you play your last tile, but it has to be a dead play. Your final tile cannot be a double, and it cannot score. If your last tile would score, you cannot use it to finish, and the hand continues.',
         'This catches people out constantly, and it is a deliberate piece of design: it stops games ending on a flourish, and it means holding a scoring tile too long can trap you with a hand you cannot close.',
-        'When you do go out, you score for the tiles left in your opponent’s hand — their remaining pips, divided by five and rounded. A hand full of heavy tiles is a serious swing.',
+        'When you do go out, you score for the tiles left in your opponent’s hand. That is their remaining pips, divided by five and rounded. A hand full of heavy tiles is a serious swing.',
         'If the pile locks and nobody can play, the hand ends anyway. The player holding the fewest pips wins it and takes the bonus. If both players hold the same total, nobody scores.',
       ],
     },
@@ -79,9 +79,9 @@ export const HOW_TO_PLAY_ARTICLE = {
       heading: 'Winning a game, and a Daily Fritz set',
       paragraphs: [
         'A single game runs to 60 points. First there wins.',
-        'Daily Fritz — the daily challenge everyone plays on the same deal — is a best-of-three set against the Fritz bot. Win two games and you take the set. Every player in the world gets the identical tiles that day, so the leaderboard measures decisions rather than luck.',
-        'The skunk rule is the twist. Win a game while your opponent is still under 30 points, and it counts as two game wins. A skunk in game one or game two therefore ends the set on the spot: skunk Fritz in the opener and you have won 2–0 without playing a second game. It cuts both ways — Fritz can skunk you just as fast.',
-        'A skunk in game three is recorded and shown, but it cannot change the result: the set is already going to a single deciding game, and winning it wins the set 2–1 regardless of the margin.',
+        'Daily Fritz is the daily challenge everyone plays on the same deal. It is a best-of-three set against the Fritz bot. Win two games and you take the set. Every player in the world gets the identical tiles that day, so the leaderboard measures decisions rather than luck.',
+        'The skunk rule is the twist. Win a game while your opponent is still under 30 points, and it counts as two game wins. A skunk in game one or game two therefore ends the set on the spot: skunk Fritz in the opener and you have won 2-0 without playing a second game. It cuts both ways. Fritz can skunk you just as fast.',
+        'A skunk in game three is recorded and shown, but it cannot change the result: the set is already going to a single deciding game, and winning it wins the set 2-1 regardless of the margin.',
       ],
     },
     {

--- a/client/src/learn/howToPlay/howToPlayArticleContent.mjs
+++ b/client/src/learn/howToPlay/howToPlayArticleContent.mjs
@@ -1,0 +1,99 @@
+/**
+ * The long-form How to Play article.
+ *
+ * Plain data in .mjs so the React page and scripts/prerender.mjs render the
+ * same words. The served HTML and the hydrated page must agree — content that
+ * only crawlers see is cloaking, and content only users see is invisible to
+ * search, which is the whole point of writing this (growth assessment,
+ * Phase 1 item 1).
+ *
+ * Every rule below is taken from the engine, not from generic dominoes:
+ *   scoring.ts   computePlayScore, computeGoOutBonusPoints
+ *   types.ts     DEFAULT_CONFIG
+ *   engine.ts    blocked-hand resolution
+ *   docs/daily-fritz-skunk-source-of-truth.md
+ */
+
+export const HOW_TO_PLAY_ARTICLE = {
+  title: 'How to Play Racehorse Dominoes',
+  standfirst:
+    'Racehorse is a scoring variant of dominoes built around a race to 60. If you have played Fives before, you already know most of it — but the forced play, the chained turns and the skunk rule make it a different game to sit down to.',
+  sections: [
+    {
+      id: 'what-makes-it-different',
+      heading: 'What makes Racehorse different',
+      paragraphs: [
+        'Most dominoes you meet online is a blocking game: play out your hand, and whoever runs out first wins. Racehorse is a scoring game. You are not really racing to empty your hand — you are racing to 60 points, and points come from the shape of the board rather than from going out.',
+        'Three rules do most of the work in making it feel unlike standard dominoes. You are never allowed to pass when you have a legal play. Scoring does not end your turn — it extends it. And a heavy enough loss counts double in a Daily Fritz set, which means a game can end before it looks finished.',
+        'The effect is a game with real momentum. One player can chain three or four scoring plays in a row and take a game from level to won in a single turn. That is the part regular players get hooked on, and the part new players usually miss on their first few hands.',
+      ],
+    },
+    {
+      id: 'setup',
+      heading: 'Setting up',
+      paragraphs: [
+        'Racehorse uses the standard double-six set: 28 tiles, from the blank-blank up to the six-six. Each player draws seven tiles. The rest form the boneyard.',
+        'Two tiles in the boneyard are dead. They are never dealt and never drawn, which means the pile can lock while tiles are still sitting in it. That matters more than it sounds — it is what stops a blocked player drawing forever, and it is why some hands end with both players still holding tiles.',
+      ],
+    },
+    {
+      id: 'taking-a-turn',
+      heading: 'Taking a turn',
+      paragraphs: [
+        'A turn has the same shape every time, and it is worth learning that shape before anything else.',
+        'First: if you can play, you must play. There is no passing to keep a good tile back, and no holding a double for a better moment. If a legal placement exists, you are making one. This single rule removes most of the stalling that slows down casual dominoes, and it means the board moves fast.',
+        'Second: if that play scores, or if it was a double, your turn continues. You play again. This is where games are won. A well-set-up board can let you score, play again, score again, and keep going while your opponent watches.',
+        'Third: if you cannot play, Racehorse draws for you automatically. You keep drawing until you find a tile you can place, or until the pile locks down to its two dead tiles. If you are still stuck when it locks, your turn passes automatically. You never have to decide whether to draw or pass — the game handles both.',
+      ],
+    },
+    {
+      id: 'scoring',
+      heading: 'How scoring works',
+      paragraphs: [
+        'Points come from the open count: the total of every exposed end currently active on the board. Add those ends together, and if the total is a multiple of five — and not zero — you score.',
+        'The points you receive are that total divided by five. An open count of 20 is worth 4 points. A count of 35 is worth 7. Since a game runs to 60, a single strong count is a meaningful chunk of it, and two or three chained together can decide a game.',
+        'This is why Racehorse rewards reading the board before you commit. The question on every turn is not "which tile do I want to get rid of" but "what does the board total become after I place this, and can I land it on a five".',
+      ],
+    },
+    {
+      id: 'doubles',
+      heading: 'Doubles, branches and the open count',
+      paragraphs: [
+        'Doubles are the most misread part of the game, and they behave in two distinct stages.',
+        'While a double is open, it counts its full value toward the open count. An open six-six adds 12, not 6. That makes doubles enormously powerful for setting up a score, and it is the fastest way for a new player to find their first big count.',
+        'Once a double has been crossed on both sides, it drops out of the count entirely and opens new branches instead. Play onto a branch and that new end joins the total. So the same double is first a large contributor, then nothing, then the root of two new ends you can build from. Tracking which stage each double is in is most of what separates a strong Racehorse player from a beginner.',
+      ],
+    },
+    {
+      id: 'ending-a-hand',
+      heading: 'Ending a hand',
+      paragraphs: [
+        'To go out, you play your last tile — but it has to be a dead play. Your final tile cannot be a double, and it cannot score. If your last tile would score, you cannot use it to finish, and the hand continues.',
+        'This catches people out constantly, and it is a deliberate piece of design: it stops games ending on a flourish, and it means holding a scoring tile too long can trap you with a hand you cannot close.',
+        'When you do go out, you score for the tiles left in your opponent’s hand — their remaining pips, divided by five and rounded. A hand full of heavy tiles is a serious swing.',
+        'If the pile locks and nobody can play, the hand ends anyway. The player holding the fewest pips wins it and takes the bonus. If both players hold the same total, nobody scores.',
+      ],
+    },
+    {
+      id: 'winning',
+      heading: 'Winning a game, and a Daily Fritz set',
+      paragraphs: [
+        'A single game runs to 60 points. First there wins.',
+        'Daily Fritz — the daily challenge everyone plays on the same deal — is a best-of-three set against the Fritz bot. Win two games and you take the set. Every player in the world gets the identical tiles that day, so the leaderboard measures decisions rather than luck.',
+        'The skunk rule is the twist. Win a game while your opponent is still under 30 points, and it counts as two game wins. A skunk in game one or game two therefore ends the set on the spot: skunk Fritz in the opener and you have won 2–0 without playing a second game. It cuts both ways — Fritz can skunk you just as fast.',
+        'A skunk in game three is recorded and shown, but it cannot change the result: the set is already going to a single deciding game, and winning it wins the set 2–1 regardless of the margin.',
+      ],
+    },
+    {
+      id: 'strategy',
+      heading: 'Strategy for your first games',
+      paragraphs: [
+        'Count before you place, not after. The open count is the whole game, and the difference between a good player and a new one is usually just that the good player knows what the total will be before the tile lands.',
+        'Treat doubles as tempo, not as liabilities. In blocking dominoes you want doubles gone early because they are hard to shed. In Racehorse an open double is a scoring engine, and playing one keeps your turn alive regardless.',
+        'Think in chains. Because scoring extends your turn, the strongest plays are not the ones that score most now but the ones that leave you able to score again immediately. Ask what the board looks like for your next tile, not just this one.',
+        'Watch what your opponent cannot play. The forced-play rule means every draw they take tells you something: they had nothing for those ends. That is real information, and it is free.',
+        'Do not hoard your closing tile. Because a final tile cannot score and cannot be a double, the tile you plan to finish on is specific. If you leave yourself holding only doubles and scoring tiles, you cannot go out at all.',
+      ],
+    },
+  ],
+};


### PR DESCRIPTION
Growth assessment Phase 1, item 1.

## The problem

`/learn/how-to-play` served about 80 words: a heading, a one-line lede, and a link into the lesson player. That is the page that has to be the answer when someone searches for how the game works, and it had nothing in it to be an answer with.

## What changed

The route now carries a ~1,300-word article in eight sections, with a table of contents and an anchor per section:

- What makes Racehorse different
- Setting up
- Taking a turn
- How scoring works
- Doubles, branches and the open count
- Ending a hand
- Winning a game, and a Daily Fritz set
- Strategy for your first games

The rules come from the engine, not from generic dominoes writing. Sourced from `packages/game-core/src/{types,scoring,engine}.ts`, `client/src/learn/howToPlay/howToPlayModules.ts`, and `docs/daily-fritz-skunk-source-of-truth.md`: the 60-point target, `deadTileCount: 2`, forced play, scoring extending rather than ending a turn, the count **divided by five** (`computePlayScore` returns `sum / scoringMultiple`, so a 15-count is 3 points, not 15), the go-out tile not being a double, `lowestPips` taking a locked hand with a tie scoring nothing, and the under-30 skunk counting as two wins in games 1 and 2 of a set.

Tone is written for someone who has never played, not keyword-stuffed. "Racehorse" appears 9 times across 1,300 words, and a test holds that ratio down.

## Where the words live

In `howToPlayArticleContent.mjs` as plain data, because two consumers need them: the React page and `prerender.mjs`. Putting the article only in the prerendered shell would have served crawlers content users never see after hydration — cloaking. Both read the same module, so the served HTML and the hydrated page say the same thing.

## Prerender and metadata

Verified against `dist/learn-how-to-play.html` after a real build:

| | |
|---|---|
| words in `#root` | 1309 |
| `<h2>` / `<section id>` | 8 / 8 |
| crawl links from #71 | 13, intact |
| `<title>` | How to Play Racehorse Dominoes |
| canonical | `https://playracehorse.com/learn/how-to-play` |
| og:url / og:title / description | correct |

Other routes are untouched — they still emit their short lede, `ARTICLES` is keyed by path.

## Guard

`client/scripts/howToPlayArticle.test.ts` (5 tests) holds the word count above 800, requires every section to have a heading and real body, requires unique anchor ids, asserts the variant-specific rules are actually stated, and caps the product-name density. The first two exist so a later edit cannot quietly hollow the page back out; the fourth so the page cannot drift from the engine.

## Verification

- `npx tsc -b` clean
- client: 197 files, 1344 tests passing (+5)
- server: 185 files, 1044 tests passing
- lint: 401 warnings, 0 errors — at budget, unchanged
- `npm run build` clean, 18 routes prerendered, sitemap 14 urls

🤖 Generated with [Claude Code](https://claude.com/claude-code)