### PR TITLE
fix(daily-fritz): restore Return Home on the completed-set card

### DIFF
--- a/client/src/dailyFritz/DailyFritzFinalResultOverlay.test.tsx
+++ b/client/src/dailyFritz/DailyFritzFinalResultOverlay.test.tsx
@@ -57,3 +57,84 @@ describe('DailyFritzFinalResultOverlay', () => {
     cancel.mockRestore();
   });
 });
+
+/**
+ * The set-result modal routes "Return Home" through `tertiaryLabel`, not
+ * `secondaryLabel` (buildDailyFritzSetOverlayViewModel.ts:270). The dossier
+ * rebuild in #64 only carried primary and secondary over, so that button
+ * silently vanished from the completed-set card while still being present in
+ * the view model. No path ever sets both, so at most two buttons share the row.
+ */
+describe('DailyFritzFinalResultOverlay — action buttons', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  const withLabels = (extra: Record<string, unknown>) =>
+    ({ ...overlay, ...extra }) as unknown as DailyFritzSetOverlayViewModel;
+
+  it('renders the tertiary action the completed-set card uses for Return Home', () => {
+    const { getByRole } = render(
+      <DailyFritzFinalResultOverlay
+        overlay={withLabels({
+          primaryLabel: 'View Leaderboard',
+          secondaryLabel: null,
+          tertiaryLabel: 'Return Home',
+          onTertiary: () => {},
+        })}
+        shareDone={false}
+        onShare={() => {}}
+      />,
+    );
+    expect(getByRole('button', { name: 'View Leaderboard' })).toBeTruthy();
+    expect(getByRole('button', { name: 'Return Home' })).toBeTruthy();
+  });
+
+  it('gives it the same treatment as View Leaderboard, not the share button', () => {
+    const { getByRole } = render(
+      <DailyFritzFinalResultOverlay
+        overlay={withLabels({
+          primaryLabel: 'View Leaderboard',
+          secondaryLabel: null,
+          tertiaryLabel: 'Return Home',
+          onTertiary: () => {},
+        })}
+        shareDone={false}
+        onShare={() => {}}
+      />,
+    );
+    const leaderboard = getByRole('button', { name: 'View Leaderboard' });
+    const home = getByRole('button', { name: 'Return Home' });
+    expect(home.className).toBe(leaderboard.className);
+    expect(home.parentElement).toBe(leaderboard.parentElement);
+  });
+
+  it('fires onTertiary when it is pressed', () => {
+    const onTertiary = vi.fn();
+    const { getByRole } = render(
+      <DailyFritzFinalResultOverlay
+        overlay={withLabels({
+          primaryLabel: 'View Leaderboard',
+          secondaryLabel: null,
+          tertiaryLabel: 'Return Home',
+          onTertiary,
+        })}
+        shareDone={false}
+        onShare={() => {}}
+      />,
+    );
+    getByRole('button', { name: 'Return Home' }).click();
+    expect(onTertiary).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders no extra button when there is no tertiary label', () => {
+    const { queryByRole, getByRole } = render(
+      <DailyFritzFinalResultOverlay
+        overlay={withLabels({ primaryLabel: 'Back Home', secondaryLabel: null, tertiaryLabel: null })}
+        shareDone={false}
+        onShare={() => {}}
+      />,
+    );
+    expect(getByRole('button', { name: 'Back Home' })).toBeTruthy();
+    expect(queryByRole('button', { name: 'Return Home' })).toBeNull();
+  });
+});

--- a/client/src/dailyFritz/DailyFritzFinalResultOverlay.tsx
+++ b/client/src/dailyFritz/DailyFritzFinalResultOverlay.tsx
@@ -122,6 +122,17 @@ export function DailyFritzFinalResultOverlay({
                   {overlay.secondaryLabel}
                 </button>
               ) : null}
+              {/*
+                The completed-set card routes "Return Home" through tertiaryLabel
+                rather than secondaryLabel, and no path sets both — so this shares
+                the two-column row with the primary action rather than adding a
+                third column.
+              */}
+              {overlay.tertiaryLabel ? (
+                <button type="button" className="dfd__btn" onClick={overlay.onTertiary}>
+                  {overlay.tertiaryLabel}
+                </button>
+              ) : null}
             </div>
           </div>
         </div>


### PR DESCRIPTION
The completed-set modal lost its home button. It was still being built — just never drawn.

## What happened

`buildDailyFritzSetOverlayViewModel.ts:266-271` routes this card's buttons like so:

```ts
primaryLabel:   canViewLeaderboard ? 'View Leaderboard' : 'Back Home',
secondaryLabel: null,                                       // ← always null on this path
tertiaryLabel:  canViewLeaderboard ? 'Return Home' : null,  // ← the missing button
```

The old overlay rendered all three slots (`DailyFritzFinalResultOverlay.tsx:130` before #64). The dossier rebuild in `d86e14ca` rewrote the action block as a share button above a two-up row of primary + secondary, and **never carried `tertiaryLabel` across**.

No type error caught it: `tertiaryLabel` is still a valid field, just unread.

The *final* overlay was unaffected because `buildFinalOverlayViewModel.ts:142` puts "Back Home" in `secondaryLabel`, which still renders — which is exactly why only the set card lost its button.

## The fix

Renders `tertiaryLabel` as a sibling in the same `dfd__row`, with the same `dfd__btn` treatment as View Leaderboard.

It shares the row rather than adding a third column because **no path sets both `secondaryLabel` and `tertiaryLabel`** — I checked every branch in both builders. So the row still holds at most two buttons, and the existing `repeat(2, minmax(0, 1fr))` grid fills exactly. That also fixes the half-width lone button visible in the report, where the grid was reserving a second column with nothing in it.

## Tests

4 new in `DailyFritzFinalResultOverlay.test.tsx`, TDD — 3 failed before the change:

- renders the tertiary action the completed-set card uses
- gives it the same treatment as View Leaderboard (asserts identical `className` **and** the same parent element, so "same shape, same row" is mechanically pinned rather than eyeballed)
- fires `onTertiary` when pressed
- renders no extra button when `tertiaryLabel` is null

**Verification:** client 1348 tests / 197 files pass; `tsc -b` clean; lint unchanged at 401 warnings, exactly the configured `--max-warnings` budget (I checked the baseline on main is also 401, so this adds none).

Not visually confirmed in the running app — reaching this modal needs an authenticated session with a completed set for the day. The class/parent assertions cover the shape requirement; worth a glance next time you finish a set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)