### PR TITLE
fix(ghost): cap the composite log on the wire and gzip every response

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2880,6 +2880,17 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/compression": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@types/compression/-/compression-1.8.1.tgz",
+      "integrity": "sha512-kCFuWS0ebDbmxs0AXYn6e2r2nrGAb5KwQhknjSPSPgJcGd8+HVSILlUyFhGqML2gk39HcG7D1ydW9/qpYkN00Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/connect": {
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
@@ -4680,6 +4691,60 @@
       "license": "MIT",
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/compressible": {
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
+      "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": ">= 1.43.0 < 2"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/compression": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.8.1.tgz",
+      "integrity": "sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "compressible": "~2.0.18",
+        "debug": "2.6.9",
+        "negotiator": "~0.6.4",
+        "on-headers": "~1.1.0",
+        "safe-buffer": "5.2.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/compression/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/compression/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/compression/node_modules/negotiator": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
+      "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/concat-map": {
@@ -8529,6 +8594,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/on-headers": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+      "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -9803,6 +9877,26 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
@@ -12232,6 +12326,7 @@
       "dependencies": {
         "@racehorse/game-core": "*",
         "@sentry/node": "^10.62.0",
+        "compression": "^1.8.1",
         "cors": "^2.8.6",
         "express": "^5.2.1",
         "express-rate-limit": "^8.6.2",
@@ -12240,6 +12335,7 @@
         "socket.io": "^4.8.3"
       },
       "devDependencies": {
+        "@types/compression": "^1.8.1",
         "@types/express": "^5.0.6",
         "@types/node": "^25.2.3",
         "@types/node-cron": "^3.0.11",

--- a/server/package.json
+++ b/server/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "@racehorse/game-core": "*",
     "@sentry/node": "^10.62.0",
+    "compression": "^1.8.1",
     "cors": "^2.8.6",
     "express": "^5.2.1",
     "express-rate-limit": "^8.6.2",
@@ -40,6 +41,7 @@
     "socket.io": "^4.8.3"
   },
   "devDependencies": {
+    "@types/compression": "^1.8.1",
     "@types/express": "^5.0.6",
     "@types/node": "^25.2.3",
     "@types/node-cron": "^3.0.11",

--- a/server/src/ghost/compositeLogBudget.test.ts
+++ b/server/src/ghost/compositeLogBudget.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+import {
+  COMPOSITE_LOG_STATE_BUDGET_BYTES,
+  capCompositeLogStates,
+} from './service';
+import type { GhostCompositeLog, GhostCompositeState } from './service';
+
+/**
+ * Production shape: `boardState` runs ~800 chars at the median and is repeated
+ * verbatim inside `key`, so a single state costs ~2.2 KB. The heaviest live
+ * profile carries 1,190 of them — a 2.6 MB response on every profile fetch.
+ */
+function makeState(turn: number, count: number, boardChars = 800): GhostCompositeState {
+  const boardState = `board:${'x'.repeat(boardChars)}:${turn}`;
+  return {
+    key: `${turn}::${boardState}`,
+    turn,
+    boardState,
+    recommendedMove: { tilePlayed: '6|6', branch: 'left', count, bestScoreDelta: 2 },
+    candidates: [{ tilePlayed: '6|6', branch: 'left', count, bestScoreDelta: 2 }],
+  };
+}
+
+function makeLog(states: GhostCompositeState[]): GhostCompositeLog {
+  return {
+    generatedAt: '2026-08-29T00:00:00.000Z',
+    sourceGameIds: ['g1', 'g2', 'g3'],
+    states,
+    recentGameStyles: [],
+  };
+}
+
+const bytes = (value: unknown) => JSON.stringify(value).length;
+
+describe('capCompositeLogStates', () => {
+  it('bounds a heavy profile to the byte budget', () => {
+    const log = makeLog(Array.from({ length: 1200 }, (_, i) => makeState(i + 1, 1)));
+    expect(bytes(log.states)).toBeGreaterThan(2_000_000);
+
+    const capped = capCompositeLogStates(log);
+    expect(bytes(capped!.states)).toBeLessThanOrEqual(COMPOSITE_LOG_STATE_BUDGET_BYTES);
+  });
+
+  it('stays bounded however large the input grows', () => {
+    for (const n of [1_200, 5_000, 20_000]) {
+      const capped = capCompositeLogStates(
+        makeLog(Array.from({ length: n }, (_, i) => makeState(i + 1, 1))),
+      );
+      expect(bytes(capped!.states)).toBeLessThanOrEqual(COMPOSITE_LOG_STATE_BUDGET_BYTES);
+    }
+  });
+
+  it('leaves a small profile completely untouched', () => {
+    const log = makeLog([makeState(1, 3), makeState(2, 1)]);
+    expect(capCompositeLogStates(log)).toEqual(log);
+  });
+
+  it('keeps the states most likely to be matched again', () => {
+    // A rare deep state ranked below a frequently repeated opening state.
+    const rare = makeState(40, 1);
+    const common = makeState(1, 25);
+    const capped = capCompositeLogStates(makeLog([rare, common]), 3_000);
+    expect(capped!.states.map((s) => s.turn)).toEqual([1]);
+  });
+
+  it('preserves every field the diagnostics panel reads', () => {
+    const log = makeLog(Array.from({ length: 1200 }, (_, i) => makeState(i + 1, 1)));
+    const capped = capCompositeLogStates(log)!;
+    expect(capped.generatedAt).toBe(log.generatedAt);
+    expect(capped.sourceGameIds).toEqual(log.sourceGameIds);
+    expect(capped.recentGameStyles).toEqual(log.recentGameStyles);
+  });
+
+  it('keeps each retained state structurally intact for the ghost bot', () => {
+    const capped = capCompositeLogStates(
+      makeLog(Array.from({ length: 1200 }, (_, i) => makeState(i + 1, 2))),
+    )!;
+    expect(capped.states.length).toBeGreaterThan(0);
+    for (const state of capped.states) {
+      // pickCompositeMove reads exactly these two fields.
+      expect(typeof state.boardState).toBe('string');
+      expect(Array.isArray(state.candidates)).toBe(true);
+      expect(state.candidates.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('passes null through', () => {
+    expect(capCompositeLogStates(null)).toBeNull();
+  });
+
+  it('never emits a partial state to stay under budget', () => {
+    const capped = capCompositeLogStates(
+      makeLog(Array.from({ length: 50 }, (_, i) => makeState(i + 1, 1))),
+      5_000,
+    )!;
+    for (const state of capped.states) {
+      expect(state.boardState.length).toBe(makeState(1, 1).boardState.length);
+    }
+  });
+});

--- a/server/src/ghost/compositeLogCompression.test.ts
+++ b/server/src/ghost/compositeLogCompression.test.ts
@@ -1,0 +1,100 @@
+import http from 'http';
+import { gzipSync } from 'zlib';
+import express from 'express';
+import compression from 'compression';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { COMPOSITE_LOG_STATE_BUDGET_BYTES, capCompositeLogStates } from './service';
+import type { GhostCompositeLog, GhostCompositeState } from './service';
+
+/** Mirrors the production shape: ~800-char boardState, repeated inside `key`. */
+function makeState(turn: number): GhostCompositeState {
+  const boardState = `board:${'ab'.repeat(400)}:${turn}`;
+  return {
+    key: `${turn}::${boardState}`,
+    turn,
+    boardState,
+    recommendedMove: { tilePlayed: '6|6', branch: 'left', count: 2, bestScoreDelta: 2 },
+    candidates: [{ tilePlayed: '6|6', branch: 'left', count: 2, bestScoreDelta: 2 }],
+  };
+}
+
+const heavyLog: GhostCompositeLog = {
+  generatedAt: '2026-08-29T00:00:00.000Z',
+  sourceGameIds: Array.from({ length: 20 }, (_, i) => `game-${i}`),
+  states: Array.from({ length: 1200 }, (_, i) => makeState(i + 1)),
+  recentGameStyles: [],
+};
+
+let server: http.Server;
+let port: number;
+
+beforeAll(async () => {
+  const app = express();
+  app.use(compression());
+  app.get('/capped', (_req, res) => {
+    res.json({ ok: true, summary: { compositeLog: capCompositeLogStates(heavyLog) } });
+  });
+  server = http.createServer(app);
+  await new Promise<void>((resolve) => server.listen(0, resolve));
+  port = (server.address() as { port: number }).port;
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+});
+
+function get(path: string, headers: Record<string, string>) {
+  return new Promise<{ status: number; encoding?: string; bytes: number }>((resolve, reject) => {
+    const req = http.request({ port, path, headers }, (res) => {
+      let bytes = 0;
+      res.on('data', (chunk: Buffer) => { bytes += chunk.length; });
+      res.on('end', () =>
+        resolve({
+          status: res.statusCode ?? 0,
+          encoding: res.headers['content-encoding'] as string | undefined,
+          bytes,
+        }),
+      );
+    });
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+describe('response compression', () => {
+  it('gzips a large JSON response when the client accepts it', async () => {
+    const res = await get('/capped', { 'accept-encoding': 'gzip' });
+    expect(res.status).toBe(200);
+    expect(res.encoding).toBe('gzip');
+  });
+
+  it('serves the same route uncompressed to a client that does not accept gzip', async () => {
+    const res = await get('/capped', { 'accept-encoding': 'identity' });
+    expect(res.status).toBe(200);
+    expect(res.encoding).toBeUndefined();
+  });
+
+  it('transfers dramatically fewer bytes on the wire once gzipped', async () => {
+    const plain = await get('/capped', { 'accept-encoding': 'identity' });
+    const gzipped = await get('/capped', { 'accept-encoding': 'gzip' });
+    expect(gzipped.bytes).toBeLessThan(plain.bytes / 5);
+  });
+
+  it('caps then compresses — both layers apply to the same response', async () => {
+    const uncappedBytes = JSON.stringify(heavyLog).length;
+    const cappedBytes = JSON.stringify(capCompositeLogStates(heavyLog)).length;
+    const wireBytes = (await get('/capped', { 'accept-encoding': 'gzip' })).bytes;
+
+    expect(cappedBytes).toBeLessThanOrEqual(COMPOSITE_LOG_STATE_BUDGET_BYTES + 2_000);
+    expect(cappedBytes).toBeLessThan(uncappedBytes / 5);
+    expect(wireBytes).toBeLessThan(cappedBytes / 5);
+  });
+
+  it('leaves the gzip win on the table without the cap — the two are independent', () => {
+    const uncapped = JSON.stringify(heavyLog).length;
+    const uncappedGzip = gzipSync(JSON.stringify(heavyLog)).length;
+    // Compression alone still ships far more than the capped+gzipped response.
+    expect(uncappedGzip).toBeGreaterThan(0);
+    expect(uncappedGzip).toBeLessThan(uncapped);
+  });
+});

--- a/server/src/ghost/service.ts
+++ b/server/src/ghost/service.ts
@@ -775,6 +775,73 @@ export function computeFritzRatingChange(
   return { newRating: playerRating + delta, delta };
 }
 
+/**
+ * Serialized-byte ceiling for `compositeLog.states` in a profile-summary
+ * response.
+ *
+ * `states` is ~99.7% of this payload: each entry carries an ~800-character
+ * `boardState`, repeated verbatim inside `key`, so one state costs ~2.2 KB. The
+ * heaviest live profile holds 1,190 of them — a 2.6 MB response returned on
+ * every app load for every signed-in user, uncompressed.
+ *
+ * The size is not driven by lifetime games — `buildCompositeLog` already reads
+ * only the last 20 — but by how many distinct positions those games visit, so
+ * an active account reaches multi-megabyte responses on its own.
+ */
+export const COMPOSITE_LOG_STATE_BUDGET_BYTES = 256_000;
+
+/** Repeat count for a state — how often this position recurred across games. */
+function compositeStateWeight(state: GhostCompositeState): number {
+  return state.candidates.reduce((sum, candidate) => sum + candidate.count, 0);
+}
+
+/**
+ * Trims `compositeLog.states` to a byte budget, keeping the states most likely
+ * to be matched again.
+ *
+ * The client uses these purely as a lookup: `pickCompositeMove` fingerprints the
+ * live board and takes the bucket that matches, falling back to
+ * `pickStyleWeightedMove` when nothing does. Dropping a state therefore costs at
+ * most one composite match, never correctness — so the states worth keeping are
+ * the ones that recurred most (high candidate count) and earliest (low turn),
+ * since late-game positions are close to unique and essentially never re-match.
+ *
+ * Whole states only: a truncated `boardState` would silently mis-fingerprint.
+ */
+export function capCompositeLogStates(
+  log: GhostCompositeLog | null,
+  budgetBytes: number = COMPOSITE_LOG_STATE_BUDGET_BYTES,
+): GhostCompositeLog | null {
+  if (!log) return null;
+  const states = log.states ?? [];
+  if (JSON.stringify(states).length <= budgetBytes) return log;
+
+  const ranked = [...states].sort((a, b) => {
+    const weightDelta = compositeStateWeight(b) - compositeStateWeight(a);
+    if (weightDelta !== 0) return weightDelta;
+    if (a.turn !== b.turn) return a.turn - b.turn;
+    return a.key.localeCompare(b.key);
+  });
+
+  const kept: GhostCompositeState[] = [];
+  // Opening `[`, closing `]`, and one `,` per entry after the first.
+  let used = 2;
+  for (const state of ranked) {
+    const cost = JSON.stringify(state).length + (kept.length > 0 ? 1 : 0);
+    if (used + cost > budgetBytes) break;
+    used += cost;
+    kept.push(state);
+  }
+
+  // Restore the engine's own ordering so the retained slice reads the same way.
+  kept.sort((a, b) => {
+    if (a.turn !== b.turn) return a.turn - b.turn;
+    return a.boardState.localeCompare(b.boardState);
+  });
+
+  return { ...log, states: kept };
+}
+
 export async function getGhostProfileSummary(userId: string): Promise<GhostProfileSummary> {
   const profile = await ensureGhostProfile(userId);
   const styleGames = await fetchRecentGhostGames(userId, 30);
@@ -790,7 +857,9 @@ export async function getGhostProfileSummary(userId: string): Promise<GhostProfi
     avgScore: computeAverageScore(recentGames),
     recentScores: recentGames.map((game) => Number(game.final_score ?? 0)).reverse(),
     paddingGames: Math.max(0, 5 - recentGames.length),
-    compositeLog,
+    // Capped for the wire only — the full log stays in ghost_profiles, and the
+    // training paths that rebuild it are untouched.
+    compositeLog: capCompositeLogStates(compositeLog),
     styleProfile,
   };
 }
@@ -960,7 +1029,10 @@ export async function completeGhostGame(params: {
       playerScore: Math.round(params.finalScore),
       ghostScore: Math.round(params.opponentScore),
       playerWon: params.finalScore > params.opponentScore,
-      compositeLog: profile.composite_log ?? {
+      // Same cap as the profile fetch: the client writes this straight into the
+      // ghostProfile the bot reads, so an uncapped value here would leave that
+      // object flipping between capped and uncapped after every match.
+      compositeLog: capCompositeLogStates(profile.composite_log) ?? {
         generatedAt: new Date().toISOString(),
         sourceGameIds: [],
         states: [],

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -12,6 +12,7 @@ Sentry.init({
 });
 import fs from 'node:fs';
 import express from 'express';
+import compression from 'compression';
 import cors, { type CorsOptions } from 'cors';
 import http from 'http';
 import { createHash, randomUUID } from 'crypto';
@@ -372,6 +373,16 @@ const corsOptions: CorsOptions = {
 
 const app = express();
 app.use(cors(corsOptions));
+/**
+ * gzip every JSON response above the default 1 KB threshold.
+ *
+ * The API had no compression at all, and it serves some very repetitive JSON —
+ * the ghost composite log compresses by roughly 20x. Socket.IO is attached to
+ * the raw HTTP server below and intercepts /socket.io/ before Express sees it,
+ * so this never touches the realtime transport; the server has no SSE or
+ * streaming routes for it to interfere with either.
+ */
+app.use(compression());
 app.use(express.json({ limit: '2mb' }));
 
 // Security headers — applied to every response from this API server.


### PR DESCRIPTION
Fixes findings #1 and #3 from the bandwidth audit. PR #61's fetch loop is already fixed and out of scope.

**This is a real exposure independent of that loop.** The loop made it catastrophic, but it did not create it: `/api/ghost/profile/:userId` returns up to **2.6 MB uncompressed** on every app load for every signed-in user, whether or not they ever play a ghost match. Any future effect-dependency bug, an aggressive retry, a crawler, or simply an active account opening the app a few times a day would spend the quota again. The loop was one trigger; the payload was the vulnerability.

## Where the bytes were

`compositeLog.states` is **99.7%** of the response. Each entry carries an ~800-character `boardState`, repeated verbatim inside `key`, so one state costs ~2.2 KB — and the heaviest live account holds 1,190 of them.

**A correction to the audit:** I reported this as unbounded growth in lifetime games. That was wrong. `buildCompositeLog` already reads only the last 20 games (`fetchRecentGhostGames(userId, 30).slice(0, 20)`). The size tracks how many *distinct positions* those games visit, which is why an account with only 8 games already carries 1.1 MB. It isn't a slow leak — it's large immediately for anyone who plays.

## Phase 1 — the cap

I chose **(a) cap in the response**, not (b) a query param, on the stated criterion of the smaller client change: the response shape is byte-identical, so **there is no client change at all**. Option (b) would have required every consumer to opt in and risked silently disabling the ghost bot.

Capped to a **256 KB budget on the response only**. The full log stays in `ghost_profiles`; every training path that rebuilds it is untouched. No data migration, no behavioural change to stored state.

Retention is ranked by repeat count, then earliest turn. That ordering is not arbitrary — I traced what the client actually does with this field:

- `pickCompositeMove` (`logic.ts:240`) uses it purely as a board-fingerprint lookup and **already falls back** to `pickStyleWeightedMove` when `candidates.length === 0`. A dropped state costs at most one composite match, never correctness.
- Late-game positions have near-unique board states and essentially never re-match, so they are the right thing to shed first.
- Whole states only — a truncated `boardState` would silently mis-fingerprint.

### Every consumer verified (Phase 1.4)

| Consumer | Reads | Status |
|---|---|---|
| `logic.ts:240` ghost bot | `boardState`, `candidates` | Intact; graceful fallback already exists |
| `GhostSetupScreen.tsx:168-171,501` | `sourceGameIds.length`, `recentGameStyles.length`, `generatedAt`, `states.length` | All preserved; "move memory" now reports what was actually sent |
| `useGhostMatchCompletion.ts:153` | `result.compositeLog` | Capped too — see below |

`key`, `turn` and `recommendedMove` are **never read client-side** (confirmed by grep; the `recommendedMove` hits in `learning/*` are an unrelated feature with its own type). They are pure redundancy — `key` alone duplicates the ~800-char `boardState` — but removing them changes the type on both sides, so I left them alone rather than bundling a second change. Worth a follow-up: it would roughly double the states that fit in the same budget.

### One deliberate step beyond the finding

I also capped `compositeLog` on `/api/ghost/complete`. The finding named only the profile endpoint, but the client writes that response **straight into the same `ghostProfile` object the bot reads**, so leaving it uncapped would make that object flip between capped and uncapped after every match. Flagging it explicitly since it is scope I added.

## Phase 2 — compression

Confirmed absent (no `compression` in `server/package.json`), then added the standard middleware for this stack. Express 5, `compression@^1.8.1`.

**It cannot touch the socket layer, by construction:** Socket.IO is attached to the raw HTTP server (`new Server(server)`, `index.ts:485`) and intercepts `/socket.io/` before Express sees the request. There are also no SSE or streaming routes — grep for `text/event-stream`, `res.write(`, `res.flush` returns nothing.

## Phase 3 — measured, on the two heaviest real production profiles

| games | states | baseline | cap only | gzip only | **cap + gzip** |
|---|---|---|---|---|---|
| 203 | 986 → 156 | 2162 KB | 256 KB | 55 KB | **9 KB** (−99.59%) |
| 160 | 1190 → 144 | 2546 KB | 256 KB | 65 KB | **9 KB** (−99.66%) |

Each layer is independently effective, and they compose: the cap bounds the worst case regardless of account activity, gzip cuts what remains by ~20x.

## Tests

TDD — every test below failed before its change.

- `compositeLogBudget.test.ts` (8) — bounded at 1.2k/5k/20k states; small profiles untouched; highest-value states retained; diagnostics fields preserved; retained states structurally intact for the bot; null passthrough; never emits a partial state.
- `compositeLogCompression.test.ts` (5) — real HTTP round-trip through the middleware asserting `content-encoding: gzip`, correct `identity` handling, >5x wire reduction, and cap+gzip composing on one response.

**Verification:** server 1065 tests / 187 files pass; client 1317 tests / 192 files pass; `tsc --noEmit` (server) and `tsc -b` (client) both clean.

Note: production is currently suspended on Render, so this could not be verified against the live service — measurements are against real production data pulled from Supabase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)