### PR TITLE
perf(ghost): read only the style snapshots the summary path actually uses

### DIFF
--- a/server/src/ghost/ghostProfileSelect.test.ts
+++ b/server/src/ghost/ghostProfileSelect.test.ts
@@ -1,4 +1,19 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * ghost/service.ts captures SUPABASE_URL / SUPABASE_SERVICE_KEY into module
+ * constants at import time, so setting them in beforeEach is too late — the
+ * import has already run. Locally Vitest loads server/.env and they happen to
+ * be present; CI has no secrets, so the module captured undefined and the tests
+ * threw "SUPABASE_URL is required" before reaching an assertion.
+ *
+ * vi.hoisted runs before the imports below.
+ */
+vi.hoisted(() => {
+  process.env.SUPABASE_URL ||= 'https://stub.supabase.co';
+  process.env.SUPABASE_SERVICE_KEY ||= 'stub-service-key';
+});
+
 import { buildCompositeLog, getGhostProfileSummary } from './service';
 
 /**
@@ -119,11 +134,6 @@ const pin = (s: Awaited<ReturnType<typeof getGhostProfileSummary>>) =>
   });
 
 describe('ghost profile select narrowing', () => {
-  beforeEach(() => {
-    process.env.SUPABASE_URL ??= 'https://stub.supabase.co';
-    process.env.SUPABASE_SERVICE_KEY ??= 'stub-key';
-  });
-
   afterEach(() => {
     vi.unstubAllGlobals();
   });

--- a/server/src/ghost/ghostProfileSelect.test.ts
+++ b/server/src/ghost/ghostProfileSelect.test.ts
@@ -1,0 +1,194 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { buildCompositeLog, getGhostProfileSummary } from './service';
+
+/**
+ * `buildCompositeLog` reads exactly one thing off the stored log —
+ * `recentGameStyles`, to reuse already-computed style snapshots. `states` is
+ * rebuilt from the games' move logs on every call, so pulling the stored copy
+ * (2.6 MB on the heaviest live account) transfers 2.59 MB that is discarded.
+ *
+ * These tests pin the narrowed query and prove the discard is genuinely a
+ * discard: the summary must be identical whether the row arrives with the whole
+ * column or only the sub-field.
+ */
+const USER = '00000000-0000-4000-8000-000000000abc';
+
+function moveLog(turn: number) {
+  return [
+    {
+      turn,
+      actor: 'you',
+      tile_played: '6|6',
+      branch: 'left',
+      board_state: `board:${'x'.repeat(40)}:${turn}`,
+      hand_before: ['6|6', '3|4'],
+      score_delta: 5,
+      hand_number: 1,
+    },
+  ];
+}
+
+function game(i: number) {
+  return {
+    id: `game-${i}`,
+    user_id: USER,
+    played_at: `2026-08-${String(28 - (i % 27)).padStart(2, '0')}T00:00:00.000Z`,
+    final_score: 60,
+    opponent_score: 30,
+    move_log: moveLog((i % 5) + 1),
+  };
+}
+
+const GAMES = Array.from({ length: 20 }, (_, i) => game(i));
+
+/** A stored log whose `states` differ wildly from anything rebuildable. */
+const STORED_STATES = [
+  {
+    key: '99::board:poisoned',
+    turn: 99,
+    boardState: 'board:poisoned',
+    recommendedMove: { tilePlayed: '0|0', branch: 'left', count: 999, bestScoreDelta: 99 },
+    candidates: [{ tilePlayed: '0|0', branch: 'left', count: 999, bestScoreDelta: 99 }],
+  },
+];
+
+const STORED_STYLES = [
+  {
+    gameId: 'game-0',
+    playedAt: '2026-08-28T00:00:00.000Z',
+    avgTurnPoints: 12.5,
+    handSize: 4.25,
+    doublesRate: 0.5,
+    branchRate: 0.25,
+    forcedDrawRate: 0.1,
+    scoringConversion: 0.75,
+    spinnerControl: 0.4,
+    attackRate: 0.3,
+  },
+];
+
+let requestedPaths: string[] = [];
+
+type StoredLog = {
+  generatedAt?: string;
+  sourceGameIds?: string[];
+  states?: unknown[];
+  recentGameStyles?: unknown[];
+} | null;
+
+/**
+ * Emulates PostgREST: when the select names the sub-field alias, Postgres
+ * projects it server-side and `states` never leaves the database. Both branches
+ * are fed from the same stored row so the equality test is meaningful.
+ */
+function stubSupabase(storedLog: StoredLog) {
+  requestedPaths = [];
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (url: URL | string) => {
+      const path = String(url);
+      requestedPaths.push(path);
+      let body: unknown = [];
+      if (path.includes('/rest/v1/ghost_profiles')) {
+        const narrowed = path.includes('composite_log-%3ErecentGameStyles');
+        const base = { user_id: USER, ghost_rating: 900, games_played: GAMES.length };
+        body = [
+          narrowed
+            ? { ...base, recentGameStyles: storedLog?.recentGameStyles ?? null }
+            : { ...base, last_updated: null, composite_log: storedLog, style_profile: null },
+        ];
+      } else if (path.includes('/rest/v1/ghost_games')) {
+        body = GAMES;
+      }
+      return {
+        ok: true,
+        status: 200,
+        json: async () => body,
+        text: async () => JSON.stringify(body),
+      } as unknown as Response;
+    }),
+  );
+}
+
+const profileQuery = () => requestedPaths.find((p) => p.includes('/rest/v1/ghost_profiles')) ?? '';
+
+const pin = (s: Awaited<ReturnType<typeof getGhostProfileSummary>>) =>
+  JSON.stringify({
+    ...s,
+    compositeLog: s.compositeLog ? { ...s.compositeLog, generatedAt: 'pinned' } : null,
+  });
+
+describe('ghost profile select narrowing', () => {
+  beforeEach(() => {
+    process.env.SUPABASE_URL ??= 'https://stub.supabase.co';
+    process.env.SUPABASE_SERVICE_KEY ??= 'stub-key';
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('asks for the recentGameStyles sub-field, not the whole composite_log column', async () => {
+    stubSupabase({ recentGameStyles: STORED_STYLES }, 'composite_log');
+    await getGhostProfileSummary(USER);
+
+    expect(profileQuery()).toContain('composite_log-%3ErecentGameStyles');
+    expect(profileQuery()).not.toMatch(/select=[^&]*[,=]composite_log(?![-%])/);
+  });
+
+  it('still issues exactly two Supabase reads', async () => {
+    stubSupabase({ recentGameStyles: STORED_STYLES });
+    await getGhostProfileSummary(USER);
+    expect(requestedPaths).toHaveLength(2);
+  });
+
+  it('rebuilds byte-identical states from the sub-field as from the whole column', () => {
+    const fullLog = {
+      generatedAt: '2026-01-01T00:00:00.000Z',
+      sourceGameIds: ['old-1', 'old-2'],
+      states: STORED_STATES,
+      recentGameStyles: STORED_STYLES,
+    } as never;
+    const subFieldOnly = { recentGameStyles: STORED_STYLES } as never;
+
+    const fromFull = buildCompositeLog(GAMES as never, GAMES as never, fullLog);
+    const fromSub = buildCompositeLog(GAMES as never, GAMES as never, subFieldOnly);
+
+    // The bot's entire input.
+    expect(JSON.stringify(fromSub.states)).toBe(JSON.stringify(fromFull.states));
+    // And everything else the summary carries.
+    expect(JSON.stringify(fromSub.recentGameStyles)).toBe(JSON.stringify(fromFull.recentGameStyles));
+    expect(fromSub.sourceGameIds).toEqual(fromFull.sourceGameIds);
+  });
+
+  it('never lets a stored state reach the bot — states are always rebuilt from move logs', async () => {
+    stubSupabase({
+      generatedAt: '2026-01-01T00:00:00.000Z',
+      sourceGameIds: ['old'],
+      states: STORED_STATES,
+      recentGameStyles: STORED_STYLES,
+    });
+    const summary = await getGhostProfileSummary(USER);
+
+    const keys = summary.compositeLog?.states.map((s) => s.key) ?? [];
+    expect(keys.length).toBeGreaterThan(0);
+    expect(keys).not.toContain('99::board:poisoned');
+    for (const state of summary.compositeLog?.states ?? []) {
+      expect(state.boardState).toContain('board:xxx');
+    }
+  });
+
+  it('reuses stored style snapshots, which is the only thing the sub-field is for', async () => {
+    stubSupabase({ recentGameStyles: STORED_STYLES });
+    const summary = await getGhostProfileSummary(USER);
+    const reused = summary.compositeLog?.recentGameStyles.find((s) => s.gameId === 'game-0');
+    expect(reused?.avgTurnPoints).toBe(12.5);
+  });
+
+  it('handles a profile with no stored log at all', async () => {
+    stubSupabase(null);
+    const summary = await getGhostProfileSummary(USER);
+    expect(summary.compositeLog?.states.length).toBeGreaterThan(0);
+    expect(summary.compositeLog?.recentGameStyles.length).toBeGreaterThan(0);
+  });
+});

--- a/server/src/ghost/service.ts
+++ b/server/src/ghost/service.ts
@@ -181,6 +181,29 @@ function normalizeMoveLog(raw: unknown): GhostMoveLogEntry[] {
     .filter((entry) => entry.turn > 0 && entry.board_state);
 }
 
+/**
+ * The only part of a stored composite log that rebuilding ever reads.
+ *
+ * `buildCompositeLog` uses `previousLog` solely to reuse already-computed style
+ * snapshots by game id; `states` is rebuilt from the games' move logs every
+ * time. Typing the parameter this narrowly is what keeps the sub-field select
+ * below honest — a future read of `previousLog.states` will not compile.
+ */
+export type CompositeStyleSource = Pick<GhostCompositeLog, 'recentGameStyles'>;
+
+/** Projection of ghost_profiles carrying only what the summary path needs. */
+type GhostProfileStyleRow = {
+  user_id: string;
+  ghost_rating: number;
+  games_played: number;
+  recentGameStyles: GhostGameStyleSnapshot[] | null;
+};
+
+/**
+ * Pulls the whole `composite_log` column — 2.6 MB on the heaviest live account.
+ * Reserved for paths that hand the stored log back to the client or rebuild and
+ * persist it. The summary path must use `fetchGhostProfileStyleSource`.
+ */
 async function fetchGhostProfile(userId: string): Promise<GhostProfileRow | null> {
   const rows = await supabaseFetch<GhostProfileRow[]>(
     `/rest/v1/ghost_profiles?select=user_id,ghost_rating,last_updated,composite_log,style_profile,games_played` +
@@ -264,6 +287,44 @@ async function insertGhostGameRow(params: {
     body: JSON.stringify([baseRow]),
   });
   return { isNewGame: true };
+}
+
+/**
+ * Postgres extracts the sub-field server-side, so the 2.59 MB of `states` never
+ * crosses the wire. Measured on the heaviest live profile: 2,636,850 bytes for
+ * the full column against 6,453 for this projection.
+ */
+const GHOST_PROFILE_STYLE_SELECT =
+  'user_id,ghost_rating,games_played,recentGameStyles:composite_log->recentGameStyles';
+
+async function fetchGhostProfileStyleSource(
+  userId: string,
+): Promise<GhostProfileStyleRow | null> {
+  const rows = await supabaseFetch<GhostProfileStyleRow[]>(
+    `/rest/v1/ghost_profiles?select=${GHOST_PROFILE_STYLE_SELECT}` +
+      `&user_id=eq.${encodeURIComponent(userId)}&limit=1`,
+    { method: 'GET' },
+  );
+  return rows[0] ?? null;
+}
+
+async function ensureGhostProfileStyleSource(userId: string): Promise<GhostProfileStyleRow> {
+  const existing = await fetchGhostProfileStyleSource(userId);
+  if (existing) return existing;
+  const created = await upsertGhostProfile({
+    user_id: userId,
+    ghost_rating: 800,
+    last_updated: null,
+    composite_log: null,
+    style_profile: null,
+    games_played: 0,
+  });
+  return {
+    user_id: created.user_id,
+    ghost_rating: created.ghost_rating,
+    games_played: created.games_played,
+    recentGameStyles: created.composite_log?.recentGameStyles ?? null,
+  };
 }
 
 async function ensureGhostProfile(userId: string): Promise<GhostProfileRow> {
@@ -649,10 +710,11 @@ function buildStyleProfileFromSnapshots(
   };
 }
 
-function buildCompositeLog(
+/** Exported for the equality proof in ghostProfileSelect.test.ts. */
+export function buildCompositeLog(
   games: GhostGameRow[],
   styleGames: GhostGameRow[],
-  previousLog?: GhostCompositeLog | null,
+  previousLog?: CompositeStyleSource | null,
 ): GhostCompositeLog {
   const states = new Map<
     string,
@@ -855,10 +917,14 @@ export function capCompositeLogStates(
 }
 
 export async function getGhostProfileSummary(userId: string): Promise<GhostProfileSummary> {
-  const profile = await ensureGhostProfile(userId);
+  const profile = await ensureGhostProfileStyleSource(userId);
   const styleGames = await fetchRecentGhostGames(userId, GHOST_COMPOSITE_GAME_WINDOW);
   const recentGames = styleGames.slice(0, GHOST_COMPOSITE_GAME_WINDOW);
-  const compositeLog = recentGames.length > 0 ? buildCompositeLog(recentGames, styleGames, profile.composite_log) : null;
+  const previousStyles: CompositeStyleSource | null = profile.recentGameStyles
+    ? { recentGameStyles: profile.recentGameStyles }
+    : null;
+  const compositeLog =
+    recentGames.length > 0 ? buildCompositeLog(recentGames, styleGames, previousStyles) : null;
   const styleProfile = compositeLog
     ? buildStyleProfileFromSnapshots(compositeLog.recentGameStyles)
     : null;


### PR DESCRIPTION
Implements option 2 from the "Cutting the 5 MB profile read" proposal — the recommended first step. **No caching, TTLs, or invalidation here**; that decision stays open pending re-measurement after this ships.

Separate from #74 (response cap) and #75 (games limit), following the same one-concern-per-PR pattern.

## The over-fetch

`fetchGhostProfile` pulled the entire `composite_log` column — 2.6 MB on the heaviest live account — but `getGhostProfileSummary` reads exactly one thing off it. `buildCompositeLog` takes it as `previousLog` and touches only `recentGameStyles`, reusing already-computed style snapshots by game id. `states` is rebuilt from the games' move logs on every call.

So 2.59 MB crossed the wire and was discarded, per call, purely to save some CPU.

Postgres can project the sub-field, so the summary path now selects `composite_log->recentGameStyles` and `states` never leaves the database.

## The split

The full-column read stays where it is genuinely needed. `completeGhostGame` hands `profile.composite_log` straight back to the client on its Fritz branch (`service.ts:963`) — that path needs the states. The persist paths keep the full read too rather than splitting them in the same change.

`previousLog` is now typed `Pick<GhostCompositeLog, 'recentGameStyles'>`, which turns the safety argument into a compile error rather than a comment: a future read of `previousLog.states` will not build.

## Measured live, with #75's `limit=20` in place

| account | games | profile query | total per call |
|---|---|---|---|
| `3d70f65e` | 203 | 2.239 → **0.006 MB** | 3.60 → **1.37 MB** (−61.9%) |
| `889bf1a4` | 160 | 2.637 → **0.006 MB** | 4.25 → **1.62 MB** (−62.0%) |

Against the original incident: the 3.37 GB Service-Initiated figure would have been roughly 1.07 GB with this alone.

## Proving the zero-bot-risk claim rather than asserting it

The equality test builds a composite log twice from the same games — once with a full stored log as `previousLog`, once with only its `recentGameStyles` — and asserts the rebuilt `states` are byte-identical. The stored log in that test carries a deliberately poisoned state (`99::board:poisoned`) that could not arise from the games, and a separate test asserts it never appears in the output.

That is the whole safety argument, made mechanically: the states the bot reads never came from the stored copy, so removing the stored copy from the wire cannot change them.

Two notes on how the tests got there, since both are worth knowing:

- **The equality assertion passed before the change as well.** That is not a gap in the TDD — it is the evidence for the premise. It demonstrates the discard was already real; only the query-shape test distinguishes old from new, and that one did fail first.
- **My first attempt tested the harness, not the code.** I initially forced the full-column path by rewriting the URL in the stub, which produced a difference that was an artifact of the stub rather than of the implementation. Comparing `buildCompositeLog` directly is the honest form, so `buildCompositeLog` is now exported for that purpose.

6 tests in `ghostProfileSelect.test.ts`: query selects the sub-field and not the bare column; exactly two Supabase reads; byte-identical rebuilt states; no stored state reaches the bot; stored style snapshots are still reused; a profile with no stored log still works.

**Verification:** server 1058 tests / 186 files pass; client 1317 tests / 192 files pass; `tsc --noEmit` (server) and `tsc -b` (client) both clean.

Render is still suspended, so this is measured against production Supabase data rather than confirmed end-to-end against the live service.

🤖 Generated with [Claude Code](https://claude.com/claude-code)