### PR TITLE
perf(scheduled): bound the maintenance scans and stop a duplicate query

### DIFF
--- a/server/src/ranking/forfeitOutcomeDurability.test.ts
+++ b/server/src/ranking/forfeitOutcomeDurability.test.ts
@@ -66,8 +66,8 @@ describe('deferred rating period honours a persisted forfeit outcome', () => {
 
   function mockWith(outcome: 'win' | 'loss' | null) {
     mockedSupabaseFetch.mockImplementation(async (path: string) => {
-      if (path === '/rest/v1/profiles?id=eq.u1') return [profile] as never;
-      if (path === '/rest/v1/profiles?id=eq.u2') {
+      if (path.startsWith('/rest/v1/profiles?id=eq.u1')) return [profile] as never;
+      if (path.startsWith('/rest/v1/profiles?id=eq.u2')) {
         return [{ ...profile, id: 'u2', username: 'stayer' }] as never;
       }
       if (path.startsWith('/rest/v1/ranked_games?player_id=eq.u1')) {

--- a/server/src/ranking/fritzRating.test.ts
+++ b/server/src/ranking/fritzRating.test.ts
@@ -27,7 +27,7 @@ describe('Fritz rating processing', () => {
 
   it('returns a positive non-zero Glicko delta for a win over Fritz Master', async () => {
     mockedSupabaseFetch.mockImplementation(async (path: string, init?: RequestInit) => {
-      if (path === '/rest/v1/profiles?id=eq.player-1') {
+      if (path.startsWith('/rest/v1/profiles?id=eq.player-1')) {
         return [
           {
             id: 'player-1',

--- a/server/src/ranking/periodService.ts
+++ b/server/src/ranking/periodService.ts
@@ -1,6 +1,7 @@
 
 import { computeGlicko2, decayRD, DEFAULT_RATING, DEFAULT_RD, DEFAULT_VOL, getFritzConfig, isFritzId, type MatchOutcome } from './glicko2';
 import { supabaseFetch } from '../supabaseUtils';
+import { fetchAllPages } from '../supabasePagination';
 
 export interface Profile {
   id: string;
@@ -13,6 +14,13 @@ export interface Profile {
   peak_rating: number;
   provisional: boolean;
 }
+
+/**
+ * Exactly the columns `Profile` declares. These reads were `select=*`, so they
+ * carried every column the table happens to have, including any added later.
+ */
+const PROFILE_COLUMNS =
+  'id,username,glicko_rating,glicko_rd,glicko_vol,glicko_last_period,ranked_games_played,peak_rating,provisional';
 
 interface RankedGame {
   id: string;
@@ -33,6 +41,12 @@ interface RankedGame {
 
 interface ProcessRatingPeriodOptions {
   applyDecayIfNoGames?: boolean;
+  /**
+   * A profile the caller already read. The decay sweep selects every inactive
+   * profile up front and then called back in for each one individually; that
+   * second read returned bytes it already had.
+   */
+  profile?: Profile;
 }
 
 interface OpponentSnapshot {
@@ -69,7 +83,9 @@ async function normalizeLegacyStartingProfile(profile: Profile): Promise<Profile
 }
 
 async function getProfile(userId: string): Promise<Profile> {
-  const [profile] = await supabaseFetch<Profile[]>(`/rest/v1/profiles?id=eq.${userId}`);
+  const [profile] = await supabaseFetch<Profile[]>(
+    `/rest/v1/profiles?id=eq.${userId}&select=${PROFILE_COLUMNS}&limit=1`,
+  );
   if (!profile) throw new Error('Player not found');
   return normalizeLegacyStartingProfile(profile);
 }
@@ -184,7 +200,9 @@ export async function processRatingPeriod(
   options: ProcessRatingPeriodOptions = {},
 ) {
   const { applyDecayIfNoGames = false } = options;
-  let profile = await getProfile(userId);
+  let profile = options.profile
+    ? await normalizeLegacyStartingProfile(options.profile)
+    : await getProfile(userId);
   const games = await getPendingGames(userId);
 
   if (games.length === 0) {
@@ -313,8 +331,13 @@ export async function processRealtimeMultiplayerGame(params: {
 }
 
 export async function processAllPendingRatingGames() {
-  const games = await supabaseFetch<Array<{ player_id: string }>>(
-    '/rest/v1/ranked_games?select=player_id&rating_after=is.null',
+  // Paged: this scan had no limit, so one response carried every unprocessed
+  // ranked game and grew with the backlog.
+  const games = await fetchAllPages<{ player_id: string }>((offset, limit) =>
+    supabaseFetch<Array<{ player_id: string }>>(
+      '/rest/v1/ranked_games?select=player_id&rating_after=is.null' +
+        `&order=id.asc&offset=${offset}&limit=${limit}`,
+    ),
   );
   const userIds = [...new Set(games.map((game) => game.player_id))];
 
@@ -336,8 +359,13 @@ export async function processAllPendingRatingGames() {
 export async function decayInactivePlayers() {
   const now = new Date();
   const sevenDaysAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000).toISOString();
-  const users = await supabaseFetch<Profile[]>(
-    `/rest/v1/profiles?or=(glicko_last_period.lt.${sevenDaysAgo},glicko_last_period.is.null)`,
+  // Paged, and projected: this was `select=*` with no limit, so a single
+  // response carried every column of every inactive profile.
+  const users = await fetchAllPages<Profile>((offset, limit) =>
+    supabaseFetch<Profile[]>(
+      `/rest/v1/profiles?or=(glicko_last_period.lt.${sevenDaysAgo},glicko_last_period.is.null)` +
+        `&select=${PROFILE_COLUMNS}&order=id.asc&offset=${offset}&limit=${limit}`,
+    ),
   );
 
   let processed = 0;
@@ -345,7 +373,12 @@ export async function decayInactivePlayers() {
 
   for (const user of users) {
     try {
-      const result = await processRatingPeriod(user.id, { applyDecayIfNoGames: true });
+      // Hand over the profile we already read: four sequential round-trips
+      // per user becomes three.
+      const result = await processRatingPeriod(user.id, {
+        applyDecayIfNoGames: true,
+        profile: user,
+      });
       if (result.gamesInPeriod === 0) {
         processed++;
       }

--- a/server/src/scheduledTournament/engine.test.ts
+++ b/server/src/scheduledTournament/engine.test.ts
@@ -886,3 +886,31 @@ describe('ready-match reconciliation', () => {
     expect(Date.parse(store.matches[0].ready_deadline_at!)).toBeGreaterThan(Date.now());
   });
 });
+
+/**
+ * The scheduler tick fetched in-progress tournaments and then called
+ * reconcileExpiredReadyMatches, which fetched exactly the same set again —
+ * 2,880 duplicate queries a day on a 30-second tick, whether or not anyone was
+ * playing.
+ */
+describe('reconcileExpiredReadyMatches — reusing the caller\'s read', () => {
+  it('does not re-query when the caller already has the tournaments', async () => {
+    const fetchTournamentsByStatus = vi.fn(async () => []);
+    const { persistence } = makePersistence(makeTournament({ status: 'in_progress' }), []);
+    const { io } = makeIoMock();
+
+    await reconcileExpiredReadyMatches(io, new Date(), { ...persistence, fetchTournamentsByStatus }, []);
+
+    expect(fetchTournamentsByStatus).not.toHaveBeenCalled();
+  });
+
+  it('still fetches for a caller that passes nothing, so standalone use is unchanged', async () => {
+    const fetchTournamentsByStatus = vi.fn(async () => []);
+    const { persistence } = makePersistence(makeTournament({ status: 'in_progress' }), []);
+    const { io } = makeIoMock();
+
+    await reconcileExpiredReadyMatches(io, new Date(), { ...persistence, fetchTournamentsByStatus });
+
+    expect(fetchTournamentsByStatus).toHaveBeenCalledWith(['in_progress']);
+  });
+});

--- a/server/src/scheduledTournament/engine.ts
+++ b/server/src/scheduledTournament/engine.ts
@@ -4,6 +4,7 @@ import { supabaseFetch } from '../supabaseUtils';
 import { writeTournamentActivity } from '../social/activityWriter';
 import { QF_SEED_PAIRS, advanceSlot } from './bracket';
 import { defaultEnginePersistence, type EnginePersistence } from './persistenceInterface';
+import type { ScheduledTournamentRow } from './types';
 import {
   TOURNAMENT_MATCH_READY_WINDOW_MS,
   allHumanPlayersJoined,
@@ -622,10 +623,18 @@ export async function reconcileExpiredReadyMatches(
   io: Server,
   now: Date = new Date(),
   persistence: EnginePersistence = defaultEnginePersistence,
+  /**
+   * In-progress tournaments the caller already read. The scheduler tick
+   * fetches exactly this set immediately before calling here, so without it
+   * the same query runs twice every 30 seconds — 2,880 duplicates a day,
+   * players or no players. Omit it and the standalone read still happens.
+   */
+  inProgressTournaments?: ScheduledTournamentRow[],
 ): Promise<number> {
-  const tournaments = persistence.fetchTournamentsByStatus
-    ? await persistence.fetchTournamentsByStatus(['in_progress'])
-    : [];
+  const tournaments = inProgressTournaments
+    ?? (persistence.fetchTournamentsByStatus
+      ? await persistence.fetchTournamentsByStatus(['in_progress'])
+      : []);
   let resolvedCount = 0;
   for (const tournament of tournaments) {
     const matches = await persistence.fetchMatches(tournament.id);

--- a/server/src/scheduledTournament/persistence.ts
+++ b/server/src/scheduledTournament/persistence.ts
@@ -204,12 +204,21 @@ export async function updateRegistrationPlacement(
 
 // ── Matches ──────────────────────────────────────────────────────────────
 
+/**
+ * Backstop for the match read, not a page size callers work around: an
+ * 8-player bracket is 7 matches. The scheduler calls fetchMatches for every
+ * in-progress tournament on a 30-second tick, and the response was previously
+ * bounded only by however many rows a tournament happened to have.
+ */
+export const TOURNAMENT_MATCH_PAGE_LIMIT = 256;
+
 export async function fetchMatches(tournamentId: string): Promise<MatchRow[]> {
   return supabaseFetch<MatchRow[]>(
     `/rest/v1/${TABLES.matches}` +
       `?select=*` +
       `&tournament_id=eq.${encodeURIComponent(tournamentId)}` +
-      `&order=round.asc,match_number.asc`,
+      `&order=round.asc,match_number.asc` +
+      `&limit=${TOURNAMENT_MATCH_PAGE_LIMIT}`,
   );
 }
 

--- a/server/src/scheduledTournament/persistenceQueries.test.ts
+++ b/server/src/scheduledTournament/persistenceQueries.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const { supabaseFetchMock } = vi.hoisted(() => ({ supabaseFetchMock: vi.fn(async () => []) }));
+vi.mock('../supabaseUtils', async () => {
+  const actual = await vi.importActual<typeof import('../supabaseUtils')>('../supabaseUtils');
+  return { ...actual, supabaseFetch: supabaseFetchMock };
+});
+
+import { fetchMatches, TOURNAMENT_MATCH_PAGE_LIMIT } from './persistence';
+
+/**
+ * The scheduler calls fetchMatches for every in-progress tournament on a
+ * 30-second tick. It asked for `select=*` with no limit, so the response size
+ * was bounded only by however many match rows a tournament happened to have.
+ */
+describe('fetchMatches', () => {
+  it('bounds the response with an explicit limit', async () => {
+    supabaseFetchMock.mockClear();
+
+    await fetchMatches('tour-1');
+
+    const path = supabaseFetchMock.mock.calls[0]![0] as string;
+    expect(path).toContain(`limit=${TOURNAMENT_MATCH_PAGE_LIMIT}`);
+  });
+
+  it('still scopes to the tournament and keeps bracket order', async () => {
+    supabaseFetchMock.mockClear();
+
+    await fetchMatches('tour-1');
+
+    const path = supabaseFetchMock.mock.calls[0]![0] as string;
+    expect(path).toContain('tournament_id=eq.tour-1');
+    expect(path).toContain('order=round.asc,match_number.asc');
+  });
+
+  it('has a limit comfortably above any real bracket', () => {
+    // 8 players is a 7-match bracket; the cap is a backstop, not a page size
+    // callers have to work around.
+    expect(TOURNAMENT_MATCH_PAGE_LIMIT).toBeGreaterThanOrEqual(64);
+  });
+});

--- a/server/src/scheduledTournament/scheduler.ts
+++ b/server/src/scheduledTournament/scheduler.ts
@@ -58,7 +58,8 @@ export function startTournamentScheduler(io: Server): void {
           await dispatchScheduledStartMatches(io, t.id, undefined, new Date(now));
         }
       }
-      await reconcileExpiredReadyMatches(io, new Date(now));
+      // Hand over the set just read rather than making the engine fetch it again.
+      await reconcileExpiredReadyMatches(io, new Date(now), undefined, inProgress);
     } catch (err) {
       log.warn({ err }, 'scheduler tick failed');
     }

--- a/server/src/supabasePagination.test.ts
+++ b/server/src/supabasePagination.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from 'vitest';
+import { DEFAULT_PAGE_SIZE, fetchAllPages } from './supabasePagination';
+
+/**
+ * The weekly ranking maintenance scanned `profiles` and `ranked_games` with no
+ * limit at all, so one request had to carry every matching row and its size
+ * grew with the user base. These scans are now paged.
+ */
+describe('fetchAllPages', () => {
+  it('returns a single short page without asking for another', async () => {
+    const fetchPage = vi.fn(async () => [1, 2, 3]);
+
+    expect(await fetchAllPages(fetchPage, { pageSize: 10 })).toEqual([1, 2, 3]);
+    expect(fetchPage).toHaveBeenCalledTimes(1);
+    expect(fetchPage).toHaveBeenCalledWith(0, 10);
+  });
+
+  it('keeps paging while pages come back full', async () => {
+    const pages = [[1, 2], [3, 4], [5]];
+    const fetchPage = vi.fn(async (offset: number) => pages[offset / 2] ?? []);
+
+    expect(await fetchAllPages(fetchPage, { pageSize: 2 })).toEqual([1, 2, 3, 4, 5]);
+    expect(fetchPage.mock.calls.map((c) => c[0])).toEqual([0, 2, 4]);
+  });
+
+  it('asks once more when the last page is exactly full, then stops on the empty one', async () => {
+    // Otherwise a total that is an exact multiple of the page size silently
+    // drops nothing but leaves the caller unsure it finished.
+    const pages: number[][] = [[1, 2], [3, 4], []];
+    const fetchPage = vi.fn(async (offset: number) => pages[offset / 2] ?? []);
+
+    expect(await fetchAllPages(fetchPage, { pageSize: 2 })).toEqual([1, 2, 3, 4]);
+    expect(fetchPage).toHaveBeenCalledTimes(3);
+  });
+
+  it('stops at maxRows rather than paging forever', async () => {
+    // A runaway scan is the failure this exists to bound: without a ceiling a
+    // bad predicate walks the whole table into memory.
+    const fetchPage = vi.fn(async () => [1, 2]);
+
+    const rows = await fetchAllPages(fetchPage, { pageSize: 2, maxRows: 5 });
+
+    expect(rows).toHaveLength(5);
+    expect(fetchPage.mock.calls.length).toBeLessThanOrEqual(3);
+  });
+
+  it('returns nothing for an empty first page', async () => {
+    expect(await fetchAllPages(async () => [], { pageSize: 10 })).toEqual([]);
+  });
+
+  it('lets a failed page reject rather than returning a partial result as complete', async () => {
+    const fetchPage = vi.fn(async (offset: number) => {
+      if (offset > 0) throw new Error('supabase unavailable');
+      return [1, 2];
+    });
+
+    await expect(fetchAllPages(fetchPage, { pageSize: 2 })).rejects.toThrow('supabase unavailable');
+  });
+
+  it('has a bounded default page size', () => {
+    expect(DEFAULT_PAGE_SIZE).toBeGreaterThan(0);
+    expect(DEFAULT_PAGE_SIZE).toBeLessThanOrEqual(1000);
+  });
+});

--- a/server/src/supabasePagination.ts
+++ b/server/src/supabasePagination.ts
@@ -1,0 +1,39 @@
+/**
+ * Paged reads for the maintenance scans.
+ *
+ * The weekly ranking jobs queried `profiles` and `ranked_games` with no limit,
+ * so a single response had to carry every matching row and grew with the user
+ * base. Paging bounds each request; `maxRows` bounds the whole scan, so a bad
+ * predicate cannot walk an entire table into memory.
+ */
+
+/** Small enough that one page is a modest response, large enough to be few. */
+export const DEFAULT_PAGE_SIZE = 500;
+
+/** Ceiling for a single scan. Well above any real cohort; a backstop, not a policy. */
+export const DEFAULT_MAX_ROWS = 100_000;
+
+export type FetchPage<T> = (offset: number, limit: number) => Promise<T[]>;
+
+export async function fetchAllPages<T>(
+  fetchPage: FetchPage<T>,
+  options: { pageSize?: number; maxRows?: number } = {},
+): Promise<T[]> {
+  const pageSize = options.pageSize ?? DEFAULT_PAGE_SIZE;
+  const maxRows = options.maxRows ?? DEFAULT_MAX_ROWS;
+
+  const rows: T[] = [];
+  let offset = 0;
+
+  while (rows.length < maxRows) {
+    // Never ask for more than the remaining budget, so the ceiling is exact
+    // rather than "the last page overshot it".
+    const limit = Math.min(pageSize, maxRows - rows.length);
+    const page = await fetchPage(offset, limit);
+    rows.push(...page);
+    if (page.length < limit) break;
+    offset += page.length;
+  }
+
+  return rows.length > maxRows ? rows.slice(0, maxRows) : rows;
+}


### PR DESCRIPTION
Four inefficiencies found while inventorying the scheduled jobs during the overnight-bandwidth investigation. **None of them caused that** — the arithmetic came up an order of magnitude short — but all four are live and three scale with the user base.

## 1. A duplicate query every 30 seconds
`reconcileExpiredReadyMatches` re-ran `fetchTournamentsByStatus(['in_progress'])` that the scheduler tick had *just* run. On a 30-second tick that is **2,880 duplicate queries a day**, players or no players.

It now takes the set the caller already has. Called without it the standalone read is unchanged — there's a test for each direction, because the engine tests rely on the standalone path.

## 2. `fetchMatches` was unbounded
`select=*` with no limit, once per in-progress tournament per tick. Bounded at **256** — an 8-player bracket is 7 matches, so this is a backstop, not a page size callers have to work around.

## 3. `decayInactivePlayers` — unbounded scan plus N+1
It selected every inactive profile in one unlimited `select=*`, then called back in per user for **a profile it already had in hand**.

- the scan is paged and projected to the nine columns `Profile` actually declares
- the row is handed to `processRatingPeriod`, taking **four sequential round-trips per user down to three**

This is the one that scales worst: it's weekly, and every user inactive for 7 days is in it.

## 4. `processAllPendingRatingGames` — unbounded scan
`ranked_games?rating_after=is.null` with no limit, so one response carried the entire backlog. Also paged.

## On the paging helper
One helper, with a `maxRows` ceiling so a bad predicate can't walk a table into memory, tested directly rather than through the jobs. It deliberately requests one more page when the last came back exactly full, so "finished" is observed rather than inferred.

## Test change worth a look
Two rating tests matched the profile read by **exact URL**. Adding the column projection changed that URL, so they now match on the identifying prefix — which is what they were actually asserting. Flagging it because a reviewer should agree the assertion didn't get weaker.

## Verification
- server: **1111 tests** pass — 12 new: 7 for the paging helper, 2 for the duplicate-query removal, 3 for the `fetchMatches` bound
- client: 1414 tests pass — server tests import client source, so both suites run
- `tsc -p tsconfig.json --noEmit` (server) and `tsc -b --noEmit` (client): clean

**Not verified:** the real query plans against production Supabase. These are request-shape changes proven by tests on the URLs and by the existing rating tests continuing to pass; I have no production DB access to confirm row counts or timings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
