### PR TITLE
fix(tournament): gate bot-only auto-sim on two feeders, not the whole round (T-INV-6)

### DIFF
--- a/server/src/scheduledTournament/engine.test.ts
+++ b/server/src/scheduledTournament/engine.test.ts
@@ -443,7 +443,7 @@ describe('closeRegistrationAndStart', () => {
     expect(store.matches.filter((m) => m.round === 2).every((m) => m.status !== 'completed')).toBe(true);
   });
 
-  it('does not complete semifinal bot-only matches before quarterfinals finish', async () => {
+  it('gates semifinal bot-only auto-resolution on its two feeders, not the whole round (T-INV-6)', async () => {
     const tournament = makeTournament({
       status: 'in_progress',
       scheduled_start: new Date('2026-05-15T00:00:00Z').toISOString(),
@@ -455,13 +455,25 @@ describe('closeRegistrationAndStart', () => {
     await closeRegistrationAndStart(io, 'tour-1', persistence);
     await dispatchScheduledStartMatches(io, 'tour-1', persistence, new Date('2026-05-15T00:00:01Z'));
 
+    // The one human is seed 1 → QF1 → SF1. QF1 stays a live human match.
     const humanQf = store.matches.find(
       (m) => m.round === 1 && (m.player1_id === 'u1' || m.player2_id === 'u1'),
     );
     expect(humanQf?.status).toBe('ready');
+    expect(humanQf?.match_number).toBe(1);
 
-    const sfMatches = store.matches.filter((m) => m.round === 2);
-    expect(sfMatches.every((m) => m.status !== 'completed')).toBe(true);
+    const sf = store.matches
+      .filter((m) => m.round === 2)
+      .sort((a, b) => a.match_number - b.match_number);
+
+    // SF1 is fed by QF1 (the unresolved human match) — it must NOT auto-resolve,
+    // even though its other feeder QF2 is a finished bot pair.
+    expect(sf[0].status).not.toBe('completed');
+
+    // SF2 is fed by QF3 + QF4, both finished bot pairs — its two feeders are
+    // done, so it auto-resolves now rather than waiting for QF1.
+    expect(sf[1].status).toBe('completed');
+    expect(sf[1].winner_id).toBeTruthy();
   });
 });
 

--- a/server/src/scheduledTournament/engine.ts
+++ b/server/src/scheduledTournament/engine.ts
@@ -147,19 +147,33 @@ function isTournamentPlayable(
   return Date.parse(tournament.scheduled_start) <= now.getTime();
 }
 
-async function isPreviousRoundComplete(
+/**
+ * A round-N match is fed by exactly two round-(N-1) matches: numbers 2M-1 and
+ * 2M, where M is this match's number (SF1 ← QF1+QF2, SF2 ← QF3+QF4, F ← SF1+SF2).
+ *
+ * This is the bracket-exact gate (invariant T-INV-6). It is deliberately NOT
+ * "the whole previous round is done" — SF1 may resolve while QF3/QF4 still play.
+ * For human matches this is already how advancement works (a target reaches
+ * `ready` only once both its slots are filled); this function applies the same
+ * rule to bot-only auto-simulation, where there is no advancement trigger.
+ */
+async function areFeederMatchesComplete(
   tournamentId: string,
   round: 1 | 2 | 3,
+  matchNumber: number,
   persistence: EnginePersistence,
 ): Promise<boolean> {
   if (round <= 1) return true;
+  const feederNumbers = [matchNumber * 2 - 1, matchNumber * 2];
   const matches = await persistence.fetchMatches(tournamentId);
-  const prevRound = matches.filter((m) => m.round === round - 1);
-  if (prevRound.length === 0) return false;
-  return prevRound.every((m) => m.status === 'completed' || m.status === 'bye');
+  const feeders = matches.filter(
+    (m) => m.round === round - 1 && feederNumbers.includes(m.match_number),
+  );
+  if (feeders.length < 2) return false;
+  return feeders.every((m) => m.status === 'completed' || m.status === 'bye');
 }
 
-/** Bot-vs-bot matches only auto-resolve after scheduled_start and when the prior round has finished. */
+/** Bot-vs-bot matches only auto-resolve after scheduled_start and once both feeder matches have finished. */
 async function canAutoSimulateBotOnlyMatch(
   match: MatchRow,
   persistence: EnginePersistence,
@@ -170,7 +184,12 @@ async function canAutoSimulateBotOnlyMatch(
   if (!isTournamentPlayable(tournament, now)) return false;
   if (!match.player1_id || !match.player2_id) return false;
   if (!isBotOnlyMatch(match)) return false;
-  return isPreviousRoundComplete(match.tournament_id, match.round as 1 | 2 | 3, persistence);
+  return areFeederMatchesComplete(
+    match.tournament_id,
+    match.round as 1 | 2 | 3,
+    match.match_number,
+    persistence,
+  );
 }
 
 async function resolveBotOnlyMatch(


### PR DESCRIPTION
Implements the reworded **T-INV-6** from `HARDENING_PLAN.md` (Decision D-6), pulled forward from Step 4 at the human's direction.

`isPreviousRoundComplete` (whole previous round must be `completed`/`bye`) → `areFeederMatchesComplete(tournamentId, round, matchNumber)` (only the two feeders — round N-1, match numbers `2M-1` and `2M`).

**Why:** the strict rule was an unexamined over-constraint. Human matches already advance on the two-feeder condition (via `applyMatchResult`'s advancement tail). This only changes **bot-only** auto-simulation: a fully-bot semifinal/final now auto-resolves once its two bot feeders finish rather than waiting for the human's half of the bracket.

**Player-visible?** No. The client's bracket-reveal logic (`computeBracketRevealThroughRound`) hides non-human match results beyond the player's current round. `tournament:round_completed` has no client listener. Bracket view / next-match / hub-state / notifications are all per-match. (Full analysis: §1.4.3 of the hardening plan.)

**Tests:** the one engine test that asserted the strict rule is rewritten to assert T-INV-6 — an SF fed by an unresolved human QF stays open; an SF fed by two finished bot QFs auto-resolves. `tsc --noEmit` clean; 352 server tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)