### PR TITLE
fix(ranking): score a forfeit as a loss for the player who quit

### DIFF
--- a/server/src/multiplayer/roomForfeit.test.ts
+++ b/server/src/multiplayer/roomForfeit.test.ts
@@ -113,7 +113,7 @@ describe('applyActiveMatchForfeit', () => {
     expect(io.to).not.toHaveBeenCalled();
   });
 
-  it('does not trigger Glicko updates when max score is < 10', async () => {
+  it('rates a forfeit below 10 points — there is no early-abandonment escape hatch', async () => {
     const roomCode = 'FORF2';
     createReservedRoom(roomCode);
     joinRoom(roomCode, 'p1');
@@ -141,8 +141,12 @@ describe('applyActiveMatchForfeit', () => {
       userId: 'u1',
     });
 
-    expect(processRealtimeMultiplayerGame).not.toHaveBeenCalled();
-    expect(insertRankedGameIdempotent).not.toHaveBeenCalled();
+    expect(insertRankedGameIdempotent).toHaveBeenCalledTimes(2);
+    expect(processRealtimeMultiplayerGame).toHaveBeenCalledTimes(1);
+    // p1 quit while ahead 5-0 and still takes the loss.
+    expect(insertRankedGameIdempotent).toHaveBeenCalledWith(
+      expect.objectContaining({ playerId: 'u1', outcome: 'loss' }),
+    );
   });
 
   it('triggers Glicko updates with scale 1.0 on manual forfeit when max score is >= 10', async () => {
@@ -465,5 +469,177 @@ describe('tournament forfeit apply durability (G2)', () => {
 
     expect(room.abandonedAt).toEqual(expect.any(String));
     expect(room.tournamentForfeitApplyStatus).toBe('succeeded');
+  });
+});
+
+describe('forfeit rating outcome is decided by who quit, not by the scoreboard', () => {
+  beforeEach(() => {
+    resetLiveRoomPersistenceForTests();
+    setLiveRoomPersistenceShuttingDown(true);
+    resetRoomRuntimeForTests();
+    vi.mocked(processRealtimeMultiplayerGame).mockClear();
+    vi.mocked(insertRankedGameIdempotent).mockClear();
+
+    initRoomSession({} as any, {
+      resolveSocketIdentity: async () => ({ username: 'Player', userId: 'u1' }),
+      normalizeUsername: (value) => (typeof value === 'string' && value.trim() ? value.trim() : 'Guest'),
+      normalizeUserId: (value) => (typeof value === 'string' && value.trim() ? value.trim() : null),
+      tryHydrateMatchmakingRoomShell: async () => 'skipped',
+      waitUntilMatchmakingRoomSocketsReady: async () => undefined,
+      onAfterMatchStarted: async () => undefined,
+      notifyRoomPlayersInGame: () => undefined,
+      persistRoomMatchLog: persistRoomMatchLogMock,
+      onGameOver: () => null,
+    });
+  });
+
+  afterEach(() => {
+    resetLiveRoomPersistenceForTests();
+  });
+
+  async function forfeitWithScores(
+    roomCode: string,
+    abandonerScore: number,
+    opponentScore: number,
+    reason: 'manual' | 'disconnect_timeout' = 'manual',
+  ) {
+    createReservedRoom(roomCode);
+    joinRoom(roomCode, 'p1');
+    joinRoom(roomCode, 'p2');
+    setRoomRoster(roomCode, [
+      { id: 'p1', socketId: 'sock-p1', username: 'P1', userId: 'u1' },
+      { id: 'p2', socketId: 'sock-p2', username: 'P2', userId: 'u2' },
+    ]);
+    const room = getRoom(roomCode);
+    room.state = {
+      config: { scoringMultiple: 5, winningScore: 60 },
+      playerIds: ['p1', 'p2'],
+      players: {
+        p1: { id: 'p1', hand: [], score: abandonerScore },
+        p2: { id: 'p2', hand: [], score: opponentScore },
+      },
+    } as any;
+
+    const io = makeIo();
+    const socket = { id: 'sock-p1', data: { userId: 'u1' } } as any;
+    return applyActiveMatchForfeit(
+      io,
+      socket,
+      roomCode,
+      { id: 'p1', username: 'P1', userId: 'u1' },
+      reason,
+    );
+  }
+
+  it('marks the abandoner as the loser when they quit while AHEAD on points', async () => {
+    const result = await forfeitWithScores('FSIGN1', 40, 20);
+
+    // Match history already had this right; the rating write now agrees with it.
+    expect(result).toEqual({ winnerUserId: 'u2' });
+
+    expect(insertRankedGameIdempotent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        playerId: 'u1',
+        opponentId: 'u2',
+        playerScore: 40,
+        opponentScore: 20,
+        outcome: 'loss',
+      }),
+    );
+    expect(insertRankedGameIdempotent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        playerId: 'u2',
+        opponentId: 'u1',
+        playerScore: 20,
+        opponentScore: 40,
+        outcome: 'win',
+      }),
+    );
+  });
+
+  it('passes the outcomes through to the Glicko update, not just the inserted row', async () => {
+    await forfeitWithScores('FSIGN2', 40, 20);
+
+    expect(processRealtimeMultiplayerGame).toHaveBeenCalledWith(
+      expect.objectContaining({
+        playerAOutcome: 'loss',
+        playerBOutcome: 'win',
+      }),
+    );
+  });
+
+  it('keeps the already-correct result when the abandoner quit while BEHIND', async () => {
+    await forfeitWithScores('FSIGN3', 20, 40);
+
+    expect(insertRankedGameIdempotent).toHaveBeenCalledWith(
+      expect.objectContaining({ playerId: 'u1', outcome: 'loss' }),
+    );
+    expect(insertRankedGameIdempotent).toHaveBeenCalledWith(
+      expect.objectContaining({ playerId: 'u2', outcome: 'win' }),
+    );
+  });
+
+  it('marks the abandoner as the loser from a level scoreboard', async () => {
+    await forfeitWithScores('FSIGN4', 30, 30);
+
+    expect(insertRankedGameIdempotent).toHaveBeenCalledWith(
+      expect.objectContaining({ playerId: 'u1', outcome: 'loss' }),
+    );
+    expect(insertRankedGameIdempotent).toHaveBeenCalledWith(
+      expect.objectContaining({ playerId: 'u2', outcome: 'win' }),
+    );
+  });
+
+  it('applies the same sign on a disconnect timeout, at half weight', async () => {
+    await forfeitWithScores('FSIGN5', 55, 5, 'disconnect_timeout');
+
+    expect(processRealtimeMultiplayerGame).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ratingScale: 0.5,
+        playerAOutcome: 'loss',
+        playerBOutcome: 'win',
+      }),
+    );
+  });
+
+  it('orients the outcome by seat, not by argument order, when seat B abandons', async () => {
+    const roomCode = 'FSIGN6';
+    createReservedRoom(roomCode);
+    joinRoom(roomCode, 'p1');
+    joinRoom(roomCode, 'p2');
+    setRoomRoster(roomCode, [
+      { id: 'p1', socketId: 'sock-p1', username: 'P1', userId: 'u1' },
+      { id: 'p2', socketId: 'sock-p2', username: 'P2', userId: 'u2' },
+    ]);
+    const room = getRoom(roomCode);
+    room.state = {
+      config: { scoringMultiple: 5, winningScore: 60 },
+      playerIds: ['p1', 'p2'],
+      players: {
+        p1: { id: 'p1', hand: [], score: 10 },
+        p2: { id: 'p2', hand: [], score: 45 },
+      },
+    } as any;
+
+    const io = makeIo();
+    const socket = { id: 'sock-p2', data: { userId: 'u2' } } as any;
+    await applyActiveMatchForfeit(
+      io,
+      socket,
+      roomCode,
+      { id: 'p2', username: 'P2', userId: 'u2' },
+      'manual',
+    );
+
+    // Seat A is p1 (the stayer) — playerA is the seat, not the abandoner.
+    expect(processRealtimeMultiplayerGame).toHaveBeenCalledWith(
+      expect.objectContaining({
+        playerAOutcome: 'win',
+        playerBOutcome: 'loss',
+      }),
+    );
+    expect(insertRankedGameIdempotent).toHaveBeenCalledWith(
+      expect.objectContaining({ playerId: 'u2', outcome: 'loss' }),
+    );
   });
 });

--- a/server/src/multiplayer/roomForfeit.ts
+++ b/server/src/multiplayer/roomForfeit.ts
@@ -11,6 +11,7 @@ import {
   requireRoomSessionHandlerDeps,
 } from './roomSession';
 import { processRealtimeMultiplayerGame, type RealtimeRatingResult, type Profile } from '../ranking/periodService';
+import type { MatchOutcome } from '../ranking/glicko2';
 import { insertRankedGameIdempotent } from '../ranking/insertRankedGameIdempotent';
 import { supabaseFetch } from '../supabaseUtils';
 import type { ProfileRow } from '../supabaseTypes';
@@ -211,22 +212,29 @@ export async function applyActiveMatchForfeit(
   const b = roster.find((p) => p.id === bId) ?? { id: bId, socketId: '', username: 'Guest', userId: null };
 
   // Glicko writes on forfeit use the actual room.state scores at the moment of
-  // forfeit — never a synthesized/inflated number. A forfeit at a low score
-  // genuinely produces a small expected-score delta for the winner; if that's
-  // an undesirable product outcome, the fix is a Glicko K-factor/period design
-  // change, not fabricating a score here.
+  // forfeit — never a synthesized/inflated number. The scores are the record of
+  // where the match stood; they do NOT decide the rating result.
   const loserActualScore = room.state?.players[abandoningPlayer.id]?.score ?? 0;
   const winnerActualScore = opponentSeatId ? (room.state?.players[opponentSeatId]?.score ?? 0) : 0;
 
-  const scoreA = abandoningPlayer.id === aId ? loserActualScore : winnerActualScore;
-  const scoreB = abandoningPlayer.id === aId ? winnerActualScore : loserActualScore;
+  const abandonerIsSeatA = abandoningPlayer.id === aId;
+  const scoreA = abandonerIsSeatA ? loserActualScore : winnerActualScore;
+  const scoreB = abandonerIsSeatA ? winnerActualScore : loserActualScore;
 
-  if (
-    isPrivate &&
-    a.userId &&
-    b.userId &&
-    Math.max(loserActualScore, winnerActualScore) >= 10
-  ) {
+  // The player who quit is the loser, whatever the scoreboard said when they
+  // left. Without this the Glicko term falls back to comparing scores, and a
+  // player who abandons while ahead is rated as the winner — disagreeing with
+  // the `winnerUserId` that match history records. Rating and history must tell
+  // the same story.
+  const outcomeA: MatchOutcome = abandonerIsSeatA ? 'loss' : 'win';
+  const outcomeB: MatchOutcome = abandonerIsSeatA ? 'win' : 'loss';
+
+  // Every forfeit is rated. There is deliberately no minimum-score threshold:
+  // one was here before and it meant a player who quit early recorded nothing
+  // at all, which is a free way to dodge a bad deal. A forfeit at 5-0 is a real
+  // loss; Glicko already scales the delta by how expected that result was, so a
+  // short match does not need a separate escape hatch.
+  if (isPrivate && a.userId && b.userId) {
     try {
       const [profilesA, profilesB] = await Promise.all([
         supabaseFetch<ProfileRow[]>(`/rest/v1/profiles?id=eq.${a.userId}`),
@@ -248,6 +256,7 @@ export async function applyActiveMatchForfeit(
             ratingBefore: profileA.glicko_rating ?? 0,
             rdBefore: profileA.glicko_rd ?? 0,
             playedAt: nowIso,
+            outcome: outcomeA,
             source: { sourceType: 'live_room', sourceMatchId },
           }),
           insertRankedGameIdempotent({
@@ -259,6 +268,7 @@ export async function applyActiveMatchForfeit(
             ratingBefore: profileB.glicko_rating ?? 0,
             rdBefore: profileB.glicko_rd ?? 0,
             playedAt: nowIso,
+            outcome: outcomeB,
             source: { sourceType: 'live_room', sourceMatchId },
           }),
         ]);
@@ -271,6 +281,8 @@ export async function applyActiveMatchForfeit(
             playerAGame: insertA.game,
             playerBGame: insertB.game,
             ratingScale,
+            playerAOutcome: outcomeA,
+            playerBOutcome: outcomeB,
           });
 
           log.info(
@@ -280,6 +292,8 @@ export async function applyActiveMatchForfeit(
               winnerId: winnerUserId,
               forfeitReason,
               ratingScale,
+              outcomeA,
+              outcomeB,
               deltaA: ratingResult.playerA.delta,
               deltaB: ratingResult.playerB.delta,
             },

--- a/server/src/ranking/forfeitOutcomeDurability.test.ts
+++ b/server/src/ranking/forfeitOutcomeDurability.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { buildRankedGameInsertPayload } from './rankedGamePayload';
+import { processRatingPeriod } from './periodService';
+import { DEFAULT_RD, DEFAULT_VOL } from './glicko2';
+import { supabaseFetch } from '../supabaseUtils';
+
+vi.mock('../supabaseUtils', () => ({
+  supabaseFetch: vi.fn(),
+}));
+
+const mockedSupabaseFetch = vi.mocked(supabaseFetch);
+
+const OUTCOME_FLAG = 'RANKED_GAMES_OUTCOME_COLUMN_ENABLED';
+
+describe('ranked_games outcome column', () => {
+  const original = process.env[OUTCOME_FLAG];
+
+  afterEach(() => {
+    if (original === undefined) delete process.env[OUTCOME_FLAG];
+    else process.env[OUTCOME_FLAG] = original;
+  });
+
+  const base = {
+    playerId: 'u1',
+    opponentId: 'u2',
+    playerScore: 40,
+    opponentScore: 20,
+    gameType: 'multiplayer',
+    ratingBefore: 1500,
+    rdBefore: 200,
+    playedAt: '2026-08-28T00:00:00.000Z',
+  };
+
+  it('writes the outcome when the column is enabled', () => {
+    process.env[OUTCOME_FLAG] = 'true';
+    expect(buildRankedGameInsertPayload({ ...base, outcome: 'loss' })).toMatchObject({
+      player_score: 40,
+      opponent_score: 20,
+      outcome: 'loss',
+    });
+  });
+
+  it('omits the outcome when the column is not enabled, so the insert still succeeds', () => {
+    delete process.env[OUTCOME_FLAG];
+    expect(buildRankedGameInsertPayload({ ...base, outcome: 'loss' })).not.toHaveProperty('outcome');
+  });
+
+  it('omits the outcome for a match with no explicit result', () => {
+    process.env[OUTCOME_FLAG] = 'true';
+    expect(buildRankedGameInsertPayload(base)).not.toHaveProperty('outcome');
+  });
+});
+
+describe('deferred rating period honours a persisted forfeit outcome', () => {
+  const profile = {
+    id: 'u1',
+    username: 'quitter',
+    glicko_rating: 1500,
+    glicko_rd: DEFAULT_RD,
+    glicko_vol: DEFAULT_VOL,
+    glicko_last_period: null,
+    ranked_games_played: 30,
+    peak_rating: 1500,
+    provisional: false,
+  };
+
+  function mockWith(outcome: 'win' | 'loss' | null) {
+    mockedSupabaseFetch.mockImplementation(async (path: string) => {
+      if (path === '/rest/v1/profiles?id=eq.u1') return [profile] as never;
+      if (path === '/rest/v1/profiles?id=eq.u2') {
+        return [{ ...profile, id: 'u2', username: 'stayer' }] as never;
+      }
+      if (path.startsWith('/rest/v1/ranked_games?player_id=eq.u1')) {
+        return [
+          {
+            id: 'g1',
+            player_id: 'u1',
+            opponent_id: 'u2',
+            // Quit while ahead 40-20.
+            player_score: 40,
+            opponent_score: 20,
+            played_at: '2026-08-28T00:00:00.000Z',
+            outcome,
+          },
+        ] as never;
+      }
+      return [] as never;
+    });
+  }
+
+  beforeEach(() => {
+    mockedSupabaseFetch.mockReset();
+  });
+
+  it('scores a persisted forfeit loss as a loss despite the winning scoreline', async () => {
+    mockWith('loss');
+    const result = await processRatingPeriod('u1');
+    expect(result.delta).toBeLessThan(0);
+    expect(result.newRating).toBeLessThan(1500);
+  });
+
+  it('still derives the result from scores when the row carries no outcome', async () => {
+    mockWith(null);
+    const result = await processRatingPeriod('u1');
+    expect(result.delta).toBeGreaterThan(0);
+  });
+});

--- a/server/src/ranking/glicko2.test.ts
+++ b/server/src/ranking/glicko2.test.ts
@@ -214,3 +214,50 @@ describe('constants', () => {
     expect(DEFAULT_RD).toBeGreaterThan(100);
   });
 });
+
+describe('computeGlicko2 explicit outcome', () => {
+  const evenPlayer = { rating: 1500, rd: 200, vol: DEFAULT_VOL, gamesPlayed: 30 };
+  const evenOpponent = { rating: 1500, rd: 200 };
+
+  it('scores an explicit loss as a loss even when the player led on points', () => {
+    const { newRating } = computeGlicko2(evenPlayer, [
+      { opponent: evenOpponent, result: { score: 40, opponentScore: 20, outcome: 'loss' } },
+    ]);
+    expect(newRating).toBeLessThan(evenPlayer.rating);
+  });
+
+  it('scores an explicit win as a win even when the player trailed on points', () => {
+    const { newRating } = computeGlicko2(evenPlayer, [
+      { opponent: evenOpponent, result: { score: 20, opponentScore: 40, outcome: 'win' } },
+    ]);
+    expect(newRating).toBeGreaterThan(evenPlayer.rating);
+  });
+
+  it('is symmetric: an explicit loss costs exactly what the mirrored win pays', () => {
+    const loser = computeGlicko2(evenPlayer, [
+      { opponent: evenOpponent, result: { score: 40, opponentScore: 20, outcome: 'loss' } },
+    ]);
+    const winner = computeGlicko2(evenPlayer, [
+      { opponent: evenOpponent, result: { score: 20, opponentScore: 40, outcome: 'win' } },
+    ]);
+    expect(loser.newRating - 1500).toBeCloseTo(1500 - winner.newRating, 6);
+  });
+
+  it('falls back to the score comparison when no outcome is supplied', () => {
+    const withoutOutcome = computeGlicko2(evenPlayer, [
+      { opponent: evenOpponent, result: { score: 40, opponentScore: 20 } },
+    ]);
+    const withWin = computeGlicko2(evenPlayer, [
+      { opponent: evenOpponent, result: { score: 40, opponentScore: 20, outcome: 'win' } },
+    ]);
+    expect(withoutOutcome.newRating).toBeGreaterThan(evenPlayer.rating);
+    expect(withoutOutcome.newRating).toBeCloseTo(withWin.newRating, 10);
+  });
+
+  it('treats an explicit draw as a draw regardless of the score gap', () => {
+    const { newRating } = computeGlicko2(evenPlayer, [
+      { opponent: evenOpponent, result: { score: 40, opponentScore: 20, outcome: 'draw' } },
+    ]);
+    expect(newRating).toBeCloseTo(evenPlayer.rating, 6);
+  });
+});

--- a/server/src/ranking/glicko2.ts
+++ b/server/src/ranking/glicko2.ts
@@ -33,9 +33,33 @@ export interface GlickoOpponent {
   rd: number;
 }
 
+/**
+ * How a rated match actually ended, from the subject player's point of view.
+ *
+ * A match that ends by forfeit does not have a trustworthy score signal: the
+ * abandoning player can be ahead on points at the moment they quit. Callers
+ * that know the real result — forfeits, and anything else where the winner is
+ * decided by something other than the scoreboard — must pass it explicitly.
+ */
+export type MatchOutcome = 'win' | 'loss' | 'draw';
+
 export interface GlickoResult {
   score: number;
   opponentScore: number;
+  /**
+   * Authoritative result. When present it decides the Glicko win/loss term and
+   * the scores are carried for the record only. When absent, the scores decide
+   * it — correct for a match played to its natural conclusion.
+   */
+  outcome?: MatchOutcome;
+}
+
+/** Glicko's `s_j` term: 1 win, 0 loss, 0.5 draw. */
+export function scoreOutcome(result: GlickoResult): number {
+  if (result.outcome) {
+    return result.outcome === 'win' ? 1 : result.outcome === 'loss' ? 0 : 0.5;
+  }
+  return result.score > result.opponentScore ? 1 : result.score < result.opponentScore ? 0 : 0.5;
 }
 
 const SCALE = 173.7178;
@@ -77,7 +101,7 @@ export function computeGlicko2(
     const { mu: mu_j, phi: phi_j } = toGlicko2(game.opponent.rating, game.opponent.rd);
     const gj = g(phi_j);
     const ej = E(mu, mu_j, phi_j);
-    const sj = game.result.score > game.result.opponentScore ? 1 : game.result.score < game.result.opponentScore ? 0 : 0.5;
+    const sj = scoreOutcome(game.result);
 
     vInv += gj * gj * ej * (1 - ej);
     deltaSum += gj * (sj - ej);

--- a/server/src/ranking/insertRankedGameIdempotent.ts
+++ b/server/src/ranking/insertRankedGameIdempotent.ts
@@ -1,4 +1,5 @@
 import { supabaseFetch } from '../supabaseUtils';
+import type { MatchOutcome } from './glicko2';
 import {
   buildRankedGameInsertPayload,
   isRankedGameSourceColumnsEnabled,
@@ -16,6 +17,7 @@ export type InsertedRankedGameRow = {
   delta?: number | null;
   source_type?: string | null;
   source_match_id?: string | null;
+  outcome?: MatchOutcome | null;
 };
 
 export type InsertRankedGameResult =

--- a/server/src/ranking/periodService.ts
+++ b/server/src/ranking/periodService.ts
@@ -1,5 +1,5 @@
 
-import { computeGlicko2, decayRD, DEFAULT_RATING, DEFAULT_RD, DEFAULT_VOL, getFritzConfig, isFritzId } from './glicko2';
+import { computeGlicko2, decayRD, DEFAULT_RATING, DEFAULT_RD, DEFAULT_VOL, getFritzConfig, isFritzId, type MatchOutcome } from './glicko2';
 import { supabaseFetch } from '../supabaseUtils';
 
 export interface Profile {
@@ -23,6 +23,12 @@ interface RankedGame {
   played_at: string;
   rating_after?: number | null;
   delta?: number | null;
+  /**
+   * Set when the scoreboard does not decide the result (forfeits). Null on
+   * rows written before the column shipped, and on matches played to their
+   * natural conclusion — both correctly fall back to comparing scores.
+   */
+  outcome?: MatchOutcome | null;
 }
 
 interface ProcessRatingPeriodOptions {
@@ -87,12 +93,22 @@ async function getOpponentSnapshot(opponentId: string): Promise<OpponentSnapshot
   };
 }
 
+type CommitOptions = {
+  /** Multiplier on the resulting delta (disconnect forfeits count half). */
+  scale?: number;
+  /**
+   * Overrides the row's own `outcome`. The inline realtime path passes this so
+   * the forfeit sign is right even when the `outcome` column is not enabled yet.
+   */
+  outcome?: MatchOutcome;
+};
+
 async function commitProcessedGame(
   profile: Profile,
   game: RankedGame,
   opponent: OpponentSnapshot,
   processedAt: string,
-  scale?: number,
+  options: CommitOptions = {},
 ): Promise<{
   profile: Profile;
   newRating: number;
@@ -109,12 +125,17 @@ async function commitProcessedGame(
     [
       {
         opponent,
-        result: { score: game.player_score, opponentScore: game.opponent_score },
+        result: {
+          score: game.player_score,
+          opponentScore: game.opponent_score,
+          outcome: options.outcome ?? game.outcome ?? undefined,
+        },
       },
     ],
   );
 
   const newGamesPlayed = profile.ranked_games_played + 1;
+  const { scale } = options;
   let delta = result.newRating - profile.glicko_rating;
   if (scale != null && Number.isFinite(scale)) {
     delta = delta * scale;
@@ -252,6 +273,13 @@ export async function processRealtimeMultiplayerGame(params: {
   playerAGame: RankedGame;
   playerBGame: RankedGame;
   ratingScale?: number;
+  /**
+   * Authoritative results for a match the scoreboard does not decide. Forfeits
+   * pass these so the player who quit is scored as the loser whatever the
+   * points said when they left. Omit for a match played to its conclusion.
+   */
+  playerAOutcome?: MatchOutcome;
+  playerBOutcome?: MatchOutcome;
 }) {
   const processedAt = new Date().toISOString();
 
@@ -264,7 +292,7 @@ export async function processRealtimeMultiplayerGame(params: {
         rd: params.playerBProfile.glicko_rd,
       },
       processedAt,
-      params.ratingScale,
+      { scale: params.ratingScale, outcome: params.playerAOutcome },
     ),
     commitProcessedGame(
       params.playerBProfile,
@@ -274,7 +302,7 @@ export async function processRealtimeMultiplayerGame(params: {
         rd: params.playerAProfile.glicko_rd,
       },
       processedAt,
-      params.ratingScale,
+      { scale: params.ratingScale, outcome: params.playerBOutcome },
     ),
   ]);
 

--- a/server/src/ranking/rankedGamePayload.ts
+++ b/server/src/ranking/rankedGamePayload.ts
@@ -1,3 +1,5 @@
+import type { MatchOutcome } from './glicko2';
+
 export type RankedGameSourceType =
   | 'live_room'
   | 'verified_single_player'
@@ -20,6 +22,13 @@ export interface RankedGameInsertInput {
   playedAt: string;
   ratingAfter?: number | null;
   source?: RankedGameSource | null;
+  /**
+   * Authoritative result when the scoreboard does not decide it — a forfeit is
+   * a loss for the player who quit even if they were ahead on points.
+   * Persisted so the deferred rating-period path scores the row the same way
+   * the inline path did. Requires RANKED_GAMES_OUTCOME_COLUMN_ENABLED=true.
+   */
+  outcome?: MatchOutcome | null;
 }
 
 export interface RankedGameInsertPayload {
@@ -34,10 +43,22 @@ export interface RankedGameInsertPayload {
   rating_after?: number | null;
   source_type?: RankedGameSourceType;
   source_match_id?: string;
+  outcome?: MatchOutcome;
 }
 
 export function isRankedGameSourceColumnsEnabled(): boolean {
   return process.env.RANKED_GAMES_SOURCE_COLUMNS_ENABLED === 'true';
+}
+
+/**
+ * The `outcome` column ships behind a flag so a server running ahead of the
+ * migration does not fail every ranked insert on an unknown column. The inline
+ * rating path passes the outcome in memory regardless, so the forfeit sign is
+ * correct with the flag off; the flag only governs whether the deferred
+ * rating-period path can recover it from the row.
+ */
+export function isRankedGameOutcomeColumnEnabled(): boolean {
+  return process.env.RANKED_GAMES_OUTCOME_COLUMN_ENABLED === 'true';
 }
 
 export function buildRankedGameInsertPayload(input: RankedGameInsertInput): RankedGameInsertPayload {
@@ -54,6 +75,10 @@ export function buildRankedGameInsertPayload(input: RankedGameInsertInput): Rank
 
   if (input.ratingAfter !== undefined) {
     payload.rating_after = input.ratingAfter;
+  }
+
+  if (isRankedGameOutcomeColumnEnabled() && input.outcome) {
+    payload.outcome = input.outcome;
   }
 
   const sourceMatchId = input.source?.sourceMatchId?.trim();

--- a/supabase/migrations/2026-08-28_ranked_games_outcome.sql
+++ b/supabase/migrations/2026-08-28_ranked_games_outcome.sql
@@ -1,0 +1,22 @@
+-- Records how a rated match actually ended, for matches the scoreboard does
+-- not decide. A forfeit is a loss for the player who quit even when they were
+-- ahead on points; without this column the deferred rating-period path
+-- recomputes the Glicko win/loss term from player_score vs opponent_score and
+-- credits the quitter with a win.
+--
+-- Requires RANKED_GAMES_OUTCOME_COLUMN_ENABLED=true on the server.
+-- Null means "decide from the scores", which is correct for every match played
+-- to its natural conclusion and for all rows written before this shipped.
+
+alter table public.ranked_games
+  add column if not exists outcome text null;
+
+alter table public.ranked_games
+  drop constraint if exists ranked_games_outcome_check;
+
+alter table public.ranked_games
+  add constraint ranked_games_outcome_check
+  check (outcome is null or outcome in ('win', 'loss', 'draw'));
+
+comment on column public.ranked_games.outcome is
+  'win | loss | draw from player_id''s point of view. Authoritative when set; overrides the score comparison. Null = derive from scores.';


### PR DESCRIPTION
Fixes the Critical finding from the multiplayer integrity audit.

## The bug

`glicko2.ts` derived the win/loss term (`sj`) purely from `score > opponentScore`, and there is no outcome/winner column on `ranked_games`. The forfeit path in `roomForfeit.ts` writes the *real* room scores at the moment of abandonment.

So a player who quit while ahead was scored as the **winner**. Measured through the real code at even ratings (1500/RD 200):

| | rating change |
|---|---|
| Player who quit while leading 40–20 | **+78.8** |
| Player who stayed | **−78.8** |

Match history was already right — `winnerUserId` correctly records the opponent. Only the rating disagreed.

## The fix

`GlickoResult` gains an optional `outcome: 'win' | 'loss' | 'draw'`. When set it decides `sj`; when absent the scores decide it, exactly as before. `roomForfeit` derives the outcome from *who forfeited* and passes it through `processRealtimeMultiplayerGame`.

Scores are still written honestly — they remain the record of where the match stood, they just no longer decide the result.

### Durability

`processRatingPeriod` picks up rows the inline path failed to process and recomputes from database columns alone, so an in-memory-only signal would have left the bug alive in that path. The outcome is persisted on `ranked_games` behind `RANKED_GAMES_OUTCOME_COLUMN_ENABLED`, following the existing `RANKED_GAMES_SOURCE_COLUMNS_ENABLED` precedent so a server running ahead of the migration does not fail every ranked insert on an unknown column.

The inline path passes the outcome in memory regardless — **the forfeit sign is correct with the flag off.** The flag only governs whether the deferred path can recover it.

Migration: `supabase/migrations/2026-08-28_ranked_games_outcome.sql` (nullable column + check constraint; null means "derive from scores", correct for every existing row).

## Also fixed: the `>= 10` gate

Removed. It meant a player who quit before either side reached 10 points recorded nothing at all — a free dodge for a bad deal, and the second High finding in the audit.

I chose "rate every forfeit" over a documented grace window because with the sign fixed there is nothing left for a threshold to protect against: Glicko already scales the delta by how expected the result was, so a forfeit at 5–0 produces a proportionately small change on its own. Any threshold is an exploitable window, and "records nothing" inside it is the same dodge in a nicer wrapper.

## Not in scope

The disconnect-stall bug (a disconnected player holding a legal play never gets an auto-act or forfeit at grace expiry) needs a turn-clock design decision.

**Confirmed this change does not make it worse:** it touches only what happens once `applyActiveMatchForfeit` is reached. Timer scheduling, the auto-act branch, and the `disconnectExpiries` counter are untouched. The ranked write stays inside the existing try/catch, so the forfeit itself still completes if Supabase fails.

## Tests

TDD throughout — every test below failed before the corresponding change.

- `glicko2.test.ts` — explicit outcome overrides the scoreline both directions; symmetry; falls back to scores when absent; draw.
- `roomForfeit.test.ts` — abandoner is the loser when ahead / behind / level; outcomes reach the Glicko call, not just the row; correct orientation when seat B abandons; disconnect timeout keeps the sign at half weight; sub-10 forfeits are now rated.
- `forfeitOutcomeDurability.test.ts` — payload includes/omits `outcome` per the flag; the deferred rating period scores a persisted forfeit loss as a loss despite a winning scoreline, and still uses scores when the row has none.

**Verification:** server 1068 tests / 186 files pass; client 1317 tests / 192 files pass; `tsc --noEmit` (server) and `tsc -b` (client) both clean.

## Blast radius: zero — no backfill needed

Read-only query against production. All 467 `ranked_games` rows pulled; 34 are `game_type='multiplayer'`, spanning 2026-04-06 → 2026-07-09.

**Every one reached the winning target** (winner-side score 60–80). A forfeit is blocked once `gameOver` is set, so a score ≥ 60 means the match completed naturally. No row has `source_type='live_room'` either.

**0 rows were written by the forfeit path, so 0 are affected.** Nothing to correct. (Separately: `matchmaking_matches` does not exist in this database — the quick-match funnel has not been deployed here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)