### PR TITLE
fix: stop a telemetry chunk from reloading a working app

### DIFF
--- a/client/scripts/appVersion.mjs
+++ b/client/scripts/appVersion.mjs
@@ -1,0 +1,20 @@
+/**
+ * The release identifier baked into the client bundle.
+ *
+ * Sentry showed `release: unknown` on every production event. CI sets
+ * VITE_APP_VERSION for the build it runs, but Vercel builds the deployed
+ * bundle itself, and Vite only exposes `VITE_`-prefixed variables to client
+ * code — so VERCEL_GIT_COMMIT_SHA, which Vercel does inject into the build
+ * environment, never reached `import.meta.env`.
+ *
+ * Resolving it here rather than in the Vercel dashboard keeps the mapping in
+ * the repo, and keeps CI's explicit VITE_APP_VERSION authoritative so the
+ * release name matches the one its sourcemap upload uses.
+ */
+export function resolveAppVersion(env = process.env) {
+  const explicit = env.VITE_APP_VERSION?.trim();
+  if (explicit) return explicit;
+  const vercelSha = env.VERCEL_GIT_COMMIT_SHA?.trim();
+  if (vercelSha) return vercelSha;
+  return 'unknown';
+}

--- a/client/scripts/appVersion.test.ts
+++ b/client/scripts/appVersion.test.ts
@@ -1,0 +1,39 @@
+/**
+ * The build-time release identifier.
+ *
+ * Production reported `release: unknown` on every Sentry event: CI sets
+ * VITE_APP_VERSION for its own build, but Vercel builds the deployed bundle
+ * separately and Vite only exposes `VITE_`-prefixed variables — so
+ * VERCEL_GIT_COMMIT_SHA, which Vercel does inject, never reached the client.
+ */
+import { describe, it, expect } from 'vitest';
+// @ts-expect-error — build script module, not part of the app's TS program.
+import { resolveAppVersion } from './appVersion.mjs';
+
+const resolve = resolveAppVersion as (env: Record<string, string | undefined>) => string;
+
+describe('resolveAppVersion', () => {
+  it('prefers an explicit VITE_APP_VERSION', () => {
+    // CI sets this to github.sha; it must keep winning.
+    expect(resolve({ VITE_APP_VERSION: 'abc123', VERCEL_GIT_COMMIT_SHA: 'def456' })).toBe('abc123');
+  });
+
+  it('falls back to the commit Vercel injects into its own build', () => {
+    expect(resolve({ VERCEL_GIT_COMMIT_SHA: 'def456' })).toBe('def456');
+  });
+
+  it('ignores an empty value rather than reporting a blank release', () => {
+    expect(resolve({ VITE_APP_VERSION: '', VERCEL_GIT_COMMIT_SHA: 'def456' })).toBe('def456');
+    expect(resolve({ VITE_APP_VERSION: '   ' })).toBe('unknown');
+  });
+
+  it('still says unknown when nothing identifies the build', () => {
+    // A local `npm run build` has neither. Keeping the literal means the
+    // Sentry events that do carry it are unambiguously untagged builds.
+    expect(resolve({})).toBe('unknown');
+  });
+
+  it('trims, so a shell-injected newline does not become part of the release', () => {
+    expect(resolve({ VITE_APP_VERSION: 'abc123\n' })).toBe('abc123');
+  });
+});

--- a/client/scripts/checkArchitectureInvariants.test.ts
+++ b/client/scripts/checkArchitectureInvariants.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { isSuspiciousDailyFritzScoreAccess } from './checkArchitectureInvariants.ts';
+import {
+  findUnguardedFloatingImports,
+  isSuspiciousDailyFritzScoreAccess,
+} from './checkArchitectureInvariants.ts';
 
 // INV-13 — Daily Fritz Score Trust. This test proves the hard-fail detection
 // path fires on an injected violation (client-supplied score/result read
@@ -45,5 +48,63 @@ describe('INV-13 Daily Fritz Score Trust heuristic', () => {
       }
     `;
     expect(isSuspiciousDailyFritzScoreAccess(unrelated)).toBe(false);
+  });
+});
+
+
+/**
+ * INV-15 — Guarded floating imports.
+ *
+ * A dynamic import kicked off as a floating promise has nowhere to report a
+ * failure, so a failed chunk fetch became an unhandled rejection. That is what
+ * the global module-import-recovery handler saw, and it could not tell a
+ * telemetry chunk from a chunk the UI needs.
+ */
+describe('INV-15 guarded floating imports', () => {
+  it('flags a void import with no catch', () => {
+    const violation = `
+      void import('./statsApi').then(({ fetchWeeklyRecap }) => {
+        setRecap(fetchWeeklyRecap());
+      });
+    `;
+    expect(findUnguardedFloatingImports(violation)).toEqual(["import('./statsApi')"]);
+  });
+
+  it('accepts a void import whose chain ends in a catch', () => {
+    const guarded = `
+      void import('./statsApi')
+        .then(({ fetchWeeklyRecap }) => setRecap(fetchWeeklyRecap()))
+        .catch(() => setRecap(null));
+    `;
+    expect(findUnguardedFloatingImports(guarded)).toEqual([]);
+  });
+
+  it('does not credit one statement with a later statement catch', () => {
+    const violation = `
+      void import('./a').then(useA);
+      void import('./b').then(useB).catch(noop);
+    `;
+    expect(findUnguardedFloatingImports(violation)).toEqual(["import('./a')"]);
+  });
+
+  it('ignores an awaited import, which the enclosing try/catch owns', () => {
+    const awaited = `
+      const mod = await import('web-vitals');
+      mod.onCLS(report);
+    `;
+    expect(findUnguardedFloatingImports(awaited)).toEqual([]);
+  });
+
+  it('ignores React.lazy, whose failures reach an ErrorBoundary', () => {
+    const lazy = `const Screen = React.lazy(() => import('../screens/SettingsScreen'));`;
+    expect(findUnguardedFloatingImports(lazy)).toEqual([]);
+  });
+
+  it('finds every violation in a file, not just the first', () => {
+    const violation = `
+      void import('./a').then(useA);
+      void import('./b').then(useB);
+    `;
+    expect(findUnguardedFloatingImports(violation)).toEqual(["import('./a')", "import('./b')"]);
   });
 });

--- a/client/scripts/checkArchitectureInvariants.ts
+++ b/client/scripts/checkArchitectureInvariants.ts
@@ -49,6 +49,70 @@ const LOC_CAPS: Array<{ file: string; cap: number }> = [
   { file: 'client/src/AppRoutes.tsx', cap: 500 },
 ];
 
+/**
+ * INV-15 — Guarded floating imports.
+ *
+ * A dynamic import started as a floating promise (`void import(...)`) has
+ * nowhere to report a failure. A failed chunk fetch therefore surfaced as an
+ * unhandled rejection, which the global module-import-recovery handler could
+ * not distinguish from a chunk the UI actually needs — so a telemetry chunk
+ * failing to load could force-reload a working app.
+ *
+ * Deliberately narrow. It looks only at the floating form: an awaited import
+ * is owned by its enclosing try/catch, and `React.lazy` failures reach an
+ * ErrorBoundary, which is the path module-import recovery now runs on.
+ *
+ * Returns the offending `import(...)` expressions, so a failure names them.
+ */
+export function findUnguardedFloatingImports(source: string): string[] {
+  const offenders: string[] = [];
+  const floating = /\bvoid\s+import\s*\(/g;
+
+  let match: RegExpExecArray | null;
+  while ((match = floating.exec(source)) !== null) {
+    const importStart = source.indexOf('import', match.index);
+    const openParen = source.indexOf('(', importStart);
+    const specifierEnd = matchingParen(source, openParen);
+    if (specifierEnd < 0) continue;
+
+    const expression = source.slice(importStart, specifierEnd + 1).replace(/\s+/g, '');
+    const chainEnd = endOfStatement(source, specifierEnd + 1);
+    const chain = source.slice(specifierEnd + 1, chainEnd);
+    if (!/\.catch\s*\(/.test(chain)) offenders.push(expression);
+  }
+
+  return offenders;
+}
+
+/** Index of the `)` closing the `(` at `open`, or -1. */
+function matchingParen(source: string, open: number): number {
+  let depth = 0;
+  for (let i = open; i < source.length; i += 1) {
+    if (source[i] === '(') depth += 1;
+    else if (source[i] === ')') {
+      depth -= 1;
+      if (depth === 0) return i;
+    }
+  }
+  return -1;
+}
+
+/**
+ * End of the statement that began at `from`: the first `;` at paren/brace
+ * depth zero. Bounded by the source length so an unterminated statement does
+ * not swallow the rest of the file and borrow a later statement's `.catch`.
+ */
+function endOfStatement(source: string, from: number): number {
+  let depth = 0;
+  for (let i = from; i < source.length; i += 1) {
+    const char = source[i];
+    if (char === '(' || char === '{' || char === '[') depth += 1;
+    else if (char === ')' || char === '}' || char === ']') depth -= 1;
+    else if (char === ';' && depth <= 0) return i;
+  }
+  return source.length;
+}
+
 type CheckResult = {
   id: string;
   name: string;
@@ -918,6 +982,36 @@ function checkLocCaps(): void {
 }
 
 // ---------------------------------------------------------------------------
+// 15. Guarded floating imports
+// ---------------------------------------------------------------------------
+function checkFloatingImports(): void {
+  const errors: string[] = [];
+  const files = walkTsFiles(CLIENT_SRC).filter((f) => !/\.test\.tsx?$/.test(f));
+
+  let flaggedFiles = 0;
+  for (const file of files) {
+    const offenders = findUnguardedFloatingImports(fs.readFileSync(file, 'utf8'));
+    if (offenders.length === 0) continue;
+    flaggedFiles += 1;
+    for (const offender of offenders) {
+      errors.push(
+        `${relativeSrcPath(file)} starts ${offender} as a floating promise with no .catch — ` +
+        `a failed chunk fetch becomes an unhandled rejection (INV-15)`,
+      );
+    }
+  }
+
+  addResult({
+    id: 'INV-15',
+    name: 'Guarded Floating Imports',
+    status: errors.length === 0 ? 'pass' : 'fail',
+    errors,
+    warnings: [],
+    metrics: { clientFilesScanned: files.length, flaggedFiles },
+  });
+}
+
+// ---------------------------------------------------------------------------
 // Report
 // ---------------------------------------------------------------------------
 function printReport(manifest: ArchitectureManifest): void {
@@ -1033,6 +1127,7 @@ function main(): void {
   checkNoBackupFiles();
   checkDailyFritzScoreTrust();
   checkLocCaps();
+  checkFloatingImports();
 
   printReport(manifest);
 }

--- a/client/scripts/prerenderRewrites.test.ts
+++ b/client/scripts/prerenderRewrites.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Every prerendered shell needs a rewrite pointing at it.
+ *
+ * /settings was added to the prerender list without one, so Vercel's catch-all
+ * served index.html and the generated settings.html was never reachable. The
+ * route worked, which is exactly why nothing caught it.
+ */
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+// @ts-expect-error — build script module, not part of the app's TS program.
+import { PRERENDER_ROUTES } from './prerenderRoutes.mjs';
+
+type Route = { path: string; output?: string };
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const vercel = JSON.parse(readFileSync(path.join(repoRoot, 'vercel.json'), 'utf8')) as {
+  rewrites: { source: string; destination: string }[];
+};
+
+/**
+ * Asserted on `output`, not on `path`. Some shells are templates rather than
+ * URLs — the `/players` shell is served for `/players/:username`, and
+ * `/tournament/result` for `/tournament/:id/result` — so the invariant that
+ * actually matters is that every generated file is some rewrite's
+ * destination. `/` has no output: it is written as index.html and served
+ * directly.
+ */
+describe('prerendered shells are reachable', () => {
+  const destinations = new Set(vercel.rewrites.map((rule) => rule.destination));
+
+  it.each(
+    (PRERENDER_ROUTES as Route[])
+      .filter((route) => route.output)
+      .map((route) => [route.path, route.output!] as const),
+  )('%s → %s is served by a rewrite, not the catch-all', (_routePath, output) => {
+    expect(destinations.has(`/${output}`), `nothing rewrites to /${output}`).toBe(true);
+  });
+
+  it('writes the home shell to index.html rather than needing a rewrite', () => {
+    const home = (PRERENDER_ROUTES as Route[]).find((route) => route.path === '/');
+    expect(home?.output).toBeUndefined();
+  });
+
+  it('keeps the catch-all last, so it cannot shadow a shell', () => {
+    expect(vercel.rewrites.at(-1)!.source).toBe('/(.*)');
+  });
+});

--- a/client/src/AppOverlays.tsx
+++ b/client/src/AppOverlays.tsx
@@ -1,4 +1,5 @@
 import React, { Suspense } from 'react';
+import { ErrorBoundary } from './components/ErrorBoundary';
 import { FriendInvitePopupBridge } from './multiplayer/FriendInvitePopupBridge';
 import type { FriendInviteState } from './multiplayer/runtime/friendInviteRuntime';
 
@@ -53,6 +54,11 @@ export function AuthModalsLayer({
   signingOut,
 }: AuthModalsLayerProps) {
   return (
+    // The only React.lazy site with no ErrorBoundary above it: the route
+    // boundaries live inside this layer's children, not around it. Without one
+    // a failed modal chunk takes the whole tree down and, now that recovery
+    // runs from the boundary, would have no way back.
+    <ErrorBoundary context="auth-modals" fallback={null}>
     <Suspense fallback={null}>
       <AuthModal
         open={authModalOpen}
@@ -78,6 +84,7 @@ export function AuthModalsLayer({
         signingOut={signingOut}
       />
     </Suspense>
+    </ErrorBoundary>
   );
 }
 

--- a/client/src/components/ErrorBoundary.chunkRecovery.test.tsx
+++ b/client/src/components/ErrorBoundary.chunkRecovery.test.tsx
@@ -1,0 +1,107 @@
+// @vitest-environment jsdom
+import { render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Where module-import recovery fires, and where it does not.
+ *
+ * It used to run from the global error/unhandledrejection handlers, so any
+ * rejected promise whose message matched could reload the page — including a
+ * telemetry chunk failing, which no user would otherwise notice. These pin the
+ * narrowed trigger.
+ */
+
+const { captureException, addBreadcrumb } = vi.hoisted(() => ({
+  captureException: vi.fn(),
+  addBreadcrumb: vi.fn(),
+}));
+vi.mock('@sentry/react', () => ({ captureException, addBreadcrumb }));
+
+const { ErrorBoundary } = await import('./ErrorBoundary');
+const { MODULE_IMPORT_RECOVERY_KEY } = await import('../debug/moduleImportRecovery');
+const { installGlobalErrorHandlers } = await import('../debug/globalErrors');
+
+const replace = vi.fn();
+
+function Boom({ message }: { message: string }): never {
+  throw new Error(message);
+}
+
+beforeEach(() => {
+  replace.mockReset();
+  captureException.mockReset();
+  window.sessionStorage.removeItem(MODULE_IMPORT_RECOVERY_KEY);
+  Object.defineProperty(window, 'location', {
+    configurable: true,
+    value: { pathname: '/solo', search: '', hash: '', replace },
+  });
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('module-import recovery — what triggers it', () => {
+  it('reloads when a lazy chunk fails under a boundary', () => {
+    render(
+      <ErrorBoundary context="test" fallback={null}>
+        <Boom message="Importing a module script failed." />
+      </ErrorBoundary>,
+    );
+
+    expect(replace).toHaveBeenCalledTimes(1);
+    expect(replace.mock.calls[0]![0]).toMatch(/rh_reload=\d+/);
+  });
+
+  it('does not also report a recovered load as an error', () => {
+    render(
+      <ErrorBoundary context="test" fallback={null}>
+        <Boom message="Importing a module script failed." />
+      </ErrorBoundary>,
+    );
+
+    expect(captureException).not.toHaveBeenCalled();
+  });
+});
+
+describe('module-import recovery — what does not trigger it', () => {
+  it('leaves an ordinary component crash alone, and still reports it', () => {
+    render(
+      <ErrorBoundary context="test" fallback={<p>fallback</p>}>
+        <Boom message="Cannot read properties of undefined" />
+      </ErrorBoundary>,
+    );
+
+    expect(replace).not.toHaveBeenCalled();
+    // Called, not called-once: ErrorBoundary reports each error to Sentry
+    // twice today (directly, and again through logger.error). Pre-existing and
+    // out of scope here, but worth knowing before reading issue counts.
+    expect(captureException).toHaveBeenCalled();
+    expect(screen.getByText('fallback')).toBeTruthy();
+  });
+
+  it('ignores an unhandled rejection, even one that mentions a module script', () => {
+    // This is the case that reloaded working apps: a telemetry chunk failing
+    // is a rejected promise, not a broken UI.
+    installGlobalErrorHandlers();
+
+    window.dispatchEvent(
+      Object.assign(new Event('unhandledrejection'), {
+        reason: new Error('Importing a module script failed.'),
+      }),
+    );
+
+    expect(replace).not.toHaveBeenCalled();
+  });
+
+  it('ignores an uncaught window error mentioning a module script', () => {
+    installGlobalErrorHandlers();
+
+    window.dispatchEvent(
+      Object.assign(new Event('error'), {
+        error: new Error('Importing a module script failed.'),
+      }),
+    );
+
+    expect(replace).not.toHaveBeenCalled();
+  });
+});

--- a/client/src/components/ErrorBoundary.tsx
+++ b/client/src/components/ErrorBoundary.tsx
@@ -3,6 +3,7 @@ import { Component } from 'react';
 import type { ErrorInfo, ReactNode } from 'react';
 import { DefaultErrorFallback } from './DefaultErrorFallback';
 import { logger } from '../utils/logger';
+import { recoverFromChunkLoadFailure } from '../debug/moduleImportRecovery';
 
 interface Props {
   children: ReactNode;
@@ -25,6 +26,12 @@ export class ErrorBoundary extends Component<Props, State> {
 
   componentDidCatch(error: Error, info: ErrorInfo) {
     const label = this.props.context ?? 'unknown';
+
+    // A lazy chunk that will not load after a deploy breaks this subtree and
+    // nothing else can fix it from here. One reload fetches a fresh entry
+    // HTML. Runs before logging so a recovered load is not also an alert.
+    if (recoverFromChunkLoadFailure(error) === 'reloaded') return;
+
     logger.error('ErrorBoundary.tsx', error, { label, componentStack: info.componentStack });
     Sentry.captureException(error, { extra: { label, componentStack: info.componentStack } });
     this.props.onError?.(error, info);

--- a/client/src/dailyFritz/api.ts
+++ b/client/src/dailyFritz/api.ts
@@ -30,6 +30,7 @@ export {
   throwApiResult,
   type DailyFritzMutationFailureKind,
 } from './dailyFritzMutations';
+import { reportOptionalChunkFailure } from '../utils/optionalChunk';
 import {
   createDailyFritzRequestId,
   DAILY_FRITZ_REQUEST_ID_HEADER,
@@ -563,7 +564,8 @@ function dfNextHandIngest(payload: {
   if (!DAILY_FRITZ_NEXT_HAND_DEBUG_INGEST) return;
   void import('../devtools/dailyFritzDebugIngest').then((module) => {
     module.ingestDailyFritzNextHandDebug(payload);
-  });
+  })
+    .catch((error) => reportOptionalChunkFailure('devtools/dailyFritzDebugIngest', error));
 }
 
 /** Production copy for modal; dev keeps the raw message for debugging. */

--- a/client/src/debug/globalErrors.ts
+++ b/client/src/debug/globalErrors.ts
@@ -1,41 +1,22 @@
 import { getSocketTrace } from './socketTrace';
 import { logger } from '../utils/logger';
 
-const MODULE_IMPORT_RECOVERY_KEY = 'rh:module-import-recovery';
-
-function isModuleImportFailure(reason: unknown): boolean {
-  if (reason instanceof Error) {
-    const msg = `${reason.name}: ${reason.message}`;
-    return /Importing a module script failed/i.test(msg);
-  }
-  if (typeof reason === 'string') {
-    return /Importing a module script failed/i.test(reason);
-  }
-  return false;
-}
-
-function recoverFromModuleImportFailure(reason: unknown): void {
-  if (!isModuleImportFailure(reason)) return;
-  try {
-    if (sessionStorage.getItem(MODULE_IMPORT_RECOVERY_KEY) === '1') return;
-    sessionStorage.setItem(MODULE_IMPORT_RECOVERY_KEY, '1');
-    // Stale chunk/index mismatch after deploy: force a clean entry HTML fetch once.
-    const bust = `rh_reload=${Date.now()}`;
-    const separator = window.location.search ? '&' : '?';
-    window.location.replace(`${window.location.pathname}${window.location.search}${separator}${bust}${window.location.hash}`);
-  } catch {
-    // Ignore storage/navigation failures and keep existing logging.
-  }
-}
-
+/**
+ * Global logging only.
+ *
+ * This used to also run the stale-chunk recovery reload, matching on the
+ * error message of *any* uncaught error or rejected promise. That could not
+ * tell a chunk the UI needs from a telemetry chunk nobody would notice, so a
+ * failed web-vitals fetch could reload a working app mid-match. Recovery now
+ * runs from the ErrorBoundary, where a chunk failure has demonstrably broken
+ * something the user can see — see debug/moduleImportRecovery.ts.
+ */
 export function installGlobalErrorHandlers() {
   window.addEventListener('error', (e) => {
     logger.error('globalErrors.ts', e.error ?? e.message, { socketTrace: getSocketTrace() });
-    recoverFromModuleImportFailure(e.error ?? e.message);
   });
 
   window.addEventListener('unhandledrejection', (e) => {
     logger.error('globalErrors.ts', e.reason, { socketTrace: getSocketTrace() });
-    recoverFromModuleImportFailure(e.reason);
   });
 }

--- a/client/src/debug/moduleImportRecovery.test.ts
+++ b/client/src/debug/moduleImportRecovery.test.ts
@@ -1,0 +1,159 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  MODULE_IMPORT_RECOVERY_KEY,
+  isChunkLoadFailure,
+  markAppLoadSuccessful,
+  recoverFromChunkLoadFailure,
+} from './moduleImportRecovery';
+
+function makeStorage(initial: Record<string, string> = {}) {
+  const store = { ...initial };
+  return {
+    getItem: (k: string) => store[k] ?? null,
+    setItem: (k: string, v: string) => {
+      store[k] = v;
+    },
+    removeItem: (k: string) => {
+      delete store[k];
+    },
+    _store: store,
+  };
+}
+
+function makeDeps(initial: Record<string, string> = {}) {
+  const storage = makeStorage(initial);
+  const reload = vi.fn();
+  return { storage, reload, href: '/solo?tier=elite#top', deps: { storage, reload, href: '/solo?tier=elite#top' } };
+}
+
+describe('isChunkLoadFailure', () => {
+  it.each([
+    // Safari / WebKit — the wording in the production report.
+    'Importing a module script failed.',
+    // Chromium.
+    'Failed to fetch dynamically imported module: https://x/assets/a.js',
+    // Firefox.
+    'error loading dynamically imported module',
+    // Vite's preload helper.
+    'Unable to preload CSS for /assets/a.css',
+  ])('recognises %s', (message) => {
+    expect(isChunkLoadFailure(new Error(message))).toBe(true);
+  });
+
+  it.each([
+    'Cannot read properties of undefined',
+    'NetworkError when attempting to fetch resource.',
+    'It is not your turn.',
+  ])('does not claim %s', (message) => {
+    expect(isChunkLoadFailure(new Error(message))).toBe(false);
+  });
+
+  it('handles a non-Error without throwing', () => {
+    expect(isChunkLoadFailure('Importing a module script failed.')).toBe(true);
+    expect(isChunkLoadFailure(undefined)).toBe(false);
+    expect(isChunkLoadFailure({ nope: true })).toBe(false);
+  });
+});
+
+describe('recoverFromChunkLoadFailure', () => {
+  let ctx: ReturnType<typeof makeDeps>;
+  beforeEach(() => {
+    ctx = makeDeps();
+  });
+
+  it('ignores anything that is not a chunk failure', () => {
+    const outcome = recoverFromChunkLoadFailure(new Error('It is not your turn.'), ctx.deps);
+
+    expect(outcome).toBe('ignored');
+    expect(ctx.reload).not.toHaveBeenCalled();
+  });
+
+  it('reloads once, busting the cached entry HTML', () => {
+    const outcome = recoverFromChunkLoadFailure(
+      new Error('Importing a module script failed.'),
+      ctx.deps,
+    );
+
+    expect(outcome).toBe('reloaded');
+    expect(ctx.reload).toHaveBeenCalledTimes(1);
+    const target = ctx.reload.mock.calls[0]![0] as string;
+    expect(target).toContain('/solo');
+    expect(target).toMatch(/rh_reload=\d+/);
+    // Query and hash survive: the reload must land the user where they were.
+    expect(target).toContain('tier=elite');
+    expect(target).toContain('#top');
+  });
+
+  it('refuses a second reload in the same tab, so a broken deploy cannot loop', () => {
+    recoverFromChunkLoadFailure(new Error('Importing a module script failed.'), ctx.deps);
+    ctx.reload.mockClear();
+
+    const outcome = recoverFromChunkLoadFailure(
+      new Error('Importing a module script failed.'),
+      ctx.deps,
+    );
+
+    expect(outcome).toBe('already-attempted');
+    expect(ctx.reload).not.toHaveBeenCalled();
+  });
+
+  it('recovers again once the app has come up successfully', () => {
+    // The bug this fixes: the guard was set and never cleared, so a long-lived
+    // mobile tab got exactly one recovery ever — and a genuine stale-deploy
+    // weeks later had none left.
+    recoverFromChunkLoadFailure(new Error('Importing a module script failed.'), ctx.deps);
+    markAppLoadSuccessful(ctx.deps);
+    ctx.reload.mockClear();
+
+    const outcome = recoverFromChunkLoadFailure(
+      new Error('Importing a module script failed.'),
+      ctx.deps,
+    );
+
+    expect(outcome).toBe('reloaded');
+    expect(ctx.reload).toHaveBeenCalledTimes(1);
+  });
+
+  it('leaves no marker behind after a successful load', () => {
+    recoverFromChunkLoadFailure(new Error('Importing a module script failed.'), ctx.deps);
+    expect(ctx.storage.getItem(MODULE_IMPORT_RECOVERY_KEY)).toBe('1');
+
+    markAppLoadSuccessful(ctx.deps);
+
+    expect(ctx.storage.getItem(MODULE_IMPORT_RECOVERY_KEY)).toBeNull();
+  });
+
+  it('does not throw when storage is unavailable', () => {
+    const hostile = {
+      getItem: () => {
+        throw new Error('storage disabled');
+      },
+      setItem: () => {
+        throw new Error('storage disabled');
+      },
+      removeItem: () => {
+        throw new Error('storage disabled');
+      },
+    };
+    const reload = vi.fn();
+
+    expect(() =>
+      recoverFromChunkLoadFailure(new Error('Importing a module script failed.'), {
+        storage: hostile,
+        reload,
+        href: '/',
+      }),
+    ).not.toThrow();
+    expect(() => markAppLoadSuccessful({ storage: hostile, reload, href: '/' })).not.toThrow();
+  });
+
+  it('does not stack cache-busting params across reloads', () => {
+    const deps = { ...ctx.deps, href: '/solo?rh_reload=111' };
+
+    recoverFromChunkLoadFailure(new Error('Importing a module script failed.'), deps);
+
+    const target = ctx.reload.mock.calls[0]![0] as string;
+    expect(target.match(/rh_reload=/g)).toHaveLength(1);
+  });
+});

--- a/client/src/debug/moduleImportRecovery.ts
+++ b/client/src/debug/moduleImportRecovery.ts
@@ -1,0 +1,114 @@
+/**
+ * Recovery from a stale chunk after a deploy.
+ *
+ * When a new build lands, an already-open tab holds an index.html that points
+ * at hashed chunks the new deploy no longer serves. The next lazy route the
+ * user opens fails to import, and the page is stuck until they reload by hand.
+ * One automatic reload fixes it, because the reload fetches a fresh entry HTML.
+ *
+ * This used to run from the global `error` and `unhandledrejection` handlers,
+ * which meant it fired for *any* rejected promise whose message matched —
+ * including a telemetry chunk that no user could notice failing. That reloaded
+ * working apps out from under people, potentially mid-match. It now runs only
+ * where a chunk failure has actually broken UI: from an ErrorBoundary, which
+ * is what catches a failed `React.lazy` import.
+ */
+
+export const MODULE_IMPORT_RECOVERY_KEY = 'rh:module-import-recovery';
+
+/** The query key the reload adds, and strips before adding again. */
+const CACHE_BUST_PARAM = 'rh_reload';
+
+/**
+ * Browser wordings for "a dynamic import did not load". They differ per engine
+ * and the production report came from WebKit, so all four are matched.
+ */
+const CHUNK_FAILURE_PATTERNS = [
+  /Importing a module script failed/i,
+  /Failed to fetch dynamically imported module/i,
+  /error loading dynamically imported module/i,
+  /Unable to preload CSS/i,
+];
+
+export type RecoveryOutcome = 'reloaded' | 'already-attempted' | 'ignored';
+
+export type RecoveryDeps = {
+  storage: Pick<Storage, 'getItem' | 'setItem' | 'removeItem'>;
+  reload: (href: string) => void;
+  href: string;
+};
+
+function defaultDeps(): RecoveryDeps | null {
+  if (typeof window === 'undefined') return null;
+  return {
+    storage: window.sessionStorage,
+    reload: (href) => window.location.replace(href),
+    href: `${window.location.pathname}${window.location.search}${window.location.hash}`,
+  };
+}
+
+export function isChunkLoadFailure(error: unknown): boolean {
+  const message =
+    error instanceof Error
+      ? `${error.name}: ${error.message}`
+      : typeof error === 'string'
+        ? error
+        : '';
+  if (!message) return false;
+  return CHUNK_FAILURE_PATTERNS.some((pattern) => pattern.test(message));
+}
+
+/** Adds a fresh cache-buster, replacing any left by a previous recovery. */
+function bustedHref(href: string): string {
+  const [pathAndQuery = '', hash = ''] = href.split('#');
+  const [path = '', query = ''] = pathAndQuery.split('?');
+  const params = new URLSearchParams(query);
+  params.delete(CACHE_BUST_PARAM);
+  params.set(CACHE_BUST_PARAM, String(Date.now()));
+  return `${path}?${params.toString()}${hash ? `#${hash}` : ''}`;
+}
+
+/**
+ * One reload per tab, per successful load. The guard stops a genuinely broken
+ * deploy from putting a tab into a reload loop; `markAppLoadSuccessful` lifts
+ * it once the app is up, so a later deploy can still be recovered from.
+ */
+export function recoverFromChunkLoadFailure(
+  error: unknown,
+  deps: RecoveryDeps | null = defaultDeps(),
+): RecoveryOutcome {
+  if (!deps) return 'ignored';
+  if (!isChunkLoadFailure(error)) return 'ignored';
+
+  try {
+    if (deps.storage.getItem(MODULE_IMPORT_RECOVERY_KEY) === '1') return 'already-attempted';
+    deps.storage.setItem(MODULE_IMPORT_RECOVERY_KEY, '1');
+  } catch {
+    // Storage unavailable (private mode, blocked cookies). Without a guard a
+    // reload could loop, so decline rather than risk it.
+    return 'already-attempted';
+  }
+
+  try {
+    deps.reload(bustedHref(deps.href));
+    return 'reloaded';
+  } catch {
+    return 'already-attempted';
+  }
+}
+
+/**
+ * Clears the guard once the app has come up.
+ *
+ * Without this the marker was set and never removed, so a tab got exactly one
+ * recovery for its whole lifetime — and mobile tabs live for weeks. A real
+ * stale-deploy failure months later had no recovery left.
+ */
+export function markAppLoadSuccessful(deps: RecoveryDeps | null = defaultDeps()): void {
+  if (!deps) return;
+  try {
+    deps.storage.removeItem(MODULE_IMPORT_RECOVERY_KEY);
+  } catch {
+    // Nothing to clear if storage is unavailable.
+  }
+}

--- a/client/src/debug/reportWebVitals.test.ts
+++ b/client/src/debug/reportWebVitals.test.ts
@@ -1,0 +1,56 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { reportOptionalChunkFailure } = vi.hoisted(() => ({
+  reportOptionalChunkFailure: vi.fn(),
+}));
+vi.mock('../utils/optionalChunk', () => ({ reportOptionalChunkFailure }));
+
+const { reportWebVitals } = await import('./reportWebVitals');
+
+/**
+ * The import this exists to guard is the one implicated in the production
+ * "Importing a module script failed" report: it ran on every load of `/`,
+ * behind a bare `void` with no catch, so a failed fetch of a telemetry chunk
+ * became an unhandled rejection — and the global recovery handler reloaded the
+ * page over it.
+ */
+describe('reportWebVitals', () => {
+  beforeEach(() => reportOptionalChunkFailure.mockReset());
+
+  it('subscribes to the vitals it reports', async () => {
+    const onCLS = vi.fn();
+    await reportWebVitals({
+      enabled: true,
+      load: async () => ({ onCLS, onINP: vi.fn(), onLCP: vi.fn(), onFCP: vi.fn(), onTTFB: vi.fn() }),
+    });
+
+    expect(onCLS).toHaveBeenCalledTimes(1);
+  });
+
+  it('resolves rather than rejecting when the chunk cannot be fetched', async () => {
+    // The whole point: no unhandled rejection escapes.
+    await expect(
+      reportWebVitals({
+        enabled: true,
+        load: () => Promise.reject(new Error('Importing a module script failed.')),
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('reports the failed fetch as an optional chunk', async () => {
+    await reportWebVitals({
+      enabled: true,
+      load: () => Promise.reject(new Error('Importing a module script failed.')),
+    });
+
+    expect(reportOptionalChunkFailure).toHaveBeenCalledWith('web-vitals', expect.any(Error));
+  });
+
+  it('does nothing at all outside production', async () => {
+    const load = vi.fn();
+    await reportWebVitals({ load, enabled: false });
+
+    expect(load).not.toHaveBeenCalled();
+  });
+});

--- a/client/src/debug/reportWebVitals.ts
+++ b/client/src/debug/reportWebVitals.ts
@@ -1,0 +1,59 @@
+import * as Sentry from '@sentry/react';
+import { reportOptionalChunkFailure } from '../utils/optionalChunk';
+
+type Metric = { name: string; value: number; id: string };
+type Subscribe = (report: (metric: Metric) => void) => void;
+
+type WebVitals = {
+  onCLS: Subscribe;
+  onINP: Subscribe;
+  onLCP: Subscribe;
+  onFCP: Subscribe;
+  onTTFB: Subscribe;
+};
+
+export type ReportWebVitalsOptions = {
+  /** Injected so the failure path can be tested without a broken network. */
+  load?: () => Promise<WebVitals>;
+  enabled?: boolean;
+};
+
+/**
+ * Web Vitals → Sentry measurements.
+ *
+ * Lives in its own module so the chunk fetch can be tested. It used to sit in
+ * main.tsx behind a bare `void reportWebVitals()` with no catch, and its
+ * `await import('web-vitals')` was unguarded — so on every load of `/`, a
+ * failed fetch of a telemetry chunk became an unhandled rejection. That is the
+ * shape of the production "Importing a module script failed" report, and the
+ * global recovery handler responded by reloading a working app.
+ *
+ * Nothing here is worth a single frame of user-visible disruption, so a
+ * failure is recorded as context and the function resolves.
+ */
+export async function reportWebVitals(options: ReportWebVitalsOptions = {}): Promise<void> {
+  const enabled = options.enabled ?? import.meta.env.PROD;
+  if (!enabled) return;
+
+  const load = options.load ?? (() => import('web-vitals') as Promise<WebVitals>);
+
+  let vitals: WebVitals;
+  try {
+    vitals = await load();
+  } catch (error) {
+    reportOptionalChunkFailure('web-vitals', error);
+    return;
+  }
+
+  const report = ({ name, value, id }: Metric) => {
+    Sentry.setMeasurement(name, Math.round(name === 'CLS' ? value * 1000 : value), 'millisecond');
+    // Also send as a custom event so Sentry's perf tab picks it up.
+    Sentry.addBreadcrumb({ category: 'web-vitals', message: name, data: { value, id }, level: 'info' });
+  };
+
+  vitals.onCLS(report);
+  vitals.onINP(report);
+  vitals.onLCP(report);
+  vitals.onFCP(report);
+  vitals.onTTFB(report);
+}

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -26,6 +26,7 @@ import { BrowserRouter } from 'react-router-dom';
 import { consumeSupabaseRecoveryHash } from './auth/recoveryHash';
 import { AuthProvider } from './auth/useAuth';
 import { installGlobalErrorHandlers } from "./debug/globalErrors";
+import { reportWebVitals } from './debug/reportWebVitals';
 import { migrateLegacyHashRoute } from './routing/legacyHashRoute';
 import './styles/tokens.css';
 import './styles/rh-mobile-chrome.css';
@@ -52,23 +53,8 @@ import './styles/board/index.css';
 
 {installGlobalErrorHandlers();}
 
-// Web Vitals — report to Sentry as measurements so we can track LCP/CLS/INP
-// in the performance dashboard without a separate analytics pipeline.
-async function reportWebVitals() {
-  if (!import.meta.env.PROD) return;
-  const { onCLS, onINP, onLCP, onFCP, onTTFB } = await import('web-vitals');
-  const report = ({ name, value, id }: { name: string; value: number; id: string }) => {
-    Sentry.setMeasurement(name, Math.round(name === 'CLS' ? value * 1000 : value), 'millisecond');
-    // Also send as a custom event so Sentry perf tab picks it up
-    Sentry.addBreadcrumb({ category: 'web-vitals', message: name, data: { value, id }, level: 'info' });
-  };
-  onCLS(report);
-  onINP(report);
-  onLCP(report);
-  onFCP(report);
-  onTTFB(report);
-}
-
+// Web Vitals → Sentry. Its chunk fetch is guarded inside the module: a
+// telemetry chunk failing must never surface as an unhandled rejection.
 void reportWebVitals();
 
 async function bootstrap() {

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -26,6 +26,7 @@ import { BrowserRouter } from 'react-router-dom';
 import { consumeSupabaseRecoveryHash } from './auth/recoveryHash';
 import { AuthProvider } from './auth/useAuth';
 import { installGlobalErrorHandlers } from "./debug/globalErrors";
+import { markAppLoadSuccessful } from './debug/moduleImportRecovery';
 import { reportWebVitals } from './debug/reportWebVitals';
 import { migrateLegacyHashRoute } from './routing/legacyHashRoute';
 import './styles/tokens.css';
@@ -66,6 +67,11 @@ async function bootstrap() {
   // Outside React on purpose: one page load, one session_start. An effect here
   // would fire twice under StrictMode in development.
   track('session_start');
+
+  // The app is up: release the one-reload-per-tab guard so a stale deploy
+  // weeks from now can still be recovered from. Deferred past render so a
+  // subtree that fails to mount does not count as a successful load.
+  window.setTimeout(markAppLoadSuccessful, 0);
 
   createRoot(document.getElementById('root')!).render(
     <StrictMode>

--- a/client/src/modules/guided/useAuthoringCapture.ts
+++ b/client/src/modules/guided/useAuthoringCapture.ts
@@ -31,6 +31,7 @@ import type {
   LessonV2Event,
   LessonV2HandStart,
 } from '../../learn/lessonV2.ts';
+import { reportOptionalChunkFailure } from '../../utils/optionalChunk';
 
 type LessonV2Api = typeof import('../../learn/lessonV2.ts');
 type CreateV2EventArgs = Parameters<LessonV2Api['createV2Event']>[0];
@@ -117,7 +118,8 @@ export function useAuthoringCapture({
       setAuthoringV2HandStarts(saved?.handStarts ?? []);
       authoringV2NextEventIndexRef.current = saved?.events.length ?? 0;
       authoringV2CreatedAtRef.current = saved?.createdAt ?? new Date().toISOString();
-    });
+    })
+      .catch((error) => reportOptionalChunkFailure('learn/lessonV2', error));
 
     return () => {
       cancelled = true;

--- a/client/src/modules/guided/useGuidedMatchRuntime.ts
+++ b/client/src/modules/guided/useGuidedMatchRuntime.ts
@@ -13,6 +13,7 @@ import type {
   UseGuidedMatchRuntimeArgs,
   UseGuidedMatchRuntimeBaseResult,
 } from './useGuidedMatchRuntimeTypes.ts';
+import { reportOptionalChunkFailure } from '../../utils/optionalChunk';
 
 export type { GuidedPlacementResult } from './guidedPlacementHandlers.ts';
 export type { UseGuidedMatchRuntimeArgs, UseGuidedMatchRuntimeBaseResult };
@@ -75,7 +76,8 @@ export function useGuidedMatchRuntime(args: UseGuidedMatchRuntimeArgs): UseGuide
       if (!cancelled) {
         setGuidedMatchFinalDebrief(module.getPublicGuidedMatchFinalDebrief());
       }
-    });
+    })
+      .catch((error) => reportOptionalChunkFailure('learn/guidedMatchLessonLoader', error));
     return () => {
       cancelled = true;
     };

--- a/client/src/modules/match/hand-lifecycle/handLifecycleRules.ts
+++ b/client/src/modules/match/hand-lifecycle/handLifecycleRules.ts
@@ -4,6 +4,7 @@
  */
 
 import type { HandLifecyclePhase, HandLifecycleLogPayload } from '@racehorse/match-protocol';
+import { reportOptionalChunkFailure } from '../../../utils/optionalChunk';
 
 export type { HandLifecyclePhase, HandLifecycleLogPayload };
 
@@ -197,5 +198,6 @@ export function emitHandLifecycleDebugLog(
   if (!import.meta.env.DEV) return;
   void import('../../../devtools/handLifecycleDebug.ts').then((module) => {
     module.emitHandLifecycleDebugLog(payload);
-  });
+  })
+    .catch((error) => reportOptionalChunkFailure('devtools/handLifecycleDebug', error));
 }

--- a/client/src/multiplayer/MultiplayerGameShell.tsx
+++ b/client/src/multiplayer/MultiplayerGameShell.tsx
@@ -53,6 +53,7 @@ import type {
   MultiplayerShellDelegates,
   MultiplayerGameShellProps,
 } from './multiplayerGameShellTypes';
+import { reportOptionalChunkFailure } from '../utils/optionalChunk';
 
 function MultiplayerGameShellComponent({
   socket,
@@ -750,7 +751,8 @@ function MultiplayerGameShellComponent({
           setAnalyzerOpen(true);
         },
       );
-    });
+    })
+      .catch((error) => reportOptionalChunkFailure('analyzer/moveAnalyzer', error));
   }, [canOpenPostGameReview, multiplayerMoveLog]);
 
   const isHandActive = Boolean(state) && !state?.handOver && !state?.gameOver;

--- a/client/src/multiplayer/usePrivateLobbyWinStreak.ts
+++ b/client/src/multiplayer/usePrivateLobbyWinStreak.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import type { AppMode } from '../appRouteTypes';
 import { shouldShowPrivateMatchLobby } from './privateLobbyVisibility';
+import { reportOptionalChunkFailure } from '../utils/optionalChunk';
 
 export type UsePrivateLobbyWinStreakParams = {
   appMode: AppMode;
@@ -35,7 +36,8 @@ export function usePrivateLobbyWinStreak(
         if (cancelled) return;
         if (res.error || !res.data) { setWinStreak(null); return; }
         setWinStreak(res.data.currentWinStreak);
-      });
+      })
+      .catch((error) => reportOptionalChunkFailure('stats/statsApi', error));
     return () => { cancelled = true; };
   }, [appMode, authUserId, isConnected, isRecoveringConnection, joinedRoom, hasLiveGameState]);
 

--- a/client/src/tournament/useTournamentDisplayLabels.ts
+++ b/client/src/tournament/useTournamentDisplayLabels.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import type { TournamentMatchContext } from '../match/session/tournament/tournamentMatchSessionTypes';
 import type { UserProfile } from '../auth/useAuth';
+import { reportOptionalChunkFailure } from '../utils/optionalChunk';
 
 type RoomPlayer = { id: string; username: string; userId: string | null };
 
@@ -42,7 +43,8 @@ export function useTournamentDisplayLabels(
           roomOpponentUsername: opponentInRoom?.username ?? null,
         }),
       );
-    });
+    })
+      .catch((error) => reportOptionalChunkFailure('./displayNames', error));
 
     return () => {
       cancelled = true;

--- a/client/src/utils/optionalChunk.test.ts
+++ b/client/src/utils/optionalChunk.test.ts
@@ -1,0 +1,50 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { addBreadcrumb, captureException } = vi.hoisted(() => ({
+  addBreadcrumb: vi.fn(),
+  captureException: vi.fn(),
+}));
+
+vi.mock('@sentry/react', () => ({ addBreadcrumb, captureException }));
+
+const { reportOptionalChunkFailure } = await import('./optionalChunk');
+
+describe('reportOptionalChunkFailure', () => {
+  beforeEach(() => {
+    addBreadcrumb.mockReset();
+    captureException.mockReset();
+  });
+
+  it('records the failure as context, not as its own Sentry issue', () => {
+    // These chunks are optional by definition. Capturing each one as an
+    // exception is how a flaky mobile connection turns into an alert storm.
+    reportOptionalChunkFailure('web-vitals', new Error('Importing a module script failed.'));
+
+    expect(captureException).not.toHaveBeenCalled();
+    expect(addBreadcrumb).toHaveBeenCalledTimes(1);
+  });
+
+  it('names the chunk and the reason in the breadcrumb', () => {
+    reportOptionalChunkFailure('canvas-confetti', new Error('boom'));
+
+    const crumb = addBreadcrumb.mock.calls[0]![0] as { data?: Record<string, unknown> };
+    expect(crumb.data).toMatchObject({ chunk: 'canvas-confetti', reason: 'boom' });
+  });
+
+  it('survives a non-Error rejection', () => {
+    expect(() => reportOptionalChunkFailure('web-vitals', 'plain string')).not.toThrow();
+    const crumb = addBreadcrumb.mock.calls[0]![0] as { data?: Record<string, unknown> };
+    expect(crumb.data).toMatchObject({ reason: 'plain string' });
+  });
+
+  it('never throws, whatever Sentry does', () => {
+    // It is only ever called from a catch handler. Throwing there would
+    // recreate the unhandled rejection it exists to prevent.
+    addBreadcrumb.mockImplementation(() => {
+      throw new Error('sentry unavailable');
+    });
+
+    expect(() => reportOptionalChunkFailure('web-vitals', new Error('boom'))).not.toThrow();
+  });
+});

--- a/client/src/utils/optionalChunk.ts
+++ b/client/src/utils/optionalChunk.ts
@@ -1,0 +1,30 @@
+import * as Sentry from '@sentry/react';
+
+/**
+ * Reports a failed *optional* chunk fetch.
+ *
+ * Some dynamic imports carry things the app can do without — telemetry,
+ * confetti, a display-name helper, a debug module. When one of those fails to
+ * load (a stale hash after a deploy, a dropped mobile connection, a
+ * backgrounded tab) the right response is to note it and carry on.
+ *
+ * A breadcrumb rather than `captureException`, deliberately: these fail for
+ * environmental reasons on flaky networks, and capturing each one turns a bad
+ * signal into an alert storm. They stay visible as context on whatever real
+ * error follows.
+ *
+ * Only ever called from a catch handler, so it must not throw — doing so would
+ * recreate the unhandled rejection it exists to prevent.
+ */
+export function reportOptionalChunkFailure(chunk: string, error: unknown): void {
+  try {
+    Sentry.addBreadcrumb({
+      category: 'chunk',
+      message: 'optional chunk failed to load',
+      level: 'warning',
+      data: { chunk, reason: error instanceof Error ? error.message : String(error) },
+    });
+  } catch {
+    // Reporting is best-effort by construction.
+  }
+}

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -3,6 +3,8 @@ import { fileURLToPath } from 'node:url';
 import type { Plugin } from 'vite';
 import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
+// @ts-expect-error — build script module, not part of the app's TS program.
+import { resolveAppVersion } from './scripts/appVersion.mjs';
 
 // Injects <link rel="preload" fetchpriority="high"> for hero images used as
 // CSS backgrounds on the home screen so Lighthouse discovers LCP resources
@@ -46,6 +48,12 @@ export default defineConfig({
     },
   },
   plugins: [react(), preloadHeroImagePlugin()],
+  // Baked in rather than read from the environment at runtime: Vite only
+  // exposes VITE_-prefixed variables, so Vercel's VERCEL_GIT_COMMIT_SHA could
+  // not reach the client and every Sentry event reported release 'unknown'.
+  define: {
+    'import.meta.env.VITE_APP_VERSION': JSON.stringify(resolveAppVersion()),
+  },
   test: {
     environment: 'jsdom',
     globals: true,

--- a/vercel.json
+++ b/vercel.json
@@ -87,6 +87,7 @@
     { "source": "/multiplayer", "destination": "/multiplayer.html" },
     { "source": "/multiplayer/private", "destination": "/multiplayer-private.html" },
     { "source": "/social", "destination": "/social.html" },
+    { "source": "/settings", "destination": "/settings.html" },
     { "source": "/players/:username", "destination": "/players.html" },
     { "source": "/journey", "destination": "/journey.html" },
     { "source": "/learn", "destination": "/learn.html" },


### PR DESCRIPTION
Follow-up to the `TypeError: Importing a module script failed` Sentry report (`008e2b2e…`, Chrome iOS, `/`). Five changes, one commit each — review them in order.

## 1. `fix(observability)` — Vercel builds get a real Sentry release
Every production event reported `release: unknown`, which is why that report arrived with no stack.

CI *already* sets `VITE_APP_VERSION` and uploads sourcemaps — but **CI is not what builds the deployed bundle**. Vercel builds it, and Vite only exposes `VITE_`-prefixed variables, so the `VERCEL_GIT_COMMIT_SHA` Vercel injects never reached `import.meta.env`. Resolved at config time so the mapping lives in the repo, with CI's explicit value still winning (its release name has to match its sourcemap upload).

**Nothing needs setting in the Vercel dashboard.** `VERCEL_GIT_COMMIT_SHA` is injected automatically. Verified by building with it set and grepping the emitted bundle. Also fixes `client_release: 'unknown'` in Daily Fritz telemetry.

## 2. `fix(chunks)` — every floating dynamic import is guarded, and enforced
The implicated import was `web-vitals`: it ran on every load of `/` behind a bare `void reportWebVitals()` with no catch, around an unguarded `await import('web-vitals')`. Extracted to `debug/reportWebVitals.ts` with an injectable loader so the failure path is testable.

**INV-15** in the architecture checker enforces the general case. It found **nine offenders across seven files** — three more than the manual read caught (`dailyFritzDebugIngest`, `lessonV2`, `handLifecycleDebug`). Deliberately narrow: only the floating `void import(...)` form, since awaited imports belong to their try/catch and `React.lazy` reaches an ErrorBoundary.

Failures report as a Sentry **breadcrumb**, not `captureException` — these fail environmentally on mobile networks, and capturing each one turns a bad signal into an alert storm.

## 3 + 4. `fix(recovery)` — narrowed trigger, and a guard that clears

**This is the behaviour change. Please sanity-check this section.**

### What DOES trigger a reload now
- A `React.lazy` chunk failing to import, caught by an `ErrorBoundary` — i.e. a route screen or modal that cannot render at all.
- Recognised across all four engine wordings (WebKit, Chromium, Firefox, Vite's CSS preloader), not just WebKit's.
- At most **once per tab per successful load**.

### What does NOT trigger a reload any more
- **Any unhandled promise rejection**, including one that says "Importing a module script failed". ← this is the case that was reloading working apps.
- Any uncaught `window.onerror`, even a matching one.
- Optional/telemetry chunk failures (web-vitals, confetti, debug modules) — they now report a breadcrumb.
- Ordinary component crashes — unchanged: fallback UI, reported to Sentry.

### The tradeoff, explicitly
The old net was wider. A chunk failure that breaks the UI *without* going through a `React.lazy` + `ErrorBoundary` path no longer self-heals — the user sees a broken screen and must reload by hand.

I checked how wide that gap actually is: all 37 `React.lazy` sites render under an `ErrorBoundary` **except `AppOverlays`**, whose route boundaries live inside its children rather than around it. This PR adds a boundary there, so the gap is closed for every lazy site in the app today. The residual risk is a *future* `React.lazy` added outside a boundary — which INV-15 does not catch, and is worth knowing.

In exchange: no more reloading a working app mid-match because a telemetry chunk 404'd.

### The guard
Previously set and never cleared, so a tab had one recovery for its entire lifetime — mobile tabs live for weeks, so a genuine stale-deploy later had none left. Now cleared once the app is up, deferred past render so a subtree that fails to mount does not count as a successful load. Reloads still cannot loop: only a load that actually succeeded lifts the guard.

## 5. `fix(routing)` — serve the prerendered `/settings` shell
`/settings` was added to the prerender list in #79 **without a matching rewrite**, so the catch-all served `index.html` and `settings.html` was never reachable. The route worked either way, which is why nothing caught it — and why #79's description overstated what the prerendering was doing. A test now asserts every generated shell is some rewrite's destination.

## Verification
- client: 205 files, 1413 tests, pass · server: 192 files, 1092 tests, pass
- `tsc -b --noEmit` (client) and `tsc -p tsconfig.json --noEmit` (server): clean
- `npm run check:architecture`: CERTIFIED, 16/16
- `npm run lint`: 401 warnings, at budget, exit 0

## One thing I did not fix
`ErrorBoundary` reports every error to Sentry **twice** — directly via `captureException`, then again through `logger.error`. Pre-existing and out of scope, but it means issue counts there are inflated by 2×.

🤖 Generated with [Claude Code](https://claude.com/claude-code)