### PR TITLE
perf(ghost): stop fetching ten games that are immediately discarded

### DIFF
--- a/server/src/ghost/ghostGamesFetchLimit.test.ts
+++ b/server/src/ghost/ghostGamesFetchLimit.test.ts
@@ -1,4 +1,20 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * ghost/service.ts captures SUPABASE_URL / SUPABASE_SERVICE_KEY into module
+ * constants at import time, so setting them in beforeEach is too late — the
+ * import has already run. Locally Vitest loads server/.env and they happen to
+ * be present; CI has no secrets, so the module captured undefined and every
+ * test threw "SUPABASE_URL is required".
+ *
+ * vi.hoisted runs before the imports below, which is the only place this can be
+ * set from inside the test file.
+ */
+vi.hoisted(() => {
+  process.env.SUPABASE_URL ||= 'https://stub.supabase.co';
+  process.env.SUPABASE_SERVICE_KEY ||= 'stub-service-key';
+});
+
 import { getGhostProfileSummary } from './service';
 
 /**
@@ -74,11 +90,6 @@ function stubSupabase(games: ReturnType<typeof game>[], honourLimit = true) {
 const gamesQuery = () => requestedPaths.find((p) => p.includes('/rest/v1/ghost_games')) ?? '';
 
 describe('ghost_games fetch limit', () => {
-  beforeEach(() => {
-    process.env.SUPABASE_URL ??= 'https://stub.supabase.co';
-    process.env.SUPABASE_SERVICE_KEY ??= 'stub-key';
-  });
-
   afterEach(() => {
     vi.unstubAllGlobals();
   });

--- a/server/src/ghost/ghostGamesFetchLimit.test.ts
+++ b/server/src/ghost/ghostGamesFetchLimit.test.ts
@@ -1,0 +1,147 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { getGhostProfileSummary } from './service';
+
+/**
+ * ghost/service.ts carries its own module-local supabaseFetch that calls global
+ * fetch directly, so the shared supabaseUtils mock does not reach it. Stub the
+ * transport instead — this also keeps the test hermetic.
+ */
+const USER = '00000000-0000-4000-8000-000000000abc';
+
+function moveLog(turn: number) {
+  return [
+    {
+      turn,
+      actor: 'you',
+      tile_played: '6|6',
+      branch: 'left',
+      board_state: `board:${'x'.repeat(40)}:${turn}`,
+      hand_before: ['6|6', '3|4'],
+      score_delta: 5,
+      hand_number: 1,
+    },
+  ];
+}
+
+function game(i: number, analyzable = true) {
+  return {
+    id: `game-${i}`,
+    user_id: USER,
+    played_at: `2026-08-${String(28 - (i % 27)).padStart(2, '0')}T00:00:00.000Z`,
+    final_score: 60,
+    opponent_score: 30,
+    move_log: analyzable ? moveLog((i % 5) + 1) : [],
+  };
+}
+
+let requestedPaths: string[] = [];
+
+/** @param honourLimit false reproduces the old behaviour: always hand back all 30. */
+function stubSupabase(games: ReturnType<typeof game>[], honourLimit = true) {
+  requestedPaths = [];
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (url: URL | string) => {
+      const path = String(url);
+      requestedPaths.push(path);
+      let body: unknown = [];
+      if (path.includes('/rest/v1/ghost_profiles')) {
+        body = [
+          {
+            user_id: USER,
+            ghost_rating: 900,
+            last_updated: null,
+            composite_log: null,
+            style_profile: null,
+            games_played: games.length,
+          },
+        ];
+      } else if (path.includes('/rest/v1/ghost_games')) {
+        const match = /limit=(\d+)/.exec(path);
+        const limit = honourLimit && match ? Number(match[1]) : games.length;
+        body = games.slice(0, limit);
+      }
+      return {
+        ok: true,
+        status: 200,
+        json: async () => body,
+        text: async () => JSON.stringify(body),
+      } as unknown as Response;
+    }),
+  );
+}
+
+const gamesQuery = () => requestedPaths.find((p) => p.includes('/rest/v1/ghost_games')) ?? '';
+
+describe('ghost_games fetch limit', () => {
+  beforeEach(() => {
+    process.env.SUPABASE_URL ??= 'https://stub.supabase.co';
+    process.env.SUPABASE_SERVICE_KEY ??= 'stub-key';
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('requests only the 20 games buildCompositeLog actually consumes', async () => {
+    stubSupabase(Array.from({ length: 30 }, (_, i) => game(i)));
+    await getGhostProfileSummary(USER);
+    expect(gamesQuery()).toContain('limit=20');
+    expect(gamesQuery()).not.toContain('limit=30');
+  });
+
+  it('makes exactly two Supabase reads per call', async () => {
+    stubSupabase(Array.from({ length: 30 }, (_, i) => game(i)));
+    await getGhostProfileSummary(USER);
+    expect(requestedPaths).toHaveLength(2);
+  });
+
+  it('produces identical output to the 30-game fetch when every game is analyzable', async () => {
+    const games = Array.from({ length: 30 }, (_, i) => game(i));
+    const pin = (s: Awaited<ReturnType<typeof getGhostProfileSummary>>) =>
+      JSON.stringify({
+        ...s,
+        compositeLog: s.compositeLog ? { ...s.compositeLog, generatedAt: 'pinned' } : null,
+      });
+
+    stubSupabase(games, true);
+    const withTwenty = pin(await getGhostProfileSummary(USER));
+    vi.unstubAllGlobals();
+
+    stubSupabase(games, false); // old behaviour: 30 rows returned regardless
+    const withThirty = pin(await getGhostProfileSummary(USER));
+
+    expect(withTwenty).toBe(withThirty);
+  });
+
+  it('still fills 20 style snapshots from 20 analyzable games', async () => {
+    stubSupabase(Array.from({ length: 30 }, (_, i) => game(i)));
+    const summary = await getGhostProfileSummary(USER);
+    expect(summary.compositeLog?.recentGameStyles).toHaveLength(20);
+  });
+
+  it('sources composite states from the 20 most recent games only', async () => {
+    stubSupabase(Array.from({ length: 30 }, (_, i) => game(i)));
+    const summary = await getGhostProfileSummary(USER);
+    expect(summary.compositeLog?.sourceGameIds).toHaveLength(20);
+    expect(summary.compositeLog?.sourceGameIds).not.toContain('game-20');
+  });
+
+  /**
+   * The one case where 20 and 30 genuinely differ. `analyzeGameStyle` returns
+   * null for a game with no analyzable player moves, and the old code filtered
+   * before slicing — so it could reach into games 21-30 to top the list back up
+   * to 20. Fetching 20 cannot.
+   *
+   * No production account hits this today: the only two with more than 20 games
+   * have zero unanalyzable games in their most recent 30, and every other
+   * account has fewer than 20 games in total. The aggregate this feeds is
+   * "recent style", which a fixed recent window describes better than reaching
+   * further back for filler.
+   */
+  it('yields fewer snapshots when some of the recent 20 are unanalyzable — the accepted tradeoff', async () => {
+    stubSupabase(Array.from({ length: 30 }, (_, i) => game(i, i >= 3)));
+    const summary = await getGhostProfileSummary(USER);
+    expect(summary.compositeLog?.recentGameStyles).toHaveLength(17);
+  });
+});

--- a/server/src/ghost/service.ts
+++ b/server/src/ghost/service.ts
@@ -279,6 +279,16 @@ async function ensureGhostProfile(userId: string): Promise<GhostProfileRow> {
   });
 }
 
+/**
+ * How many recent games the composite log is built from.
+ *
+ * `buildCompositeLog` slices to 20 for both `states` and `recentGameStyles`, so
+ * fetching more than this pulls `move_log` blobs (median 86 KB each) that are
+ * parsed, analysed and then discarded. At 30 that was ~860 KB of wasted
+ * Supabase transfer on every profile fetch for an active account.
+ */
+export const GHOST_COMPOSITE_GAME_WINDOW = 20;
+
 async function fetchRecentGhostGames(userId: string, limit = 5): Promise<GhostGameRow[]> {
   return await supabaseFetch<GhostGameRow[]>(
     `/rest/v1/ghost_games?select=id,user_id,played_at,final_score,opponent_score,move_log` +
@@ -716,7 +726,9 @@ function buildCompositeLog(
       return analyzeGameStyle(game);
     })
     .filter((entry): entry is GhostGameStyleSnapshot => Boolean(entry))
-    .slice(0, 20);
+    // Redundant now that the caller fetches exactly this many, kept as the bound
+    // of record so a wider fetch cannot silently widen the style window.
+    .slice(0, GHOST_COMPOSITE_GAME_WINDOW);
 
   return {
     generatedAt: new Date().toISOString(),
@@ -777,8 +789,8 @@ export function computeFritzRatingChange(
 
 export async function getGhostProfileSummary(userId: string): Promise<GhostProfileSummary> {
   const profile = await ensureGhostProfile(userId);
-  const styleGames = await fetchRecentGhostGames(userId, 30);
-  const recentGames = styleGames.slice(0, 20);
+  const styleGames = await fetchRecentGhostGames(userId, GHOST_COMPOSITE_GAME_WINDOW);
+  const recentGames = styleGames.slice(0, GHOST_COMPOSITE_GAME_WINDOW);
   const compositeLog = recentGames.length > 0 ? buildCompositeLog(recentGames, styleGames, profile.composite_log) : null;
   const styleProfile = compositeLog
     ? buildStyleProfileFromSnapshots(compositeLog.recentGameStyles)
@@ -827,8 +839,8 @@ async function persistFritzGhostTrainingProfile(params: {
     matchId: params.matchId,
   });
 
-  const styleGames = await fetchRecentGhostGames(params.userId, 30);
-  const recentGames = styleGames.slice(0, 20);
+  const styleGames = await fetchRecentGhostGames(params.userId, GHOST_COMPOSITE_GAME_WINDOW);
+  const recentGames = styleGames.slice(0, GHOST_COMPOSITE_GAME_WINDOW);
   const compositeLog = buildCompositeLog(recentGames, styleGames, params.profile.composite_log);
   const styleProfile = buildStyleProfileFromSnapshots(compositeLog.recentGameStyles);
   // Same fail-closed contract as the profiles.glicko_rating write this
@@ -984,8 +996,8 @@ export async function completeGhostGame(params: {
     matchId: params.matchId,
   });
 
-  const styleGames = await fetchRecentGhostGames(params.userId, 30);
-  const recentGames = styleGames.slice(0, 20);
+  const styleGames = await fetchRecentGhostGames(params.userId, GHOST_COMPOSITE_GAME_WINDOW);
+  const recentGames = styleGames.slice(0, GHOST_COMPOSITE_GAME_WINDOW);
   const compositeLog = buildCompositeLog(recentGames, styleGames, profile.composite_log);
   const styleProfile = buildStyleProfileFromSnapshots(compositeLog.recentGameStyles);
 


### PR DESCRIPTION
Part of the Service-Initiated bandwidth work. **Independent of #74** — that one caps `composite_log` on the way out to the browser; this one stops pulling data in from Supabase that was never used.

## The waste

`fetchRecentGhostGames(userId, 30)` asked for 30 games, but `buildCompositeLog` only ever consumes 20:

- `states` and `sourceGameIds` come from `styleGames.slice(0, 20)`
- `recentGameStyles` ran `analyzeGameStyle` over **all 30** and *then* sliced to 20

So ten `move_log` blobs — median 86 KB each — were transferred, parsed, analysed and thrown away on every call.

All three call sites shared the pattern, including the two on the completion path that run once per finished match, so all three now go through one named constant (`GHOST_COMPOSITE_GAME_WINDOW`).

## Measured on the two heaviest live accounts

| account | games | games query | total Supabase read per call |
|---|---|---|---|
| `3d70f65e` | 203 | 2.10 → **1.37 MB** | 4.34 → **3.60 MB** |
| `889bf1a4` | 160 | 2.46 → **1.61 MB** | 5.09 → **4.25 MB** |

Roughly a 17% cut to Service-Initiated per profile fetch. Modest on its own — the `composite_log` pull is still the bigger half — but it is free.

## This is not quite the pure no-op it looks like

The brief assumed the change would be byte-identical because the extra ten games were unused. That is true for `states`, but **not unconditionally true for `recentGameStyles`**, and the difference is worth stating rather than discovering later:

`analyzeGameStyle` returns `null` for a game with no analyzable player moves (`service.ts:502`, and again at `playCount === 0`). The old code **filtered before slicing**, so with 30 rows in hand it could reach into games 21–30 to top the list back up to 20. Fetching 20 cannot.

I checked this against live data rather than reasoning about it:

- **27% of all `ghost_games` rows have empty `move_log`s** — so the null path is real, not hypothetical.
- But the only two accounts with more than 20 games have **zero** unanalyzable games in their most recent 30.
- Every other account has fewer than 20 games in total, so a limit of 20 and a limit of 30 return the same rows anyway.

**Output is therefore identical for every account in production today.** The divergence needs an active account to accumulate an unanalyzable game inside its recent 20. When that happens, the aggregate this feeds is "recent style", which a fixed recent window describes better than reaching further back for filler — so I took the simpler semantics deliberately rather than preserving the old top-up behaviour.

A test pins that tradeoff explicitly so it is recorded rather than implicit.

## Tests

6 new, in `ghostGamesFetchLimit.test.ts`. Verified they genuinely regress: reverting the constant to 30 fails 4 of them.

- requests `limit=20`, not `limit=30`
- exactly two Supabase reads per call
- identical output to the 30-game fetch when every game is analyzable
- 20 style snapshots still filled from 20 analyzable games
- composite states sourced from the 20 most recent only
- the documented divergence when some of the recent 20 are unanalyzable

Note: `ghost/service.ts` carries its own module-local `supabaseFetch` that calls global `fetch` directly rather than going through `supabaseUtils`, so the test stubs the transport. That also keeps it hermetic — my first attempt at this test reached real Supabase, which is worth knowing for anyone testing this module. (It also means this module bypasses the shared circuit breaker and timing spans; out of scope here.)

**Verification:** server 1058 tests / 186 files pass; client 1317 tests / 192 files pass; `tsc --noEmit` (server) and `tsc -b` (client) both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)