### PR TITLE
fix(settings): make the page scroll, and stop the account trigger widening the nav

### DIFF
--- a/client/src/components/GlobalNav.tsx
+++ b/client/src/components/GlobalNav.tsx
@@ -389,6 +389,7 @@ export function GlobalNav({
                     {initials}
                   </span>
                 </span>
+                <span className="rh-nav-account-label">
                 <span className="rh-nav-account-name" style={{ fontSize: '15px', fontWeight: 600, color: 'white' }}>
                   {displayName}
                 </span>
@@ -403,6 +404,7 @@ export function GlobalNav({
                 >
                   <path d="M5 7.5L10 12.5L15 7.5" stroke="var(--text-secondary)" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round" />
                 </svg>
+                </span>
               </button>
 
               {authUser && accountMenuOpen && (

--- a/client/src/components/globalNavAccountMenu.css
+++ b/client/src/components/globalNavAccountMenu.css
@@ -11,10 +11,17 @@
   align-items: center;
 }
 
+/* Two children — the avatar, then the name+chevron group — mirroring the two
+   buttons this replaced, so the spacing lands where it used to.
+   
+   In rem, not px. The header scales with the root font size, so the Tailwind
+   `gap-4`/`gap-3` the old markup used shrank with it; hardcoded pixels did
+   not. That is what widened the stats block by 14px and pushed the tab row
+   into it at 1366px, on top of the 1280px band that already overlapped. */
 .rh-nav-account-trigger {
   display: flex;
   align-items: center;
-  gap: 16px;
+  gap: 1rem;
   padding: 0;
   border: 0;
   background: transparent;
@@ -29,6 +36,13 @@
 
 .rh-nav-account-trigger:active {
   transform: scale(0.97);
+}
+
+.rh-nav-account-label {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  min-width: 0;
 }
 
 .rh-nav-account-avatar {
@@ -86,8 +100,17 @@
     display: block;
   }
 
-  .rh-nav-account-avatar {
+
+  .rh-nav-account-label {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  min-width: 0;
+}
+
+.rh-nav-account-avatar {
     width: 42px;
     height: 42px;
   }
 }
+

--- a/client/src/screens/SettingsAccount.test.tsx
+++ b/client/src/screens/SettingsAccount.test.tsx
@@ -2,9 +2,9 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-vi.mock('../components/hub/HubViewportPage', () => ({
-  default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-}));
+// The page renders GlobalNav directly now — it is no longer a hub page, so
+// there is no HubViewportPage between them.
+vi.mock('../components/GlobalNav', () => ({ GlobalNav: () => null }));
 
 const { SettingsScreen } = await import('./SettingsScreen');
 type Props = import('./SettingsScreen').SettingsScreenProps;

--- a/client/src/screens/SettingsDeleteAccount.test.tsx
+++ b/client/src/screens/SettingsDeleteAccount.test.tsx
@@ -2,9 +2,9 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-vi.mock('../components/hub/HubViewportPage', () => ({
-  default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-}));
+// The page renders GlobalNav directly now — it is no longer a hub page, so
+// there is no HubViewportPage between them.
+vi.mock('../components/GlobalNav', () => ({ GlobalNav: () => null }));
 
 const { SettingsScreen } = await import('./SettingsScreen');
 type Props = import('./SettingsScreen').SettingsScreenProps;

--- a/client/src/screens/SettingsPreferences.test.tsx
+++ b/client/src/screens/SettingsPreferences.test.tsx
@@ -2,9 +2,9 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-vi.mock('../components/hub/HubViewportPage', () => ({
-  default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-}));
+// The page renders GlobalNav directly now — it is no longer a hub page, so
+// there is no HubViewportPage between them.
+vi.mock('../components/GlobalNav', () => ({ GlobalNav: () => null }));
 
 const { mutePreference } = await import('../utils/mutePreference');
 const { SettingsScreen } = await import('./SettingsScreen');

--- a/client/src/screens/SettingsScreen.test.tsx
+++ b/client/src/screens/SettingsScreen.test.tsx
@@ -2,9 +2,9 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
-vi.mock('../components/hub/HubViewportPage', () => ({
-  default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-}));
+// The page renders GlobalNav directly now — it is no longer a hub page, so
+// there is no HubViewportPage between them.
+vi.mock('../components/GlobalNav', () => ({ GlobalNav: () => null }));
 
 const { SettingsScreen } = await import('./SettingsScreen');
 

--- a/client/src/screens/SettingsScreen.tsx
+++ b/client/src/screens/SettingsScreen.tsx
@@ -1,7 +1,7 @@
 import { useId, useState } from 'react';
 import type { User } from '@supabase/supabase-js';
-import { Button, GlassCard } from '../components/primitives';
-import HubViewportPage from '../components/hub/HubViewportPage';
+import { Button } from '../components/primitives';
+import { GlobalNav } from '../components/GlobalNav';
 import { resolvePasswordChange } from '../auth/passwordChange';
 import { useMutePreference } from '../utils/useMutePreference';
 import type { UserProfile } from '../auth/useAuth';
@@ -60,6 +60,31 @@ function useSettingsAction() {
   return { pending, status, setStatus, run };
 }
 
+/**
+ * One settings panel, in the same shape the how-to-play article uses for its
+ * rules sections: an accent-tinted card, an uppercase eyebrow above the
+ * heading, and a dot tying the heading to the panel's accent.
+ */
+function SettingsSection({
+  eyebrow,
+  title,
+  accent = 'green',
+  children,
+}: {
+  eyebrow: string;
+  title: string;
+  accent?: 'green' | 'gold' | 'danger';
+  children: React.ReactNode;
+}) {
+  return (
+    <section className={`rh-settings-section rh-settings-section--${accent}`}>
+      <p className="rh-settings-section-eyebrow">{eyebrow}</p>
+      <h2 className="rh-settings-section-title">{title}</h2>
+      {children}
+    </section>
+  );
+}
+
 function StatusLine({ status }: { status: Status }) {
   if (status.error) return <p className="rh-settings-error" role="alert">{status.error}</p>;
   if (status.message) return <p className="rh-settings-success" role="status">{status.message}</p>;
@@ -78,8 +103,7 @@ function UsernameSection({
   const { pending, status, run } = useSettingsAction();
 
   return (
-    <GlassCard className="rh-settings-section">
-      <h2 className="rh-settings-section-title">Handle</h2>
+    <SettingsSection eyebrow="Identity" title="Handle" accent="green">
       <p className="rh-settings-section-note">
         This name appears on leaderboards, friends lists, and match results.
       </p>
@@ -103,7 +127,7 @@ function UsernameSection({
       >
         {pending ? 'Saving…' : 'Save username'}
       </Button>
-    </GlassCard>
+    </SettingsSection>
   );
 }
 
@@ -130,8 +154,7 @@ function PasswordSection({
   }
 
   return (
-    <GlassCard className="rh-settings-section">
-      <h2 className="rh-settings-section-title">Password</h2>
+    <SettingsSection eyebrow="Sign-in" title="Password" accent="green">
       <p className="rh-settings-section-note">
         Change it here while you are signed in. The emailed reset link is for when you cannot.
       </p>
@@ -163,7 +186,7 @@ function PasswordSection({
       <Button variant="primary" disabled={pending} onClick={submit}>
         {pending ? 'Saving…' : 'Update password'}
       </Button>
-    </GlassCard>
+    </SettingsSection>
   );
 }
 
@@ -181,8 +204,7 @@ function EmailSection({
   const { pending, status, run } = useSettingsAction();
 
   return (
-    <GlassCard className="rh-settings-section">
-      <h2 className="rh-settings-section-title">Email</h2>
+    <SettingsSection eyebrow="Sign-in" title="Email" accent="gold">
       <p className="rh-settings-section-note">
         Signed in as <span className="rh-settings-current-email">{currentEmail ?? 'no address on record'}</span>.
       </p>
@@ -206,7 +228,7 @@ function EmailSection({
       >
         {pending ? 'Sending…' : 'Change email'}
       </Button>
-    </GlassCard>
+    </SettingsSection>
   );
 }
 
@@ -227,8 +249,7 @@ function DangerZoneSection({
     confirmation.trim().toLowerCase() === username.trim().toLowerCase();
 
   return (
-    <GlassCard className="rh-settings-section rh-settings-section--danger">
-      <h2 className="rh-settings-section-title">Delete account</h2>
+    <SettingsSection eyebrow="Irreversible" title="Delete account" accent="danger">
       <p className="rh-settings-section-note">
         This erases your profile, your handle, your friends, and your rating history. It cannot be
         undone, and the handle becomes available for someone else to take.
@@ -281,7 +302,7 @@ function DangerZoneSection({
           Delete account
         </Button>
       )}
-    </GlassCard>
+    </SettingsSection>
   );
 }
 
@@ -290,8 +311,7 @@ function PreferencesSection() {
   const soundOn = !isMuted;
 
   return (
-    <GlassCard className="rh-settings-section">
-      <h2 className="rh-settings-section-title">Preferences</h2>
+    <SettingsSection eyebrow="Game" title="Preferences" accent="gold">
       <div className="rh-settings-toggle-row">
         <span className="rh-settings-toggle-copy">
           <span className="rh-settings-toggle-label">Sound</span>
@@ -311,7 +331,7 @@ function PreferencesSection() {
           {soundOn ? 'On' : 'Off'}
         </Button>
       </div>
-    </GlassCard>
+    </SettingsSection>
   );
 }
 
@@ -335,13 +355,24 @@ export function SettingsScreen({
   onDeleteAccount,
 }: SettingsScreenProps) {
   return (
-    <HubViewportPage
-      currentMode="settings"
-      activeColor="var(--tier-standard)"
-      onNavigate={onNavigate}
-      onOpenAuth={onOpenAuth}
-      onSignOut={onSignOut}
-    >
+    /*
+     * Not HubViewportPage. That shell is deliberately viewport-contained —
+     * "long content should scroll inside its panel" — which is right for a hub
+     * of fixed panels and wrong for this, a stack of forms taller than any
+     * viewport. On production it clipped everything below the fold with no way
+     * to reach it. This is the how-to-play pattern instead: one scrollport
+     * under a pinned nav.
+     */
+    <div className="rh-settings-page">
+      <GlobalNav
+        currentMode="settings"
+        activeColor="var(--tier-standard)"
+        solidDarkChrome
+        onNavigate={onNavigate}
+        onOpenAuth={onOpenAuth}
+        onSignOut={onSignOut}
+      />
+      <div className="rh-settings-scroll">
       <div className="rh-settings">
         <header className="rh-settings-head">
           <p className="rh-settings-eyebrow">Account</p>
@@ -359,12 +390,11 @@ export function SettingsScreen({
 
             <PreferencesSection />
 
-            <GlassCard className="rh-settings-section">
-              <h2 className="rh-settings-section-title">Session</h2>
+            <SettingsSection eyebrow="Device" title="Session" accent="green">
               <Button variant="outline" onClick={() => onSignOut?.()}>
                 Sign out
               </Button>
-            </GlassCard>
+            </SettingsSection>
 
             <DangerZoneSection
               username={authProfile?.username ?? ''}
@@ -372,22 +402,22 @@ export function SettingsScreen({
             />
           </>
         ) : (
-          <GlassCard className="rh-settings-section">
-            <h2 className="rh-settings-section-title">Not signed in</h2>
+          <SettingsSection eyebrow="Account" title="Not signed in" accent="green">
             <p className="rh-settings-section-note">
               Sign in to manage your handle, your sign-in details, and your game preferences.
             </p>
             <Button variant="primary" onClick={() => onOpenAuth?.()}>
               Sign in
             </Button>
-          </GlassCard>
+          </SettingsSection>
         )}
 
         {/* Sound is stored on the device, not the account, so it is offered
             whether or not anyone is signed in. */}
         {!authUser && <PreferencesSection />}
       </div>
-    </HubViewportPage>
+      </div>
+    </div>
   );
 }
 

--- a/client/src/screens/settingsScreen.css
+++ b/client/src/screens/settingsScreen.css
@@ -1,31 +1,63 @@
 /* Settings — account and preferences.
  *
- * Mobile-first, matching the hub screens: the unprefixed rules are the phone
- * layout, desktop widens in the `desk` query at the end.
+ * Laid out as a document, not a hub. `HubViewportPage` is deliberately
+ * viewport-contained ("long content should scroll inside its panel"), which is
+ * right for a hub of fixed panels and wrong for a stack of forms taller than
+ * any viewport — on production it clipped everything below the fold with no
+ * way to reach it. This follows `.rh-htp-page` instead: `.app` is
+ * `100dvh; overflow: hidden`, the nav is pinned, and one scrollport underneath
+ * carries the content.
+ *
+ * The section cards mirror `.rh-htp-article__section`, so the two long-form
+ * pages read as the same product. Duplicated rather than imported: each
+ * feature's CSS stays scoped to that feature.
  */
+
+.rh-settings-page {
+  display: flex;
+  flex: 1 1 auto;
+  min-height: 0;
+  flex-direction: column;
+  background: var(--bg-obsidian);
+}
+
+.rh-settings-scroll {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-x: hidden;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scroll-behavior: smooth;
+}
 
 .rh-settings {
   width: 100%;
-  max-width: 720px;
+  /* The rules article's measure: long enough to read, short enough not to
+     stretch a form field across a desktop. */
+  max-width: 68ch;
   margin: 0 auto;
-  padding: 20px 16px 48px;
+  padding: var(--space-md) var(--space-sm) 96px;
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: var(--space-md);
+  color: var(--text-primary);
+  font-family: var(--font-body);
 }
+
+/* ── Head ───────────────────────────────────────────────────────── */
 
 .rh-settings-head {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 6px;
 }
 
 .rh-settings-eyebrow {
   margin: 0;
-  font-family: var(--font-display);
+  font-family: var(--font-body);
   font-size: 12px;
-  font-weight: 700;
-  letter-spacing: 0.25em;
+  font-weight: 800;
+  letter-spacing: 0.2em;
   text-transform: uppercase;
   color: rgba(255, 255, 255, 0.35);
 }
@@ -33,51 +65,87 @@
 .rh-settings-title {
   margin: 0;
   font-family: var(--font-display);
-  font-size: 40px;
-  font-weight: 700;
-  line-height: 1;
-  letter-spacing: -0.01em;
-  color: rgba(255, 255, 255, 0.95);
+  font-size: clamp(34px, 6vw, 52px);
+  font-weight: 800;
+  line-height: 1.02;
+  letter-spacing: 0.01em;
+  color: var(--text-primary);
+  text-shadow: 0 0 36px rgba(160, 200, 255, 0.1);
+  text-wrap: balance;
 }
+
+/* ── Sections ───────────────────────────────────────────────────── */
 
 .rh-settings-section {
   display: flex;
   flex-direction: column;
   align-items: flex-start;
   gap: 12px;
-  padding: 20px;
+  padding: var(--space-md);
+  border: 1px solid color-mix(in srgb, var(--rh-settings-accent) 26%, rgba(255, 255, 255, 0.1));
+  /* Fallback: the --pvf-radius-* scale only loads with the PvF stylesheet,
+     which this route does not pull in. */
+  border-radius: var(--pvf-radius-md, 14px);
+  background: color-mix(in srgb, var(--rh-settings-accent) 5%, rgba(0, 0, 0, 0.22));
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.07),
+    0 0 28px color-mix(in srgb, var(--rh-settings-accent) 7%, transparent);
+}
+
+.rh-settings-section--green {
+  --rh-settings-accent: var(--accent-green);
+}
+
+.rh-settings-section--gold {
+  --rh-settings-accent: var(--tier-elite);
+}
+
+.rh-settings-section--danger {
+  --rh-settings-accent: var(--accent-danger);
+}
+
+.rh-settings-section-eyebrow {
+  margin: 0;
+  color: var(--rh-settings-accent);
+  font-family: var(--font-body);
+  font-size: 12px;
+  font-weight: 800;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
 }
 
 .rh-settings-section-title {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
   margin: 0;
   font-family: var(--font-display);
-  font-size: 20px;
+  font-size: clamp(25px, 4vw, 30px);
   font-weight: 700;
-  letter-spacing: 0.02em;
-  color: rgba(255, 255, 255, 0.95);
+  line-height: 1.15;
+  letter-spacing: 0.01em;
+  color: var(--text-primary);
+  text-wrap: balance;
+}
+
+/* The kicker dot, tying the heading to its panel accent. */
+.rh-settings-section-title::before {
+  content: '';
+  flex-shrink: 0;
+  width: 7px;
+  height: 7px;
+  border-radius: var(--radius-pill);
+  background: var(--rh-settings-accent);
+  box-shadow: 0 0 12px color-mix(in srgb, var(--rh-settings-accent) 60%, transparent);
 }
 
 .rh-settings-section-note {
   margin: 0;
   font-family: var(--font-body);
-  font-size: 14px;
-  line-height: 1.5;
-  color: rgba(255, 255, 255, 0.6);
-}
-
-@media (min-width: 769px) and (min-height: 600px) {
-  .rh-settings {
-    padding: 36px 24px 64px;
-    gap: 20px;
-  }
-
-  .rh-settings-title {
-    font-size: 52px;
-  }
-
-  .rh-settings-section {
-    padding: 24px;
-  }
+  font-size: 16px;
+  line-height: 1.7;
+  color: var(--text-secondary);
+  text-wrap: pretty;
 }
 
 /* ── Fields ─────────────────────────────────────────────────────── */
@@ -112,8 +180,8 @@
 
 .rh-settings-input:focus {
   outline: none;
-  border-color: rgba(59, 130, 246, 0.6);
-  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.16);
+  border-color: color-mix(in srgb, var(--rh-settings-accent) 60%, transparent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--rh-settings-accent) 16%, transparent);
 }
 
 .rh-settings-input:disabled {
@@ -146,7 +214,7 @@
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
-  gap: 16px;
+  gap: var(--space-sm);
   width: 100%;
 }
 
@@ -159,7 +227,7 @@
 
 .rh-settings-toggle-label {
   font-family: var(--font-body);
-  font-size: 15px;
+  font-size: 16px;
   font-weight: 600;
   color: rgba(255, 255, 255, 0.95);
 }
@@ -170,10 +238,6 @@
 }
 
 /* ── Danger zone ────────────────────────────────────────────────── */
-
-.rh-settings-section--danger {
-  border-color: color-mix(in srgb, var(--accent-danger) 32%, transparent);
-}
 
 .rh-settings-actions {
   display: flex;
@@ -188,4 +252,10 @@
 
 .rh-settings-danger-button.rh-btn:hover:not(:disabled) {
   border-color: color-mix(in srgb, var(--accent-danger) 70%, transparent);
+}
+
+@media (min-width: 769px) and (min-height: 600px) {
+  .rh-settings {
+    padding: var(--space-lg) var(--space-md) 96px;
+  }
 }


### PR DESCRIPTION
Two header/layout fixes found by looking at the real page rather than the diff.

---

## 1. `/settings` bled off the bottom and could not scroll

Reported on production: Sign out and Delete account were unreachable on a laptop window.

**Cause:** `HubViewportPage`, behaving exactly as designed. Its own comment says *"primary Racehorse hub pages are viewport-contained. Do not add page-level vertical overflow. Long content should scroll inside its panel."* That is right for a hub of fixed panels. Settings is a stack of forms taller than any viewport, so `.rh-hub-body { overflow: hidden }` simply clipped it. Below 1080px that shell *does* allow overflow — which is why this only appeared on a wide window and not in earlier checks.

**Fix:** Settings stops pretending to be a hub and follows `/learn/how-to-play`, the other long-form page in the app: `.app` is `100dvh; overflow: hidden`, the nav is pinned, and one scrollport underneath carries the content.

**Format:** the section cards now match that article — accent-tinted panels alternating mint and gold, an uppercase eyebrow above each heading, the kicker dot, and its 68ch measure so a form field is not stretched across a desktop. Eyebrows name the section (IDENTITY, SIGN-IN, GAME, DEVICE, IRREVERSIBLE) rather than numbering it, since these are not a sequence to work through. Delete account keeps the danger accent.

CSS is duplicated rather than imported from the learn module, per the rule that each feature's CSS stays scoped to that feature.

Verified in a browser at **390×844**, **844×390** and **1512×830**: the scrollport overflows, Delete account is reachable at every size, and nothing overflows horizontally.

---

## 2. The account trigger widened the header row

Found while verifying #84 — the "Learn" tab was colliding with the Rating stat.

Measured against a worktree at `4f251800` (the commit before #79):

| width | before #79 | after #79 | after this |
|---|---|---|---|
| 1280px | overlap | overlap | overlap |
| 1366px | ok | **overlap** | ok |
| 1440px | ok | ok | ok |

`.rh-nav-user-block` at 1366px: **188.3px** before #79 → **202px** after → **188.3px** now. Exact parity.

**The 1280px overlap is pre-existing** and untouched here — it predates all the settings work. What #79 did was widen the block by 14px, dragging a second width band into the same failure.

Two causes, both mine:
1. The trigger set one flat `gap` across three children (avatar, name, chevron), so the spacing was spent twice. It is now two children — the avatar, and a name+chevron group — mirroring the two buttons it replaced.
2. The gaps were in **px**. The header scales with the root font size, so the Tailwind `gap-4`/`gap-3` the old markup used shrank with it while hardcoded pixels did not. In rem they scale again, which also made the px media-query overrides I first reached for unnecessary.

---

## Verification
- client: 1414 tests pass
- `tsc -b --noEmit`: clean
- `npm run check:architecture`: CERTIFIED 15/15
- `npm run lint`: 401 warnings, at budget, exit 0
- Browser measurements above, against the real dev bundle

🤖 Generated with [Claude Code](https://claude.com/claude-code)