### PR TITLE
feat(settings): delete account

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -72,6 +72,7 @@ import { resolveAppRoute } from './routing/appRoutePath';
 import { useFullscreen } from './utils/useFullscreen';
 import { useNetworkStatus } from './hooks/useNetworkStatus';
 import { OfflineBanner } from './components/OfflineBanner';
+import { deleteAccount } from './auth/deleteAccount';
 
 function normalizeRoomCode(value: unknown): string {
   return typeof value === 'string' ? value.trim().toUpperCase() : '';
@@ -782,6 +783,24 @@ export default function App() {
     [updateUsername, setOnboardingDismissed, setUsernameModalOpen],
   );
 
+  /**
+   * Deletes the account, then signs out and lands on home.
+   *
+   * Only a confirmed deletion tears the session down: signing out on a failed
+   * call would leave the user unable to retry from a page that requires them
+   * to be signed in.
+   */
+  const handleDeleteAccount = useCallback(
+    async (confirmation: string) => {
+      const result = await deleteAccount(confirmation);
+      if (result.error) return result;
+      handleSignOut();
+      setAppMode('home');
+      return result;
+    },
+    [handleSignOut, setAppMode],
+  );
+
   const authModalsLayer = (
     <AuthModalsLayer
       authModalOpen={authModalOpen}
@@ -865,6 +884,7 @@ export default function App() {
       auth: {
         handleSignOut,
         handleSaveUsername,
+        handleDeleteAccount,
         updatePassword,
         updateEmail,
         isAdmin,

--- a/client/src/appRouteTypes.ts
+++ b/client/src/appRouteTypes.ts
@@ -58,6 +58,8 @@ export type AppRoutesAuthProps = {
   /** Full sign-out, including room-recovery and multiplayer teardown. */
   handleSignOut: () => void;
   handleSaveUsername: (username: string) => Promise<{ error: string | null }>;
+  /** Resolves only on failure — a success signs out and navigates home. */
+  handleDeleteAccount: (confirmation: string) => Promise<{ error: string | null }>;
   updatePassword: (password: string) => Promise<{ error: string | null; message?: string | null }>;
   updateEmail: (email: string) => Promise<{ error: string | null; message?: string | null }>;
   isAdmin: boolean;

--- a/client/src/auth/deleteAccount.test.ts
+++ b/client/src/auth/deleteAccount.test.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { apiDelete } = vi.hoisted(() => ({ apiDelete: vi.fn() }));
+// The factory returns the mock itself. Wrapping it in an arrow leaves vitest
+// untracking the result, and a rejection then surfaces as an unhandled error.
+vi.mock('../api/client', () => ({ apiDelete }));
+
+const { deleteAccount } = await import('./deleteAccount');
+
+describe('deleteAccount', () => {
+  beforeEach(() => apiDelete.mockReset());
+
+  it('sends the typed confirmation to the account endpoint', async () => {
+    apiDelete.mockResolvedValue({ data: { ok: true }, error: null });
+
+    const result = await deleteAccount('oliver');
+
+    expect(apiDelete).toHaveBeenCalledWith('/api/account', { confirm: 'oliver' });
+    expect(result).toEqual({ error: null });
+  });
+
+  it('passes the server error straight through', async () => {
+    apiDelete.mockResolvedValue({
+      data: null,
+      error: 'Type your username exactly to confirm deletion.',
+    });
+
+    expect(await deleteAccount('olivia')).toEqual({
+      error: 'Type your username exactly to confirm deletion.',
+    });
+  });
+
+  it('reports a transport failure rather than resolving as deleted', async () => {
+    // A rejected call must never look like success — the caller signs the user
+    // out on success, and doing that to a live account is the worse failure.
+    apiDelete.mockRejectedValueOnce(new Error('offline'));
+
+    expect(await deleteAccount('oliver')).toEqual({ error: 'offline' });
+  });
+
+  it('treats a 200 with no ok flag as a failure', async () => {
+    apiDelete.mockResolvedValue({ data: {}, error: null });
+
+    const result = await deleteAccount('oliver');
+
+    expect(result.error).toBeTruthy();
+  });
+});

--- a/client/src/auth/deleteAccount.ts
+++ b/client/src/auth/deleteAccount.ts
@@ -1,0 +1,25 @@
+import { apiDelete } from '../api/client';
+
+/**
+ * Irreversibly deletes the signed-in account.
+ *
+ * The confirmation the user typed is sent and re-checked on the server — a
+ * client is not the place to enforce intent for something that cannot be
+ * undone.
+ *
+ * Anything short of an explicit `ok` is reported as an error. The caller signs
+ * the user out on success, and doing that to an account that still exists is a
+ * worse outcome than showing a failure the user can retry.
+ */
+export async function deleteAccount(confirmation: string): Promise<{ error: string | null }> {
+  try {
+    const { data, error } = await apiDelete<{ ok?: boolean }>('/api/account', {
+      confirm: confirmation,
+    });
+    if (error) return { error };
+    if (!data?.ok) return { error: 'Account deletion did not complete. Try again.' };
+    return { error: null };
+  } catch (err) {
+    return { error: err instanceof Error ? err.message : 'Unable to delete your account.' };
+  }
+}

--- a/client/src/routes/socialRoutes.tsx
+++ b/client/src/routes/socialRoutes.tsx
@@ -160,6 +160,7 @@ export function SettingsRoute({
     handleOpenAuthModal,
     handleSignOut,
     handleSaveUsername,
+    handleDeleteAccount,
     updatePassword,
     updateEmail,
   } = auth;
@@ -176,6 +177,7 @@ export function SettingsRoute({
             onSaveUsername={handleSaveUsername}
             onUpdatePassword={updatePassword}
             onUpdateEmail={updateEmail}
+            onDeleteAccount={handleDeleteAccount}
           />
         </Suspense>
       </ErrorBoundary>

--- a/client/src/screens/SettingsDeleteAccount.test.tsx
+++ b/client/src/screens/SettingsDeleteAccount.test.tsx
@@ -1,0 +1,89 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../components/hub/HubViewportPage', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+const { SettingsScreen } = await import('./SettingsScreen');
+type Props = import('./SettingsScreen').SettingsScreenProps;
+
+const authUser = { id: 'user-1', email: 'qa@racehorse.test' } as never;
+const authProfile = { id: 'user-1', username: 'oliver' } as never;
+
+function renderSettings(overrides: Partial<Props> = {}) {
+  const props: Props = {
+    authUser,
+    authProfile,
+    onDeleteAccount: vi.fn(() => Promise.resolve({ error: null })),
+    ...overrides,
+  };
+  render(<SettingsScreen {...props} />);
+  return props;
+}
+
+const openDelete = () => fireEvent.click(screen.getByRole('button', { name: /delete account/i }));
+const confirmField = () => screen.getByLabelText(/type your username/i);
+const confirmButton = () => screen.getByRole('button', { name: /delete my account/i });
+
+describe('SettingsScreen — delete account', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('does not expose the confirmation until the user asks for it', () => {
+    renderSettings();
+    expect(screen.queryByLabelText(/type your username/i)).toBeNull();
+  });
+
+  it('will not delete until the handle is typed exactly', async () => {
+    const props = renderSettings();
+    openDelete();
+
+    expect(confirmButton()).toHaveProperty('disabled', true);
+
+    fireEvent.change(confirmField(), { target: { value: 'olive' } });
+    expect(confirmButton()).toHaveProperty('disabled', true);
+
+    fireEvent.change(confirmField(), { target: { value: 'oliver' } });
+    expect(confirmButton()).toHaveProperty('disabled', false);
+
+    fireEvent.click(confirmButton());
+    await waitFor(() => expect(props.onDeleteAccount).toHaveBeenCalledWith('oliver'));
+  });
+
+  it('accepts the handle with stray whitespace or casing', () => {
+    renderSettings();
+    openDelete();
+
+    fireEvent.change(confirmField(), { target: { value: ' Oliver ' } });
+
+    expect(confirmButton()).toHaveProperty('disabled', false);
+  });
+
+  it('can be backed out of', () => {
+    renderSettings();
+    openDelete();
+
+    fireEvent.click(screen.getByRole('button', { name: /^cancel$/i }));
+
+    expect(screen.queryByLabelText(/type your username/i)).toBeNull();
+  });
+
+  it('surfaces a failure and does not pretend the account is gone', async () => {
+    renderSettings({
+      onDeleteAccount: vi.fn(() => Promise.resolve({ error: 'Unable to delete your account.' })),
+    });
+    openDelete();
+    fireEvent.change(confirmField(), { target: { value: 'oliver' } });
+    fireEvent.click(confirmButton());
+
+    expect(await screen.findByText('Unable to delete your account.')).toBeTruthy();
+    // Still on the page, still confirmable — nothing was destroyed.
+    expect(confirmField()).toBeTruthy();
+  });
+
+  it('is not offered to a signed-out visitor', () => {
+    render(<SettingsScreen authUser={null} authProfile={null} />);
+    expect(screen.queryByRole('button', { name: /delete account/i })).toBeNull();
+  });
+});

--- a/client/src/screens/SettingsScreen.tsx
+++ b/client/src/screens/SettingsScreen.tsx
@@ -20,6 +20,8 @@ export interface SettingsScreenProps {
   onSaveUsername?: (username: string) => Promise<SettingsMutationResult>;
   onUpdatePassword?: (password: string) => Promise<SettingsMutationResult>;
   onUpdateEmail?: (email: string) => Promise<SettingsMutationResult>;
+  /** Resolves only on failure — a success unmounts this screen. */
+  onDeleteAccount?: (confirmation: string) => Promise<SettingsMutationResult>;
 }
 
 type Status = { error: string | null; message: string | null };
@@ -171,6 +173,8 @@ function EmailSection({
 }: {
   currentEmail: string | null;
   onUpdateEmail?: (email: string) => Promise<SettingsMutationResult>;
+  /** Resolves only on failure — a success unmounts this screen. */
+  onDeleteAccount?: (confirmation: string) => Promise<SettingsMutationResult>;
 }) {
   const id = useId();
   const [email, setEmail] = useState('');
@@ -202,6 +206,81 @@ function EmailSection({
       >
         {pending ? 'Sending…' : 'Change email'}
       </Button>
+    </GlassCard>
+  );
+}
+
+function DangerZoneSection({
+  username,
+  onDeleteAccount,
+}: {
+  username: string;
+  onDeleteAccount?: (confirmation: string) => Promise<SettingsMutationResult>;
+}) {
+  const id = useId();
+  const [confirming, setConfirming] = useState(false);
+  const [confirmation, setConfirmation] = useState('');
+  const { pending, status, run } = useSettingsAction();
+
+  const matches =
+    username.trim().length > 0 &&
+    confirmation.trim().toLowerCase() === username.trim().toLowerCase();
+
+  return (
+    <GlassCard className="rh-settings-section rh-settings-section--danger">
+      <h2 className="rh-settings-section-title">Delete account</h2>
+      <p className="rh-settings-section-note">
+        This erases your profile, your handle, your friends, and your rating history. It cannot be
+        undone, and the handle becomes available for someone else to take.
+      </p>
+
+      {confirming ? (
+        <>
+          <label className="rh-settings-field" htmlFor={id}>
+            <span className="rh-settings-field-label">
+              Type your username ({username}) to confirm
+            </span>
+            <input
+              id={id}
+              type="text"
+              className="rh-settings-input"
+              value={confirmation}
+              autoComplete="off"
+              disabled={pending}
+              onChange={(event) => setConfirmation(event.target.value)}
+            />
+          </label>
+          <StatusLine status={status} />
+          <div className="rh-settings-actions">
+            <Button
+              variant="secondary"
+              disabled={pending}
+              onClick={() => {
+                setConfirming(false);
+                setConfirmation('');
+              }}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="outline"
+              className="rh-settings-danger-button"
+              disabled={!matches || pending}
+              onClick={() => void run(() => onDeleteAccount!(confirmation.trim()))}
+            >
+              {pending ? 'Deleting…' : 'Delete my account'}
+            </Button>
+          </div>
+        </>
+      ) : (
+        <Button
+          variant="outline"
+          className="rh-settings-danger-button"
+          onClick={() => setConfirming(true)}
+        >
+          Delete account
+        </Button>
+      )}
     </GlassCard>
   );
 }
@@ -253,6 +332,7 @@ export function SettingsScreen({
   onSaveUsername,
   onUpdatePassword,
   onUpdateEmail,
+  onDeleteAccount,
 }: SettingsScreenProps) {
   return (
     <HubViewportPage
@@ -285,6 +365,11 @@ export function SettingsScreen({
                 Sign out
               </Button>
             </GlassCard>
+
+            <DangerZoneSection
+              username={authProfile?.username ?? ''}
+              onDeleteAccount={onDeleteAccount}
+            />
           </>
         ) : (
           <GlassCard className="rh-settings-section">

--- a/client/src/screens/settingsScreen.css
+++ b/client/src/screens/settingsScreen.css
@@ -169,3 +169,23 @@
   min-width: 64px;
 }
 
+/* ── Danger zone ────────────────────────────────────────────────── */
+
+.rh-settings-section--danger {
+  border-color: color-mix(in srgb, var(--accent-danger) 32%, transparent);
+}
+
+.rh-settings-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.rh-settings-danger-button.rh-btn {
+  color: var(--accent-danger);
+  border-color: color-mix(in srgb, var(--accent-danger) 45%, transparent);
+}
+
+.rh-settings-danger-button.rh-btn:hover:not(:disabled) {
+  border-color: color-mix(in srgb, var(--accent-danger) 70%, transparent);
+}

--- a/client/src/useAppRoutesProps.tsx
+++ b/client/src/useAppRoutesProps.tsx
@@ -320,6 +320,7 @@ export function useAppRoutesProps(source: UseAppRoutesPropsSource): AppRoutesPro
       handleOpenAuthModal,
       handleSignOut,
       handleSaveUsername: auth.handleSaveUsername,
+      handleDeleteAccount: auth.handleDeleteAccount,
       updatePassword: auth.updatePassword,
       updateEmail: auth.updateEmail,
       isAdmin: auth.isAdmin,

--- a/server/src/account/deleteAccountRoute.test.ts
+++ b/server/src/account/deleteAccountRoute.test.ts
@@ -1,0 +1,139 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { supabaseFetchMock, requireAuthMock } = vi.hoisted(() => ({
+  supabaseFetchMock: vi.fn(),
+  requireAuthMock: vi.fn(),
+}));
+
+vi.mock('../supabaseUtils', async () => {
+  const actual = await vi.importActual<typeof import('../supabaseUtils')>('../supabaseUtils');
+  return { ...actual, supabaseFetch: supabaseFetchMock };
+});
+
+vi.mock('../social/socialAuth', async () => {
+  const actual = await vi.importActual<typeof import('../social/socialAuth')>('../social/socialAuth');
+  return { ...actual, requireAuth: requireAuthMock };
+});
+
+import { registerAccountRoutes } from './routes';
+import type { Router } from 'express';
+
+type Handler = (req: unknown, res: unknown) => unknown | Promise<unknown>;
+
+function makeHarness() {
+  const routes = new Map<string, Handler>();
+  const router = {
+    get(path: string, handler: Handler) { routes.set(`GET ${path}`, handler); },
+    post(path: string, handler: Handler) { routes.set(`POST ${path}`, handler); },
+    delete(path: string, handler: Handler) { routes.set(`DELETE ${path}`, handler); },
+  };
+  registerAccountRoutes(router as unknown as Router);
+
+  return async function request(method: 'DELETE', path: string, body: unknown = {}) {
+    const handler = routes.get(`${method} ${path}`);
+    if (!handler) throw new Error(`Missing route ${method} ${path}`);
+    let status = 200;
+    let payload: unknown;
+    const res = {
+      status(code: number) { status = code; return res; },
+      json(value: unknown) { payload = value; return res; },
+    };
+    await handler({ headers: {}, params: {}, query: {}, body, method, path }, res);
+    return { status, body: payload as Record<string, unknown> };
+  };
+}
+
+const USER_ID = '11111111-1111-1111-1111-111111111111';
+
+/** The profile lookup the route does before it will accept the confirmation. */
+const profileRow = [{ username: 'oliver' }];
+
+describe('DELETE /api/account', () => {
+  beforeEach(() => {
+    supabaseFetchMock.mockReset();
+    requireAuthMock.mockReset();
+    requireAuthMock.mockResolvedValue(USER_ID);
+  });
+
+  it('refuses an unauthenticated caller and deletes nothing', async () => {
+    // requireAuth has already written 401 to the response by the time it
+    // resolves null; the route's job is to stop.
+    requireAuthMock.mockResolvedValue(null);
+    const request = makeHarness();
+
+    await request('DELETE', '/', { confirm: 'oliver' });
+
+    expect(supabaseFetchMock).not.toHaveBeenCalled();
+  });
+
+  it('deletes the auth user when the typed handle matches', async () => {
+    supabaseFetchMock.mockResolvedValueOnce(profileRow).mockResolvedValueOnce(undefined);
+    const request = makeHarness();
+
+    const response = await request('DELETE', '/', { confirm: 'oliver' });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ ok: true });
+    // Deleting the auth user is what cascades; deleting the profile row alone
+    // would leave a sign-in-able account with no profile.
+    expect(supabaseFetchMock).toHaveBeenLastCalledWith(
+      `/auth/v1/admin/users/${USER_ID}`,
+      expect.objectContaining({ method: 'DELETE' }),
+    );
+  });
+
+  it('accepts the handle however the user cased or padded it', async () => {
+    supabaseFetchMock.mockResolvedValueOnce(profileRow).mockResolvedValueOnce(undefined);
+    const request = makeHarness();
+
+    const response = await request('DELETE', '/', { confirm: '  OLIVER ' });
+
+    expect(response.status).toBe(200);
+  });
+
+  it('refuses a confirmation that does not match, and deletes nothing', async () => {
+    supabaseFetchMock.mockResolvedValueOnce(profileRow);
+    const request = makeHarness();
+
+    const response = await request('DELETE', '/', { confirm: 'olivia' });
+
+    expect(response.status).toBe(400);
+    expect(supabaseFetchMock).toHaveBeenCalledTimes(1);
+    expect(supabaseFetchMock).not.toHaveBeenCalledWith(
+      expect.stringContaining('/auth/v1/admin/users/'),
+      expect.anything(),
+    );
+  });
+
+  it('refuses a missing confirmation', async () => {
+    supabaseFetchMock.mockResolvedValueOnce(profileRow);
+    const request = makeHarness();
+
+    const response = await request('DELETE', '/', {});
+
+    expect(response.status).toBe(400);
+    expect(supabaseFetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports a failed delete rather than telling the user it worked', async () => {
+    supabaseFetchMock
+      .mockResolvedValueOnce(profileRow)
+      .mockRejectedValueOnce(new Error('supabase unavailable'));
+    const request = makeHarness();
+
+    const response = await request('DELETE', '/', { confirm: 'oliver' });
+
+    expect(response.status).toBe(500);
+    expect(response.body.ok).toBeUndefined();
+  });
+
+  it('404s when the account has no profile row to confirm against', async () => {
+    supabaseFetchMock.mockResolvedValueOnce([]);
+    const request = makeHarness();
+
+    const response = await request('DELETE', '/', { confirm: 'oliver' });
+
+    expect(response.status).toBe(404);
+    expect(supabaseFetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/server/src/account/routes.ts
+++ b/server/src/account/routes.ts
@@ -1,0 +1,72 @@
+import { Router } from 'express';
+import { supabaseFetch } from '../supabaseUtils';
+import { requireAuth } from '../social/socialAuth';
+import { childLogger } from '../logger';
+
+const log = childLogger('account');
+
+/**
+ * Account deletion.
+ *
+ * Deletes the **auth user**, not the profile row. Every table that belongs to
+ * a player hangs off `auth.users` with `on delete cascade` — profiles,
+ * friends, ranked_games.player_id, ghost_profiles, daily_fritz_attempts,
+ * puzzle_rush runs — so removing the auth user is what actually erases the
+ * account. Deleting `profiles` alone would leave a sign-in-able account with
+ * no profile, which is worse than not deleting at all.
+ *
+ * What deliberately survives:
+ *
+ *  - `ranked_games` rows where the deleted user was the *opponent*.
+ *    `opponent_id` is a bare uuid with no foreign key, so those rows are
+ *    untouched and the other player's rating history stays intact and
+ *    recomputable. The cost is that the id no longer resolves to a profile, so
+ *    an opponent shows as unknown. Anonymising them instead would be a bigger
+ *    change with no better outcome for the surviving player, and rewriting
+ *    them would corrupt the very history it is meant to protect.
+ *  - `matches.winner_user_id` / `loser_user_id` and the tournament tables,
+ *    which are `on delete set null` — the match happened, the player is gone.
+ *
+ * This needs the service-role key. `supabaseFetch` uses it by default.
+ */
+export function registerAccountRoutes(router: Router): void {
+  router.delete('/', async (req, res) => {
+    const userId = await requireAuth(req, res);
+    if (!userId) return;
+
+    const confirm = typeof req.body?.confirm === 'string' ? req.body.confirm.trim().toLowerCase() : '';
+
+    try {
+      const profiles = await supabaseFetch<Array<{ username: string }>>(
+        `/rest/v1/profiles?id=eq.${encodeURIComponent(userId)}&select=username&limit=1`,
+      );
+      const username = profiles?.[0]?.username;
+      if (!username) {
+        res.status(404).json({ error: 'Account not found.' });
+        return;
+      }
+
+      // Typed confirmation, checked here as well as in the UI: this is
+      // irreversible and a client is not the place to enforce intent.
+      if (confirm !== username.trim().toLowerCase()) {
+        res.status(400).json({ error: 'Type your username exactly to confirm deletion.' });
+        return;
+      }
+
+      await supabaseFetch(`/auth/v1/admin/users/${encodeURIComponent(userId)}`, {
+        method: 'DELETE',
+      });
+
+      log.info({ userId }, 'account deleted');
+      res.json({ ok: true });
+    } catch (err) {
+      log.error({ err, userId }, 'account deletion failed');
+      res.status(500).json({
+        error: err instanceof Error ? err.message : 'Unable to delete your account.',
+      });
+    }
+  });
+}
+
+export const accountRouter = Router();
+registerAccountRoutes(accountRouter);

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -38,6 +38,7 @@ import { computeWeeklyAwards } from "./stats/matchLog";
 import { computeOnlineCurrentWinStreak } from './stats/onlineWinStreak';
 import { recordUserMatch } from './stats/recordUserMatch';
 import { socialRouter } from './social/routes';
+import { accountRouter } from './account/routes';
 import { socketsByUserId as presenceSocketsByUserId, setActivity } from './social/presenceRegistry';
 import { registerFriendInviteHandlers } from './social/registerFriendInviteHandlers';
 import {
@@ -417,6 +418,14 @@ const dailySubmitLimit = createRateLimitMiddleware(
   getUserIdFromAuthHeaderSync,
 );
 const adminLimit = createRateLimitMiddleware(restRateLimiter, { windowMs: 10 * 60_000, max: 20 }, 'rest:admin');
+// Account deletion is irreversible and per-user. A handful of attempts is a
+// user correcting a typed confirmation; more than that is not a person.
+const accountDeleteLimit = createRateLimitMiddleware(
+  restRateLimiter,
+  { windowMs: 10 * 60_000, max: 10 },
+  'rest:account-delete',
+  getUserIdFromAuthHeaderSync,
+);
 const cronLimit = createRateLimitMiddleware(restRateLimiter, { windowMs: 10 * 60_000, max: 20 }, 'rest:cron');
 // Leaderboard queries are read-heavy and trigger unbounded DB scans — give them their own budget
 // so a single poller can't exhaust the global restApiLimit for all other /api/* callers.
@@ -461,6 +470,8 @@ app.use('/bot-matches/cleanup-stale', adminLimit);
 app.use('/api', restApiLimit);
 app.use('/league', restApiLimit);
 app.use('/bot-matches', restApiLimit);
+app.use('/api/account', accountDeleteLimit);
+app.use('/api/account', accountRouter);
 app.use('/api/social', socialRouter);
 app.use('/api/profile', socialRouter);
 


### PR DESCRIPTION
Fourth of four. Stacked on #81.

`DELETE /api/account`, behind the service-role key, with a typed confirmation checked on the server as well as in the UI. This is irreversible and a client is not the place to enforce intent.

## It deletes the auth user, not the profile row
Every table that belongs to a player hangs off `auth.users` with `on delete cascade` — `profiles`, `friends`, `ranked_games.player_id`, `ghost_profiles`, `daily_fritz_attempts`, `puzzle_rush` runs, `daily_puzzle_attempts`. Removing the auth user is what actually erases the account. Deleting `profiles` alone would leave a sign-in-able account with no profile, which is worse than not deleting at all.

Verified against the schema rather than assumed — the cascades the audit named are all present.

## The opponent question — stating it rather than deciding quietly
`ranked_games.opponent_id` is **a bare uuid with no foreign key**. Rows where the deleted user was the *opponent* are therefore untouched by the cascade.

That is the good outcome, for free: the surviving player's match history and rating history stay intact and recomputable, which is exactly what an anonymisation scheme would have been built to achieve. **The cost**: the id no longer resolves to a profile, so those matches will show an unknown opponent wherever the UI joins `opponent_id` → `profiles`.

I have left the cascade as it is. Rewriting those rows to a tombstone id would corrupt the very history it is meant to protect, and the only thing it would buy is a nicer label — which is better solved in the UI, by rendering an unresolvable opponent as "deleted player" rather than blank. Flagging that as the natural follow-up rather than doing it here.

`matches` and the tournament tables are already `on delete set null` — the match happened, the player is gone.

## Rest
- Rate-limited per user, 10 per 10 minutes: a few attempts is someone correcting a typed confirmation; more than that is not a person.
- The UI keeps the confirmation behind a second step, and the delete button stays disabled until the typed handle matches (trimmed, case-insensitive).
- The client signs out and returns home **only on a confirmed success**. Signing out on a failed call would strand the user on a page that requires them to be signed in, unable to retry — so anything short of an explicit `ok` is reported as an error.

## Verification
- `npx vitest run` (client): 208 files, 1410 tests, all pass
- `npx vitest run` (server): 192 files, 1099 tests, all pass — including 7 new route tests covering auth, confirmation match/mismatch/missing, the admin endpoint actually called, failure, and a missing profile
- `tsc -b --noEmit` (client) and `tsc -p tsconfig.json --noEmit` (server): clean
- `npm run lint`: 401 warnings, at budget, exit 0

Not covered by an automated test: the real Supabase cascade. The route test asserts the admin delete endpoint is the thing called; the cascade itself is a schema property, verified by reading the migrations. Worth one manual run against a staging account before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)