### PR TITLE
fix(health): report the running release from /api/health too

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -120,6 +120,7 @@ import {
   isFritzId,
 } from './ranking/glicko2';
 import { startRankingCron } from './ranking/cron';
+import { buildApiHealthPayload } from './platform/health/apiHealthPayload';
 import {
   scheduleDailyFritzWarmup,
   scheduleDailyPuzzleLadderWarmup,
@@ -541,7 +542,7 @@ const socketsByUserId = presenceSocketsByUserId;
 
 app.get('/api/health', (_req, res) => {
   res.set('Cache-Control', 'no-store');
-  res.json({ ok: true, ts: Date.now() });
+  res.json(buildApiHealthPayload());
 });
 
 registerStatsRoutes(app, {

--- a/server/src/platform/health/apiHealthPayload.test.ts
+++ b/server/src/platform/health/apiHealthPayload.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { buildApiHealthPayload } from './apiHealthPayload';
+
+/**
+ * `/api/health` reported `{ok, ts}` and nothing else, so the endpoint most
+ * likely to be probed first was the one that could not answer "what commit is
+ * live". It now says what `/health` says.
+ */
+describe('buildApiHealthPayload', () => {
+  it('reports the running release alongside the liveness flag', () => {
+    const payload = buildApiHealthPayload({ RENDER_GIT_COMMIT: 'abc123' }, () => 1700);
+
+    expect(payload).toEqual({ ok: true, ts: 1700, release: 'abc123' });
+  });
+
+  it('still answers when nothing identifies the build', () => {
+    expect(buildApiHealthPayload({}, () => 1).release).toBe('dev');
+  });
+
+  it('keeps ts a live clock read, not a captured constant', () => {
+    // A frozen timestamp would make the endpoint useless for spotting a
+    // wedged process.
+    let now = 10;
+    const clock = () => (now += 5);
+    expect(buildApiHealthPayload({}, clock).ts).toBe(15);
+    expect(buildApiHealthPayload({}, clock).ts).toBe(20);
+  });
+});

--- a/server/src/platform/health/apiHealthPayload.ts
+++ b/server/src/platform/health/apiHealthPayload.ts
@@ -1,0 +1,17 @@
+import { resolveReleaseVersion } from './releaseVersion';
+
+export type ApiHealthPayload = { ok: true; ts: number; release: string };
+
+/**
+ * The `/api/health` body.
+ *
+ * `release` is the point: this endpoint sits under the same `/api` prefix as
+ * everything else, so it is the one people reach for first, and it was the one
+ * that could not say which commit was running.
+ */
+export function buildApiHealthPayload(
+  env: NodeJS.ProcessEnv = process.env,
+  now: () => number = Date.now,
+): ApiHealthPayload {
+  return { ok: true, ts: now(), release: resolveReleaseVersion(env) };
+}

--- a/server/src/platform/health/registerHealthRoutes.ts
+++ b/server/src/platform/health/registerHealthRoutes.ts
@@ -6,6 +6,7 @@ import type { Server } from 'socket.io';
 const log = childLogger('health');
 import { isGracefulShutdownInProgress } from '../gracefulShutdown';
 import { supabaseFetch } from '../../supabaseUtils';
+import { resolveReleaseVersion } from './releaseVersion';
 import {
   assessDailyPuzzleLadderReadiness,
   isPastLadderReadinessGracePt,
@@ -20,16 +21,6 @@ const READY_RECOMMENDED_ENV_VARS = [
   'DAILY_PUZZLE_CRON_SECRET',
   'SERVER_URL',
 ] as const;
-
-function getReleaseVersion(): string {
-  return (
-    process.env.RELEASE_VERSION?.trim() ||
-    process.env.RENDER_GIT_COMMIT?.trim() ||
-    process.env.VERCEL_GIT_COMMIT_SHA?.trim() ||
-    process.env.npm_package_version?.trim() ||
-    'dev'
-  );
-}
 
 function getEnvPresence(names: readonly string[]): Record<string, boolean> {
   return Object.fromEntries(names.map((name) => [name, Boolean(process.env[name]?.trim())]));
@@ -108,7 +99,7 @@ export function registerHealthRoutes(deps: HealthRouteDeps): void {
     const { roomCount, gamesInProgress } = getRoomRuntimeStats();
     return {
       ok: true,
-      release: getReleaseVersion(),
+      release: resolveReleaseVersion(),
       nodeEnv: process.env.NODE_ENV ?? 'development',
       pid: process.pid,
       uptimeSeconds: Math.round(process.uptime()),
@@ -121,14 +112,14 @@ export function registerHealthRoutes(deps: HealthRouteDeps): void {
   app.get('/health', (_, res) => {
     res.json({
       ok: true,
-      release: getReleaseVersion(),
+      release: resolveReleaseVersion(),
       nodeEnv: process.env.NODE_ENV ?? 'development',
       uptimeSeconds: Math.round(process.uptime()),
     });
   });
 
   app.get('/ping', (_, res) => {
-    res.json({ status: 'ok', release: getReleaseVersion() });
+    res.json({ status: 'ok', release: resolveReleaseVersion() });
   });
 
   app.get('/healthz', async (_req, res) => {
@@ -142,7 +133,7 @@ export function registerHealthRoutes(deps: HealthRouteDeps): void {
     res.status(200).json({
       status: 'ok',
       db: 'ok',
-      release: getReleaseVersion(),
+      release: resolveReleaseVersion(),
       uptimeSeconds: Math.floor(process.uptime()),
     });
   });

--- a/server/src/platform/health/releaseVersion.test.ts
+++ b/server/src/platform/health/releaseVersion.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { resolveReleaseVersion } from './releaseVersion';
+
+/**
+ * The release string every health route reports.
+ *
+ * `/health` and `/ping` already carried it; `/api/health` did not, and that
+ * gap cost an investigation an hour of "I can't tell what commit is live"
+ * while the answer was one endpoint away.
+ */
+describe('resolveReleaseVersion', () => {
+  it('prefers an explicit RELEASE_VERSION', () => {
+    expect(
+      resolveReleaseVersion({ RELEASE_VERSION: 'v9', RENDER_GIT_COMMIT: 'abc' }),
+    ).toBe('v9');
+  });
+
+  it('falls back to the commit Render injects', () => {
+    expect(resolveReleaseVersion({ RENDER_GIT_COMMIT: 'abc123' })).toBe('abc123');
+  });
+
+  it('then to the commit Vercel injects', () => {
+    expect(resolveReleaseVersion({ VERCEL_GIT_COMMIT_SHA: 'def456' })).toBe('def456');
+  });
+
+  it('then to the package version', () => {
+    expect(resolveReleaseVersion({ npm_package_version: '1.2.3' })).toBe('1.2.3');
+  });
+
+  it('says dev when nothing identifies the build', () => {
+    expect(resolveReleaseVersion({})).toBe('dev');
+  });
+
+  it('ignores blank and whitespace-only values rather than reporting an empty release', () => {
+    expect(resolveReleaseVersion({ RELEASE_VERSION: '   ', RENDER_GIT_COMMIT: 'abc' })).toBe('abc');
+    expect(resolveReleaseVersion({ RELEASE_VERSION: '' })).toBe('dev');
+  });
+
+  it('trims, so a shell-injected newline is not part of the release', () => {
+    expect(resolveReleaseVersion({ RENDER_GIT_COMMIT: 'abc123\n' })).toBe('abc123');
+  });
+});

--- a/server/src/platform/health/releaseVersion.ts
+++ b/server/src/platform/health/releaseVersion.ts
@@ -1,0 +1,18 @@
+/**
+ * The release identifier the health routes report.
+ *
+ * Extracted from registerHealthRoutes so `/api/health` can report the same
+ * string `/health` and `/ping` already did. That inconsistency is not
+ * cosmetic: `/api/health` returned `{ok, ts}` only, and an investigation into
+ * overnight bandwidth concluded "there is no way to tell what commit is live"
+ * on the strength of it, while `/health` had the answer all along.
+ */
+export function resolveReleaseVersion(env: NodeJS.ProcessEnv = process.env): string {
+  return (
+    env.RELEASE_VERSION?.trim() ||
+    env.RENDER_GIT_COMMIT?.trim() ||
+    env.VERCEL_GIT_COMMIT_SHA?.trim() ||
+    env.npm_package_version?.trim() ||
+    'dev'
+  );
+}


### PR DESCRIPTION
## The correction that prompted this

I told you `/api/health` had no version and therefore "what commit is live" was unanswerable. **That was wrong** — `/health` and `/ping` already reported it. I probed the wrong endpoint and drew a conclusion from it.

The live answer, which settles question #2 of the bandwidth investigation:

```
$ curl https://racehorse.onrender.com/health
{"ok":true,"release":"b3a8b4bc563ba7deb5c0affa8b76c190348db4dd",
 "nodeEnv":"production","uptimeSeconds":62233}
```

`b3a8b4bc` is the current tip of main, and all four ghost fixes are ancestors of it — **#74, #75, #76 and #77 are live.**

## What this PR actually changes

`/api/health` returned `{ok, ts}` while `/health` returned the release. That inconsistency is what misled me, so it is worth closing: the endpoint under the same prefix as everything else is the one people reach for first.

The resolver moves into its own module so it can be tested directly instead of only through a route, and both call sites share one definition.

## Verification
- server: 1109 tests pass (10 new — 7 for the resolver's precedence and trimming, 3 for the payload)
- `tsc -p tsconfig.json --noEmit`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)