### PR TITLE
feat(settings): sound preference on the Settings page, honored everywhere

### DIFF
--- a/client/src/auth/passwordRecoveryFlow.test.tsx
+++ b/client/src/auth/passwordRecoveryFlow.test.tsx
@@ -11,6 +11,13 @@ import { describe, expect, it, vi } from 'vitest';
 
 vi.mock('../multiplayer/FriendInvitePopupBridge', () => ({ FriendInvitePopupBridge: () => null }));
 
+/**
+ * AuthModalsLayer lazy-loads its modals, so the first find in each test waits
+ * on a dynamic import. Under a full parallel run that can exceed
+ * findBy's 1s default — which is a slow import, not a broken modal.
+ */
+const LAZY_IMPORT_TIMEOUT = { timeout: 10_000 };
+
 const { AuthModalsLayer } = await import('../AppOverlays');
 
 const baseProps = {
@@ -39,19 +46,22 @@ const renderLayer = (overrides: Partial<LayerProps>) =>
 describe('recovery-link password flow', () => {
   it('stays closed when no recovery is pending', async () => {
     renderLayer({ passwordRecoveryPending: false });
-    await waitFor(() => expect(screen.queryByText('Set a new password')).toBeNull());
+    // Give the lazy import the same room it gets above, then assert nothing
+    // arrived — otherwise this passes simply because the chunk had not loaded.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(screen.queryByText('Set a new password')).toBeNull();
   });
 
   it('opens on the recovery marker alone', async () => {
     renderLayer({ passwordRecoveryPending: true });
-    expect(await screen.findByText('Set a new password')).toBeTruthy();
+    expect(await screen.findByText('Set a new password', undefined, LAZY_IMPORT_TIMEOUT)).toBeTruthy();
   });
 
   it('still submits a new password through the same handler Settings uses', async () => {
     const onUpdatePassword = vi.fn(() => Promise.resolve({ error: null }));
     renderLayer({ passwordRecoveryPending: true, onUpdatePassword });
 
-    const password = await screen.findByLabelText('New password');
+    const password = await screen.findByLabelText('New password', undefined, LAZY_IMPORT_TIMEOUT);
     fireEvent.change(password, { target: { value: 'correct-horse' } });
     fireEvent.change(screen.getByLabelText('Confirm password'), {
       target: { value: 'correct-horse' },
@@ -65,7 +75,7 @@ describe('recovery-link password flow', () => {
     const onUpdatePassword = vi.fn(() => Promise.resolve({ error: null }));
     renderLayer({ passwordRecoveryPending: true, onUpdatePassword });
 
-    const password = await screen.findByLabelText('New password');
+    const password = await screen.findByLabelText('New password', undefined, LAZY_IMPORT_TIMEOUT);
     fireEvent.change(password, { target: { value: 'correct-horse' } });
     fireEvent.change(screen.getByLabelText('Confirm password'), {
       target: { value: 'correct-hoarse' },
@@ -82,7 +92,7 @@ describe('recovery-link password flow', () => {
     const onUpdatePassword = vi.fn(() => Promise.resolve({ error: null }));
     renderLayer({ passwordRecoveryPending: true, onUpdatePassword });
 
-    const password = await screen.findByLabelText('New password');
+    const password = await screen.findByLabelText('New password', undefined, LAZY_IMPORT_TIMEOUT);
     fireEvent.change(password, { target: { value: 'abc' } });
     fireEvent.change(screen.getByLabelText('Confirm password'), { target: { value: 'abc' } });
     fireEvent.click(screen.getByRole('button', { name: 'Update password' }));

--- a/client/src/bot/useBotGamePreferences.test.ts
+++ b/client/src/bot/useBotGamePreferences.test.ts
@@ -14,13 +14,6 @@ vi.mock('./pvfTierPreference', () => ({
   writeStoredPvfFritzTier: vi.fn(),
 }));
 
-vi.mock('../utils/mutePreference', () => ({
-  mutePreference: {
-    get: vi.fn(() => false),
-    set: vi.fn(),
-  },
-}));
-
 const { useBotGamePreferences } = await import('./useBotGamePreferences');
 const { writeStoredPvfFritzTier } = await import('./pvfTierPreference');
 const { mutePreference } = await import('../utils/mutePreference');
@@ -34,11 +27,11 @@ function defaultParams(overrides: Partial<Params> = {}): Params {
 describe('useBotGamePreferences — initial state', () => {
   beforeEach(() => {
     window.localStorage.clear();
-    vi.mocked(mutePreference.get).mockReturnValue(false);
+    mutePreference.set(false);
   });
 
-  it('isMuted initializes from mutePreference.get()', () => {
-    vi.mocked(mutePreference.get).mockReturnValue(true);
+  it('isMuted initializes from the stored mute preference', () => {
+    mutePreference.set(true);
     const { result } = renderHook((p: Params) => useBotGamePreferences(p), {
       initialProps: defaultParams(),
     });
@@ -81,8 +74,7 @@ describe('useBotGamePreferences — initial state', () => {
 describe('useBotGamePreferences — persistence effects', () => {
   beforeEach(() => {
     window.localStorage.clear();
-    vi.mocked(mutePreference.get).mockReturnValue(false);
-    vi.mocked(mutePreference.set).mockClear();
+    mutePreference.set(false);
     vi.mocked(writeStoredPvfFritzTier).mockClear();
   });
 
@@ -102,17 +94,17 @@ describe('useBotGamePreferences — persistence effects', () => {
     expect(writeStoredPvfFritzTier).toHaveBeenCalledWith(3);
   });
 
-  it('calls mutePreference.set on isMuted change', () => {
+  it('persists the mute preference on change', () => {
     const { result } = renderHook((p: Params) => useBotGamePreferences(p), {
       initialProps: defaultParams(),
     });
     act(() => { result.current.setIsMuted(true); });
-    expect(mutePreference.set).toHaveBeenCalledWith(true);
+    expect(mutePreference.get()).toBe(true);
   });
 });
 
 describe('useBotGamePreferences — isMutedRef sync', () => {
-  beforeEach(() => { vi.mocked(mutePreference.get).mockReturnValue(false); });
+  beforeEach(() => { mutePreference.set(false); });
 
   it('isMutedRef tracks isMuted', () => {
     const { result } = renderHook((p: Params) => useBotGamePreferences(p), {
@@ -125,7 +117,7 @@ describe('useBotGamePreferences — isMutedRef sync', () => {
 });
 
 describe('useBotGamePreferences — botSetup deal-size reset', () => {
-  beforeEach(() => { vi.mocked(mutePreference.get).mockReturnValue(false); });
+  beforeEach(() => { mutePreference.set(false); });
 
   it('resets botDealSize to 7 when appMode becomes botSetup', () => {
     const { result, rerender } = renderHook((p: Params) => useBotGamePreferences(p), {

--- a/client/src/bot/useBotGamePreferences.ts
+++ b/client/src/bot/useBotGamePreferences.ts
@@ -4,7 +4,7 @@ import type { AppMode } from '../appRouteTypes';
 import type { BotDealSize } from './botEngine';
 import type { FritzTier } from './fritzConfig';
 import { resolveDefaultPvfFritzTier, writeStoredPvfFritzTier } from './pvfTierPreference';
-import { mutePreference } from '../utils/mutePreference';
+import { useMutePreference } from '../utils/useMutePreference';
 
 export type UseBotGamePreferencesParams = {
   appMode: AppMode;
@@ -35,7 +35,7 @@ export function useBotGamePreferences(
 ): UseBotGamePreferencesResult {
   const { appMode } = params;
 
-  const [isMuted, setIsMuted] = useState<boolean>(() => mutePreference.get());
+  const [isMuted, setIsMuted] = useMutePreference();
   const [botDealSize, setBotDealSize] = useState<BotDealSize>(() => {
     if (typeof window === 'undefined') return 7;
     const stored = window.localStorage.getItem('racehorse_bot_deal_size');
@@ -59,10 +59,6 @@ export function useBotGamePreferences(
   useEffect(() => {
     writeStoredPvfFritzTier(botFritzTier);
   }, [botFritzTier]);
-
-  useEffect(() => {
-    mutePreference.set(isMuted);
-  }, [isMuted]);
 
   useEffect(() => {
     isMutedRef.current = isMuted;

--- a/client/src/bot/useMatchUiChrome.ts
+++ b/client/src/bot/useMatchUiChrome.ts
@@ -10,7 +10,7 @@
 
 import { useEffect, useState, type RefObject } from 'react';
 import { logLayoutDebug } from '../match/layoutDebug';
-import { mutePreference } from '../utils/mutePreference';
+import { useMutePreference } from '../utils/useMutePreference';
 
 export type MatchUiChromeLayoutRefs = {
   rootRef: RefObject<HTMLDivElement | null>;
@@ -20,7 +20,7 @@ export type MatchUiChromeLayoutRefs = {
 
 export function useMatchUiChrome(layoutRefs: MatchUiChromeLayoutRefs) {
   const [isFullscreen, setIsFullscreen] = useState(false);
-  const [isMuted, setIsMuted] = useState<boolean>(() => mutePreference.get());
+  const [isMuted, setIsMuted] = useMutePreference();
   const [scoreTrackOpen, setScoreTrackOpen] = useState(false);
   const [showLeaveConfirm, setShowLeaveConfirm] = useState(false);
   const [showFullCoachTip, setShowFullCoachTip] = useState(false);
@@ -32,10 +32,6 @@ export function useMatchUiChrome(layoutRefs: MatchUiChromeLayoutRefs) {
       handAreaRef: layoutRefs.handAreaRef,
     });
   }, [showLeaveConfirm, layoutRefs.rootRef, layoutRefs.boardStageRef, layoutRefs.handAreaRef]);
-
-  useEffect(() => {
-    mutePreference.set(isMuted);
-  }, [isMuted]);
 
   useEffect(() => {
     const onChange = () => setIsFullscreen(Boolean(document.fullscreenElement));

--- a/client/src/puzzleRush/PuzzleRushScreen.tsx
+++ b/client/src/puzzleRush/PuzzleRushScreen.tsx
@@ -22,7 +22,6 @@ type Phase = 'intro' | 'starting' | 'running' | 'error' | 'leaderboard';
 
 export interface PuzzleRushScreenProps {
   onBack: () => void;
-  muted?: boolean;
   onNavigate?: (mode: AppMode) => void;
 }
 
@@ -36,7 +35,7 @@ const FALLBACK_STAGES: PuzzleRushStage[] = [
   { key: 'master', label: 'Master', fromOrdinal: 9, toOrdinal: 15, maxPointsPerPuzzle: 500, puzzleCount: 7 },
 ];
 
-export function PuzzleRushScreen({ onBack, muted = false, onNavigate }: PuzzleRushScreenProps) {
+export function PuzzleRushScreen({ onBack, onNavigate }: PuzzleRushScreenProps) {
   const [phase, setPhase] = useState<Phase>('intro');
   const [startResponse, setStartResponse] = useState<PuzzleRushStartResponse | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -90,7 +89,6 @@ export function PuzzleRushScreen({ onBack, muted = false, onNavigate }: PuzzleRu
       <PuzzleRushActiveRun
         key={startResponse.run.id}
         start={startResponse}
-        muted={muted}
         onBack={() => {
           // Returning to the hub after a run: refresh the stats it shows.
           setStartResponse(null);
@@ -130,12 +128,10 @@ export function PuzzleRushScreen({ onBack, muted = false, onNavigate }: PuzzleRu
 
 function PuzzleRushActiveRun({
   start,
-  muted,
   onBack,
   onPlayAgain,
 }: {
   start: PuzzleRushStartResponse;
-  muted: boolean;
   /** Return to the hub (and refresh its stats). */
   onBack: () => void;
   onPlayAgain: () => void;
@@ -245,7 +241,6 @@ function PuzzleRushActiveRun({
       />
       <RushStageTransition
         stage={transitionStage}
-        muted={muted}
         onDone={() => setTransitionStage(null)}
       />
     </>

--- a/client/src/puzzleRush/RushStageTransition.tsx
+++ b/client/src/puzzleRush/RushStageTransition.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from 'react';
 import { playMatchFoundSound } from '../utils/sound';
+import { useMutePreference } from '../utils/useMutePreference';
 import type { PuzzleRushStage } from './types';
 
 export const STAGE_TRANSITION_MS = 1400;
@@ -16,13 +17,15 @@ export const STAGE_TRANSITION_MS = 1400;
  */
 export function RushStageTransition({
   stage,
-  muted = false,
   onDone,
 }: {
   stage: PuzzleRushStage | null;
-  muted?: boolean;
   onDone?: () => void;
 }) {
+  // Read straight from the shared preference. This used to be a `muted` prop
+  // defaulting to false that no call site ever passed, so Puzzle Rush was the
+  // one mode that played through a mute set anywhere else.
+  const [muted] = useMutePreference();
   const onDoneRef = useRef(onDone);
   onDoneRef.current = onDone;
 

--- a/client/src/puzzleRush/rushStageAudio.test.tsx
+++ b/client/src/puzzleRush/rushStageAudio.test.tsx
@@ -1,0 +1,33 @@
+// @vitest-environment jsdom
+import { render } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Puzzle Rush was the one mode that never received the mute preference:
+ * `PuzzleRushScreen({ muted = false })` and no call site passing it, so the
+ * stage sound played through a mute set anywhere else in the app.
+ */
+
+const playMatchFoundSound = vi.fn();
+vi.mock('../utils/sound', () => ({ playMatchFoundSound: (m: boolean) => playMatchFoundSound(m) }));
+
+const { mutePreference } = await import('../utils/mutePreference');
+const { RushStageTransition } = await import('./RushStageTransition');
+
+describe('RushStageTransition', () => {
+  beforeEach(() => {
+    playMatchFoundSound.mockReset();
+    mutePreference.set(false);
+  });
+
+  it('plays the stage sound when audio is on', () => {
+    render(<RushStageTransition stage={{ key: 'stage-1' } as never} onDone={() => {}} />);
+    expect(playMatchFoundSound).toHaveBeenCalledWith(false);
+  });
+
+  it('honors a mute set anywhere in the app, with no prop threaded to it', () => {
+    mutePreference.set(true);
+    render(<RushStageTransition stage={{ key: 'stage-1' } as never} onDone={() => {}} />);
+    expect(playMatchFoundSound).toHaveBeenCalledWith(true);
+  });
+});

--- a/client/src/screens/SettingsPreferences.test.tsx
+++ b/client/src/screens/SettingsPreferences.test.tsx
@@ -1,0 +1,54 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../components/hub/HubViewportPage', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+const { mutePreference } = await import('../utils/mutePreference');
+const { SettingsScreen } = await import('./SettingsScreen');
+
+const authUser = { id: 'user-1', email: 'qa@racehorse.test' } as never;
+
+const soundToggle = () => screen.getByRole('switch', { name: /sound/i });
+
+describe('SettingsScreen — preferences', () => {
+  beforeEach(() => {
+    mutePreference.set(false);
+  });
+
+  it('reflects sound being on', () => {
+    render(<SettingsScreen authUser={authUser} />);
+    expect(soundToggle().getAttribute('aria-checked')).toBe('true');
+  });
+
+  it('reflects a mute set elsewhere — in a match tray, say', () => {
+    mutePreference.set(true);
+    render(<SettingsScreen authUser={authUser} />);
+    expect(soundToggle().getAttribute('aria-checked')).toBe('false');
+  });
+
+  it('mutes the whole app from here', () => {
+    render(<SettingsScreen authUser={authUser} />);
+
+    fireEvent.click(soundToggle());
+
+    expect(mutePreference.get()).toBe(true);
+    expect(soundToggle().getAttribute('aria-checked')).toBe('false');
+  });
+
+  it('unmutes again', () => {
+    mutePreference.set(true);
+    render(<SettingsScreen authUser={authUser} />);
+
+    fireEvent.click(soundToggle());
+
+    expect(mutePreference.get()).toBe(false);
+  });
+
+  it('offers sound to a signed-out visitor too — it is a device preference', () => {
+    render(<SettingsScreen authUser={null} />);
+    expect(soundToggle()).toBeTruthy();
+  });
+});

--- a/client/src/screens/SettingsScreen.tsx
+++ b/client/src/screens/SettingsScreen.tsx
@@ -3,6 +3,7 @@ import type { User } from '@supabase/supabase-js';
 import { Button, GlassCard } from '../components/primitives';
 import HubViewportPage from '../components/hub/HubViewportPage';
 import { resolvePasswordChange } from '../auth/passwordChange';
+import { useMutePreference } from '../utils/useMutePreference';
 import type { UserProfile } from '../auth/useAuth';
 import type { AppMode } from '../types';
 import './settingsScreen.css';
@@ -205,6 +206,36 @@ function EmailSection({
   );
 }
 
+function PreferencesSection() {
+  const [isMuted, setIsMuted] = useMutePreference();
+  const soundOn = !isMuted;
+
+  return (
+    <GlassCard className="rh-settings-section">
+      <h2 className="rh-settings-section-title">Preferences</h2>
+      <div className="rh-settings-toggle-row">
+        <span className="rh-settings-toggle-copy">
+          <span className="rh-settings-toggle-label">Sound</span>
+          <span className="rh-settings-section-note">
+            Tile placement, scoring, and end-of-hand audio, in every mode.
+          </span>
+        </span>
+        <Button
+          variant={soundOn ? 'tier-standard' : 'outline'}
+          size="sm"
+          role="switch"
+          aria-checked={soundOn}
+          aria-label="Sound"
+          className="rh-settings-toggle"
+          onClick={() => setIsMuted((prev) => !prev)}
+        >
+          {soundOn ? 'On' : 'Off'}
+        </Button>
+      </div>
+    </GlassCard>
+  );
+}
+
 /**
  * Account and preferences, in one place.
  *
@@ -246,6 +277,8 @@ export function SettingsScreen({
             <EmailSection currentEmail={authUser.email ?? null} onUpdateEmail={onUpdateEmail} />
             <PasswordSection onUpdatePassword={onUpdatePassword} />
 
+            <PreferencesSection />
+
             <GlassCard className="rh-settings-section">
               <h2 className="rh-settings-section-title">Session</h2>
               <Button variant="outline" onClick={() => onSignOut?.()}>
@@ -264,6 +297,10 @@ export function SettingsScreen({
             </Button>
           </GlassCard>
         )}
+
+        {/* Sound is stored on the device, not the account, so it is offered
+            whether or not anyone is signed in. */}
+        {!authUser && <PreferencesSection />}
       </div>
     </HubViewportPage>
   );

--- a/client/src/screens/settingsScreen.css
+++ b/client/src/screens/settingsScreen.css
@@ -139,3 +139,33 @@
 .rh-settings-success {
   color: var(--tier-rookie);
 }
+
+/* ── Toggle rows ────────────────────────────────────────────────── */
+
+.rh-settings-toggle-row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  width: 100%;
+}
+
+.rh-settings-toggle-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.rh-settings-toggle-label {
+  font-family: var(--font-body);
+  font-size: 15px;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.95);
+}
+
+.rh-settings-toggle.rh-btn {
+  flex-shrink: 0;
+  min-width: 64px;
+}
+

--- a/client/src/utils/mutePreference.test.ts
+++ b/client/src/utils/mutePreference.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 
 const localStorageMock = (() => {
   let store: Record<string, string> = {};
@@ -39,5 +39,39 @@ describe('mutePreference', () => {
     mutePreference.set(true);
     mutePreference.set(false);
     expect(mutePreference.get()).toBe(false);
+  });
+
+  it('notifies subscribers when the preference changes', () => {
+    // The Settings toggle and a match screen are different mounts of the same
+    // preference. Without this, changing it in Settings left the App-level
+    // mute state stale until a reload.
+    const seen: boolean[] = [];
+    const unsubscribe = mutePreference.subscribe(() => seen.push(mutePreference.get()));
+
+    mutePreference.set(true);
+    mutePreference.set(false);
+
+    expect(seen).toEqual([true, false]);
+    unsubscribe();
+  });
+
+  it('stops notifying once unsubscribed', () => {
+    const listener = vi.fn();
+    mutePreference.subscribe(listener)();
+
+    mutePreference.set(true);
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('does not notify when the value is unchanged', () => {
+    mutePreference.set(true);
+    const listener = vi.fn();
+    const unsubscribe = mutePreference.subscribe(listener);
+
+    mutePreference.set(true);
+
+    expect(listener).not.toHaveBeenCalled();
+    unsubscribe();
   });
 });

--- a/client/src/utils/mutePreference.ts
+++ b/client/src/utils/mutePreference.ts
@@ -1,12 +1,51 @@
 const KEY = 'racehorse_muted';
 
+/**
+ * The mute preference, and a subscription to it.
+ *
+ * There are several independent readers — the App-level game preferences, each
+ * match screen's UI chrome, the matchmaking screen — and they are not mounted
+ * at the same time as the Settings toggle. Reading localStorage on mount was
+ * enough while the only control lived inside a match; with a control on the
+ * Settings page, a live reader has to hear about the change or it keeps playing
+ * sound the user just turned off.
+ *
+ * `get` reads storage every time rather than caching. The value is a boolean,
+ * so useSyncExternalStore's identity comparison is safe on a fresh read, and a
+ * module-level cache would outlive the storage it mirrors — which is exactly
+ * what makes it wrong in tests and after a sign-out clears site data.
+ */
+
+const listeners = new Set<() => void>();
+
 export const mutePreference = {
   get(): boolean {
     if (typeof window === 'undefined') return false;
-    return window.localStorage.getItem(KEY) === '1';
+    try {
+      return window.localStorage.getItem(KEY) === '1';
+    } catch {
+      // Private mode / storage disabled — audio on is the safer default.
+      return false;
+    }
   },
+
   set(muted: boolean): void {
-    if (typeof window === 'undefined') return;
-    window.localStorage.setItem(KEY, muted ? '1' : '0');
+    if (mutePreference.get() === muted) return;
+    if (typeof window !== 'undefined') {
+      try {
+        window.localStorage.setItem(KEY, muted ? '1' : '0');
+      } catch {
+        // Nothing to persist to; the listeners below still update this session.
+      }
+    }
+    for (const listener of listeners) listener();
+  },
+
+  /** Returns the unsubscribe function, in useSyncExternalStore's shape. */
+  subscribe(listener: () => void): () => void {
+    listeners.add(listener);
+    return () => {
+      listeners.delete(listener);
+    };
   },
 };

--- a/client/src/utils/useMutePreference.test.tsx
+++ b/client/src/utils/useMutePreference.test.tsx
@@ -1,0 +1,71 @@
+// @vitest-environment jsdom
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+const { mutePreference } = await import('./mutePreference');
+const { useMutePreference } = await import('./useMutePreference');
+
+describe('useMutePreference', () => {
+  beforeEach(() => {
+    mutePreference.set(false);
+  });
+
+  it('starts from the stored preference', () => {
+    mutePreference.set(true);
+    const { result } = renderHook(() => useMutePreference());
+    expect(result.current[0]).toBe(true);
+  });
+
+  it('writes through when the hook sets it', () => {
+    const { result } = renderHook(() => useMutePreference());
+
+    act(() => result.current[1](true));
+
+    expect(mutePreference.get()).toBe(true);
+    expect(result.current[0]).toBe(true);
+  });
+
+  it('follows a change made anywhere else', () => {
+    // The Settings toggle and a match screen are separate mounts. This is the
+    // one that matters: muting in Settings has to reach a reader that is
+    // already mounted.
+    const { result } = renderHook(() => useMutePreference());
+    expect(result.current[0]).toBe(false);
+
+    act(() => mutePreference.set(true));
+
+    expect(result.current[0]).toBe(true);
+  });
+
+  it('keeps two mounted readers in agreement', () => {
+    const a = renderHook(() => useMutePreference());
+    const b = renderHook(() => useMutePreference());
+
+    act(() => a.result.current[1](true));
+
+    expect(b.result.current[0]).toBe(true);
+  });
+
+  it('accepts an updater, the way the match trays call it', () => {
+    // The mute buttons are written `setIsMuted((prev) => !prev)`.
+    const { result } = renderHook(() => useMutePreference());
+
+    act(() => result.current[1]((prev) => !prev));
+
+    expect(result.current[0]).toBe(true);
+    expect(mutePreference.get()).toBe(true);
+  });
+
+  it('unmutes through the updater too', () => {
+    // A setter that forwards the function itself passes this only by accident
+    // on the muting direction — a function is truthy. This is the direction
+    // that catches it.
+    mutePreference.set(true);
+    const { result } = renderHook(() => useMutePreference());
+
+    act(() => result.current[1]((prev) => !prev));
+
+    expect(result.current[0]).toBe(false);
+    expect(mutePreference.get()).toBe(false);
+  });
+});

--- a/client/src/utils/useMutePreference.ts
+++ b/client/src/utils/useMutePreference.ts
@@ -1,0 +1,24 @@
+import { useCallback, useSyncExternalStore, type Dispatch, type SetStateAction } from 'react';
+import { mutePreference } from './mutePreference';
+
+/**
+ * The mute preference as React state, shared by every reader.
+ *
+ * `useState(() => mutePreference.get())` — what the match screens used to do —
+ * reads once on mount and never hears about a change made elsewhere. With a
+ * toggle on the Settings page there is always an "elsewhere".
+ */
+export function useMutePreference(): [boolean, Dispatch<SetStateAction<boolean>>] {
+  const isMuted = useSyncExternalStore(
+    mutePreference.subscribe,
+    mutePreference.get,
+    () => false,
+  );
+  // Setter-function form included: the match trays are written
+  // `setIsMuted((prev) => !prev)`, and forwarding the function itself would
+  // store a truthy value rather than the toggle's result.
+  const setMuted = useCallback<Dispatch<SetStateAction<boolean>>>((next) => {
+    mutePreference.set(typeof next === 'function' ? next(mutePreference.get()) : next);
+  }, []);
+  return [isMuted, setMuted];
+}


### PR DESCRIPTION
Third of four. Stacked on #80.

The mute preference had no control outside a match. It now has one in Settings — which required making it reactive.

## Why a store, not just a toggle
Two independent `isMuted` states both seeded from `mutePreference` on mount and wrote back on change: `useBotGamePreferences` (App-level, feeds multiplayer and the live match) and `useMatchUiChrome` (each bot / Daily Fritz match screen). Reading once on mount was fine while the only control lived inside a match. With a control on a different screen there is always an "elsewhere", so `mutePreference` gained a subscription and both readers moved to `useMutePreference`, a `useSyncExternalStore` wrapper.

It keeps the `setIsMuted(prev => !prev)` shape the match trays are written in. Forwarding the updater unchanged would store a truthy *function* rather than the toggle's result — which passes the muting direction by accident and fails the other one, so there is a test for the unmute direction specifically.

## Answering "is mute read everywhere gameplay uses audio?"
Almost. It reaches bot matches, Daily Fritz, multiplayer, the live match, matchmaking, and the guided modes. **Puzzle Rush was the exception**: `RushStageTransition({ muted = false })` with no call site ever passing it, so its stage sound played through a mute set anywhere else. It reads the preference directly now and the dead prop is gone.

Sound sits outside the signed-in branch: it is stored on the device, not the account, so a signed-out visitor gets it too.

## Fritz tier / bot deal size — flagged, not fixed
They stay on their setup screens: per-match choices made where the match is configured, not global preferences.

But the audit's observation is real and I have **deliberately not fixed it here**: `useBotGamePreferences` resets `botDealSize` to 7 on every entry to `botSetup`, so the value it writes to localStorage is never read back. Either the persistence or the reset is wrong. Which one depends on whether the deal size is meant to be remembered between sessions — a product call, not a mechanical one. Happy to do either in a follow-up.

## Also
Raises the `findBy` timeout in `passwordRecoveryFlow.test.tsx` (from #80). Its modals are lazy-loaded and the dynamic import can exceed the 1s default under a full parallel run — a real flake, one failure in three full-suite runs, not a broken modal.

## Verification
- `npx vitest run` (client): 206 files, 1400 tests, all pass; suite run 4× more to confirm the flake is gone
- `tsc -b --noEmit`: clean
- `npm run lint`: 401 warnings, at budget, exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)