### PR TITLE
feat(tournament): consolidate match participant authz into one gate (PR-B)

### DIFF
--- a/server/src/multiplayer/registerTournamentAttachHandlers.ts
+++ b/server/src/multiplayer/registerTournamentAttachHandlers.ts
@@ -8,6 +8,8 @@ import {
   peekRoom,
 } from '../rooms';
 import { fetchMatchById, updateMatch } from '../scheduledTournament/persistence';
+import { authorizeMatchParticipant, matchAuthzAck } from '../scheduledTournament/tournamentAuth';
+import type { MatchRow } from '../scheduledTournament/types';
 import {
   dispatchTournamentMatch,
   humanJoinedAt,
@@ -65,46 +67,36 @@ export function registerTournamentAttachHandlers(
 
     try {
       const authenticatedUserId = handlerDeps.normalizeUserId(socket.data?.userId);
-      if (!authenticatedUserId) {
-        log.info({ socketId: socket.id }, 'rejected/no-user');
-        ackOnce({ ok: false, error: 'not_authenticated' });
-        return;
-      }
       const matchId = matchIdFromPayload;
       if (!matchId) {
         ackOnce({ ok: false, error: 'missing_matchId' });
         return;
       }
-      let match = await fetchMatchById(matchId);
-      if (!match) {
-        log.info({ matchId, userId: authenticatedUserId }, 'rejected/no-match');
-        ackOnce({ ok: false, error: 'match_not_found' });
+
+      const authz = await authorizeMatchParticipant(authenticatedUserId, { matchId });
+      if (!authz.ok) {
+        log.info({ matchId, userId: authenticatedUserId, code: authz.code }, 'rejected/authz');
+        ackOnce(matchAuthzAck(authz.code));
         return;
       }
-      if (match.status === 'completed' || match.status === 'bye' || match.completed_at || match.winner_id) {
-        ackOnce({ ok: false, error: 'match_completed' });
-        return;
-      }
-      if (match.room_code) {
-        const existingRoom = peekRoom(match.room_code);
+      // authz.ok ⇒ a verified, non-null participant of this fresh match row.
+      const participantUserId: string = authenticatedUserId as string;
+      const authorizedMatch = authz.match;
+
+      if (authorizedMatch.room_code) {
+        const existingRoom = peekRoom(authorizedMatch.room_code);
         if (existingRoom?.state?.gameOver) {
-          log.info({ roomCode: match.room_code }, 'rejected completed room');
+          log.info({ roomCode: authorizedMatch.room_code }, 'rejected completed room');
           ackOnce({ ok: false, error: 'match_completed' });
           return;
         }
       }
-      if (match.player1_id !== authenticatedUserId && match.player2_id !== authenticatedUserId) {
-        log.info({
-          matchId,
-          userId: authenticatedUserId,
-        }, 'rejected/not-participant');
-        ackOnce({ ok: false, error: 'tournament_not_assigned' });
-        return;
-      }
-      if (match.status !== 'ready' && match.status !== 'in_progress') {
+      if (authorizedMatch.status !== 'ready' && authorizedMatch.status !== 'in_progress') {
         ackOnce({ ok: false, error: 'match_not_ready' });
         return;
       }
+
+      let match: MatchRow | null = authorizedMatch;
       if (!match.room_code) {
         await dispatchTournamentMatch(io, match.id, { reason: 'repair', emitIfAlreadyReady: true });
         match = await fetchMatchById(matchId);
@@ -136,29 +128,29 @@ export function registerTournamentAttachHandlers(
       }
 
       const seat =
-        match.player1_id === authenticatedUserId
+        match.player1_id === participantUserId
           ? 'player1'
-          : match.player2_id === authenticatedUserId
+          : match.player2_id === participantUserId
             ? 'player2'
             : null;
       log.info({
         matchId: match.id,
         roomCode: match.room_code,
-        userId: authenticatedUserId,
+        userId: participantUserId,
         seat,
       }, 'joining-room');
 
       const attached = await attachSocketToTrackedRoom({
         roomCode: match.room_code,
         username: typeof socket.data?.username === 'string' ? socket.data.username : 'Player',
-        userId: authenticatedUserId,
+        userId: participantUserId,
         via: 'tournament:attach_assigned_match',
         hydrateMatchmakingRoom: false,
       });
       const nowIso = new Date().toISOString();
-      if (!humanJoinedAt(match, authenticatedUserId)) {
+      if (!humanJoinedAt(match, participantUserId)) {
         const patch =
-          match.player1_id === authenticatedUserId
+          match.player1_id === participantUserId
             ? { player1_joined_at: nowIso }
             : { player2_joined_at: nowIso };
         await updateMatch(match.id, patch);
@@ -178,7 +170,7 @@ export function registerTournamentAttachHandlers(
             room.scheduledTournamentMatchId!,
             defaultEnginePersistence,
             nowIso,
-            authenticatedUserId,
+            participantUserId,
           );
           handlerDeps.notifyRoomPlayersInGame(room.code);
           await handlerDeps.onAfterMatchStarted(room);
@@ -203,7 +195,7 @@ export function registerTournamentAttachHandlers(
       }
 
       const refreshed = await fetchMatchById(match.id);
-      const humanAttached = Boolean(humanJoinedAt(refreshed ?? match, authenticatedUserId));
+      const humanAttached = Boolean(humanJoinedAt(refreshed ?? match, participantUserId));
       const matchStatus =
         refreshed?.status === 'in_progress' && humanAttached
           ? 'in_progress'
@@ -216,7 +208,7 @@ export function registerTournamentAttachHandlers(
       log.info({
         matchId: match.id,
         roomCode: room.code,
-        userId: authenticatedUserId,
+        userId: participantUserId,
         seat,
         handCount,
         matchStatus,
@@ -224,13 +216,13 @@ export function registerTournamentAttachHandlers(
       log.info({
         matchId: match.id,
         roomCode: room.code,
-        userId: authenticatedUserId,
+        userId: participantUserId,
         seat,
       }, 'accepted');
       log.info({
         matchId: match.id,
         roomCode: room.code,
-        userId: authenticatedUserId,
+        userId: participantUserId,
         seat,
       }, 'accepted');
       ackOnce({

--- a/server/src/multiplayer/roomForfeit.test.ts
+++ b/server/src/multiplayer/roomForfeit.test.ts
@@ -443,12 +443,18 @@ describe('tournament forfeit apply durability (G2)', () => {
     vi.useFakeTimers();
     const room = seedTournamentRoom('TFOR4');
     let resolveApply!: () => void;
-    applyMatchResultMock.mockImplementation(
-      () =>
-        new Promise<void>((resolve) => {
-          resolveApply = resolve;
-        }),
-    );
+    let signalApplyEntered!: () => void;
+    // Resolves exactly when applyMatchResult is entered — deterministic, no
+    // dependence on how many async hops precede the retry loop.
+    const applyEntered = new Promise<void>((resolve) => {
+      signalApplyEntered = resolve;
+    });
+    applyMatchResultMock.mockImplementation(() => {
+      signalApplyEntered();
+      return new Promise<void>((resolve) => {
+        resolveApply = resolve;
+      });
+    });
 
     const io = makeIo();
     const socket = { id: 'sock-p1', data: { userId: 'u1' } } as any;
@@ -458,7 +464,8 @@ describe('tournament forfeit apply durability (G2)', () => {
       userId: 'u1',
     });
 
-    await Promise.resolve();
+    await applyEntered;
+    expect(applyMatchResultMock).toHaveBeenCalledTimes(1);
     expect(room.tournamentForfeitApplyStatus).toBe('pending');
     expect(room.abandonedAt).toBeUndefined();
     expect(io.__emit).not.toHaveBeenCalledWith('room:match_abandoned', expect.anything());

--- a/server/src/multiplayer/roomForfeit.ts
+++ b/server/src/multiplayer/roomForfeit.ts
@@ -1,7 +1,7 @@
 import type { Server, Socket } from 'socket.io';
 import { appendRoomEvent } from '../roomEvents';
 import { getRoom, type Room } from '../rooms';
-import { fetchMatchById } from '../scheduledTournament/persistence';
+import { authorizeMatchParticipant } from '../scheduledTournament/tournamentAuth';
 import { applyMatchResult } from '../scheduledTournament/engine';
 import { recordMatchEnd } from '../matchmaking/persistence';
 import {
@@ -117,47 +117,55 @@ export async function applyActiveMatchForfeit(
   if (room.scheduledTournamentMatchId) {
     room.tournamentForfeitApplyStatus = 'pending';
 
-    let match;
+    // Who left decides who wins, so an unresolved leaver cannot be allowed to
+    // fall through to a default: a null userId (guest seat, or an identity lost
+    // on the disconnect-timeout path) or anyone who reached this room without
+    // being assigned to the match must forfeit nothing — not hand player1 the
+    // win. The participant gate (§1.4.5) reads the match fresh and answers this.
+    // `allowCompleted` so a race with the real game-over still flows through
+    // (the RPC is idempotent); the not-a-participant branch is preserved below.
+    let authz;
     try {
-      match = await fetchMatchById(room.scheduledTournamentMatchId);
+      authz = await authorizeMatchParticipant(
+        authenticatedUserId,
+        { matchId: room.scheduledTournamentMatchId },
+        { allowCompleted: true },
+      );
     } catch (err) {
       room.tournamentForfeitApplyStatus = 'failed';
       emitTournamentForfeitApplyFailed(io, room, err);
       return null;
     }
 
-    if (!match || !match.player1_id || !match.player2_id) {
-      room.tournamentForfeitApplyStatus = 'failed';
-      emitTournamentForfeitApplyFailed(io, room, new Error('match_not_found'));
-      return null;
-    }
-
-    // Who left decides who wins, so an unresolved leaver cannot be allowed to
-    // fall through to a default. The previous two-branch ternary had no "not a
-    // participant" case: a null userId (guest seat, or an identity lost on the
-    // disconnect-timeout path) or anyone who reached this room without being
-    // assigned to the match took the else branch and handed the win to
-    // player1 — forfeiting on behalf of a player who never left.
-    const abandonerIsPlayer1 = match.player1_id === authenticatedUserId;
-    const abandonerIsPlayer2 = match.player2_id === authenticatedUserId;
-    if (!abandonerIsPlayer1 && !abandonerIsPlayer2) {
-      // Not this match's player: leaving forfeits nothing. Leave the row alone
-      // for the real players, or for the no-show reconciler if neither shows.
+    if (!authz.ok) {
+      if (authz.code === 'match_not_found') {
+        room.tournamentForfeitApplyStatus = 'failed';
+        emitTournamentForfeitApplyFailed(io, room, new Error('match_not_found'));
+        return null;
+      }
+      // not_authenticated / not_a_participant: leaving forfeits nothing. Leave
+      // the row alone for the real players, or for the no-show reconciler.
       room.tournamentForfeitApplyStatus = 'idle';
       log.warn(
         {
           roomCode: room.code,
-          matchId: match.id,
-          tournamentId: match.tournament_id,
+          matchId: room.scheduledTournamentMatchId,
           leavingUserId: authenticatedUserId,
-          player1Id: match.player1_id,
-          player2Id: match.player2_id,
+          authzCode: authz.code,
         },
         'tournament forfeit ignored — leaver is not a participant of this match',
       );
       return null;
     }
 
+    const match = authz.match;
+    if (!match.player1_id || !match.player2_id) {
+      room.tournamentForfeitApplyStatus = 'failed';
+      emitTournamentForfeitApplyFailed(io, room, new Error('match_not_found'));
+      return null;
+    }
+
+    const abandonerIsPlayer1 = match.player1_id === authenticatedUserId;
     winnerUserId = abandonerIsPlayer1 ? match.player2_id : match.player1_id;
     const winTarget =
       typeof room.config.winningScore === 'number' && Number.isFinite(room.config.winningScore)

--- a/server/src/multiplayer/roomSocketAttach.ts
+++ b/server/src/multiplayer/roomSocketAttach.ts
@@ -10,8 +10,8 @@ import {
   type Room,
 } from '../rooms';
 import { supabaseFetch } from '../supabaseUtils';
-import { fetchMatchById, fetchMatchByRoomCode } from '../scheduledTournament/persistence';
 import { isTournamentRoomCode } from '../scheduledTournament/matchDispatch';
+import { authorizeMatchParticipant, type MatchParticipantAuthz } from '../scheduledTournament/tournamentAuth';
 import { ensureRoomHydrated } from './roomLivePersistence';
 import {
   isTerminalHydrationError,
@@ -367,18 +367,28 @@ export function createRoomSocketAttach(ctx: RoomSocketAttachContext): RoomSocket
     if (via === 'room:join') {
       const knownTournamentMatchId = existingRoom.scheduledTournamentMatchId ?? null;
       if (knownTournamentMatchId || isTournamentRoomCode(roomCode)) {
-        const assignedMatch = knownTournamentMatchId
-          ? await fetchMatchById(knownTournamentMatchId).catch(() => null)
-          : await fetchMatchByRoomCode(roomCode).catch(() => null);
-        const isTournamentRoom = Boolean(knownTournamentMatchId || assignedMatch);
-        const isAssignedPlayer = Boolean(
-          userId &&
-            assignedMatch &&
-            (assignedMatch.player1_id === userId || assignedMatch.player2_id === userId),
-        );
-        if (isTournamentRoom && !isAssignedPlayer) {
+        // A read failure here is treated as "couldn't resolve the match" — same
+        // as #91's `.catch(() => null)`: fail closed when we have a match-id
+        // marker, fall through otherwise.
+        const authz = await authorizeMatchParticipant(
+          userId ?? null,
+          knownTournamentMatchId ? { matchId: knownTournamentMatchId } : { roomCode },
+          { allowCompleted: true },
+        ).catch((): MatchParticipantAuthz => ({ ok: false, code: 'match_not_found' }));
+        // Fail closed when we know this is a tournament room (a match id marker,
+        // or a resolved bracket row). A bare code-shape match with no row is not
+        // a tournament room — let the ordinary private join proceed.
+        //
+        // A regex-shaped code with no backing match row falls through to
+        // "treat as ordinary private room" (unchanged from #91): an intentional
+        // tradeoff accepting the ambiguity between a coincidental code collision
+        // and a stale/deleted tournament match, rather than locking out a real
+        // private room that happens to match the pattern.
+        const codeShapeOnlyMiss =
+          !authz.ok && authz.code === 'match_not_found' && !knownTournamentMatchId;
+        if (!authz.ok && !codeShapeOnlyMiss) {
           log.info(
-            { roomCode, userId: userId ?? null, via, matchResolved: Boolean(assignedMatch) },
+            { roomCode, userId: userId ?? null, via, authzCode: authz.code },
             'join rejected: not a tournament participant',
           );
           throw new Error('not_match_participant');

--- a/server/src/scheduledTournament/matchDispatch.ts
+++ b/server/src/scheduledTournament/matchDispatch.ts
@@ -3,6 +3,7 @@ import type { Server } from 'socket.io';
 import { supabaseFetch } from '../supabaseUtils';
 import { defaultEnginePersistence, type EnginePersistence } from './persistenceInterface';
 import type { MatchRow } from './types';
+import { isTournamentRoomCode, makeTournamentRoomCode } from './tournamentRoomCode';
 import type { Room } from '../rooms';
 import { seatSyntheticBotInRoom } from '../multiplayer/botSeating';
 
@@ -31,23 +32,9 @@ export type DispatchTournamentMatchOptions = {
   emitIfAlreadyReady?: boolean;
 };
 
-function makeTournamentRoomCode(match: MatchRow): string {
-  const short = match.tournament_id.replace(/-/g, '').slice(0, 6).toUpperCase();
-  return `T${short}R${match.round}M${match.match_number}`;
-}
-
-/**
- * True for codes shaped like {@link makeTournamentRoomCode} output. Kept beside
- * the generator so the two cannot drift.
- *
- * Used by the room:join ACL to decide whether a code is worth a tournament
- * lookup: a restarted server rehydrates a room shell without
- * `scheduledTournamentMatchId` (it is not persisted), so the in-memory field
- * alone cannot be trusted to identify a tournament room.
- */
-export function isTournamentRoomCode(code: string): boolean {
-  return /^T[0-9A-F]{6}R[1-3]M[1-4]$/.test(code.trim().toUpperCase());
-}
+// Room-code generator + recognizer live in a dependency-free leaf module now
+// (the authz layer needs the recognizer without the persistence graph).
+export { isTournamentRoomCode, makeTournamentRoomCode };
 
 export function isBotUserId(userId: string | null | undefined): boolean {
   return typeof userId === 'string' && userId.startsWith('bot:fritz:');

--- a/server/src/scheduledTournament/tournamentAuth.ts
+++ b/server/src/scheduledTournament/tournamentAuth.ts
@@ -1,7 +1,9 @@
 import type { Request, Response } from 'express';
 import type { Socket } from 'socket.io';
 import { supabaseFetch } from '../supabaseUtils';
-import { isValidUuid } from './persistence';
+import { fetchMatchById, fetchMatchByRoomCode, isValidUuid } from './persistence';
+import { isTournamentRoomCode } from './tournamentRoomCode';
+import type { MatchRow } from './types';
 
 export type TournamentAuthError =
   | 'not_authenticated'
@@ -69,6 +71,105 @@ export function rejectMismatchedPayloadUserId(
   if (!isValidUuid(trimmed)) return 'invalid_user';
   if (trimmed !== authenticatedUserId) return 'user_mismatch';
   return null;
+}
+
+// ── Match participant authorization (§1.4.5) ────────────────────────────────
+//
+// "May this verified user act on this tournament match?" — one gate, replacing
+// the inline fetch/null-check/completed-check/participant-check that had been
+// hand-rolled (and drifted) in registerTournamentAttachHandlers, roomForfeit,
+// and roomSocketAttach. Reads the match FRESH every call: a stale client id
+// can't slip through, and callers get the row back so they don't re-fetch.
+
+export type TournamentAuthzDenial =
+  | 'not_authenticated'   // no verified user id
+  | 'match_not_found'
+  | 'match_completed'     // terminal — nothing to act on
+  | 'not_a_participant';  // authenticated, but not player1/player2 of this match
+
+export type MatchParticipantAuthz =
+  | { ok: true; match: MatchRow }
+  | { ok: false; code: TournamentAuthzDenial };
+
+/** A match is terminal once it is completed/bye or carries a winner/completion stamp. */
+function isMatchTerminal(match: MatchRow): boolean {
+  return (
+    match.status === 'completed' ||
+    match.status === 'bye' ||
+    match.completed_at != null ||
+    match.winner_id != null
+  );
+}
+
+/**
+ * The single participant gate. `ref` is a match id or a room code; the room-code
+ * form only hits the DB for codes shaped like a tournament room (the post-restart
+ * fallback — a rehydrated room shell carries no match-id marker). A row that
+ * doesn't exist returns `match_not_found`; a fetch that *throws* (DB down) is
+ * NOT swallowed — it propagates so each caller decides retry vs. give-up.
+ *
+ * `opts.allowCompleted` lets forfeit / room-join paths proceed on a terminal
+ * match (the RPC is idempotent; the room still needs to report terminal state).
+ */
+export async function authorizeMatchParticipant(
+  userId: string | null,
+  ref: { matchId: string } | { roomCode: string },
+  opts?: { allowCompleted?: boolean },
+  deps?: {
+    fetchMatchById?: typeof fetchMatchById;
+    fetchMatchByRoomCode?: typeof fetchMatchByRoomCode;
+  },
+): Promise<MatchParticipantAuthz> {
+  const verifiedUserId = typeof userId === 'string' && userId.trim() ? userId.trim() : null;
+  if (!verifiedUserId) return { ok: false, code: 'not_authenticated' };
+
+  // Bindings are resolved per-branch, not eagerly — one variant never touches
+  // the other's fetch function (matters for tests that mock only one).
+  let match: MatchRow | null = null;
+  if ('matchId' in ref) {
+    match = await (deps?.fetchMatchById ?? fetchMatchById)(ref.matchId);
+  } else if (isTournamentRoomCode(ref.roomCode)) {
+    match = await (deps?.fetchMatchByRoomCode ?? fetchMatchByRoomCode)(ref.roomCode);
+  }
+  if (!match) return { ok: false, code: 'match_not_found' };
+
+  if (!opts?.allowCompleted && isMatchTerminal(match)) {
+    return { ok: false, code: 'match_completed' };
+  }
+
+  if (match.player1_id !== verifiedUserId && match.player2_id !== verifiedUserId) {
+    return { ok: false, code: 'not_a_participant' };
+  }
+
+  return { ok: true, match };
+}
+
+/** Denial → socket ack. Strings kept wire-compatible with existing clients. */
+export function matchAuthzAck(code: TournamentAuthzDenial): { ok: false; error: string } {
+  switch (code) {
+    case 'not_authenticated':
+      return { ok: false, error: 'not_authenticated' };
+    case 'match_not_found':
+      return { ok: false, error: 'match_not_found' };
+    case 'match_completed':
+      return { ok: false, error: 'match_completed' };
+    case 'not_a_participant':
+      return { ok: false, error: 'tournament_not_assigned' };
+  }
+}
+
+/** Denial → HTTP status for REST routes. */
+export function matchAuthzHttpStatus(code: TournamentAuthzDenial): 401 | 403 | 404 | 409 {
+  switch (code) {
+    case 'not_authenticated':
+      return 401;
+    case 'match_not_found':
+      return 404;
+    case 'match_completed':
+      return 409;
+    case 'not_a_participant':
+      return 403;
+  }
 }
 
 export function sendAuthError(res: Response, error: TournamentAuthError): void {

--- a/server/src/scheduledTournament/tournamentRoomCode.ts
+++ b/server/src/scheduledTournament/tournamentRoomCode.ts
@@ -1,0 +1,23 @@
+import type { MatchRow } from './types';
+
+// Tournament room-code generator and its recognizer, kept side-by-side so the
+// two cannot drift. This module has no runtime imports (only a type) so it can
+// be pulled into the participant-authz layer without dragging the persistence /
+// engine graph along with it.
+
+export function makeTournamentRoomCode(match: Pick<MatchRow, 'tournament_id' | 'round' | 'match_number'>): string {
+  const short = match.tournament_id.replace(/-/g, '').slice(0, 6).toUpperCase();
+  return `T${short}R${match.round}M${match.match_number}`;
+}
+
+/**
+ * True for codes shaped like {@link makeTournamentRoomCode} output.
+ *
+ * Used by the room:join ACL to decide whether a code is worth a tournament
+ * lookup: a restarted server rehydrates a room shell without
+ * `scheduledTournamentMatchId` (it is not persisted), so the in-memory field
+ * alone cannot be trusted to identify a tournament room.
+ */
+export function isTournamentRoomCode(code: string): boolean {
+  return /^T[0-9A-F]{6}R[1-3]M[1-4]$/.test(code.trim().toUpperCase());
+}


### PR DESCRIPTION
Step 4 / PR-B of the tournament hardening plan (§1.4.5).

## What

One authorization gate — `authorizeMatchParticipant(userId, {matchId}|{roomCode}, {allowCompleted?})` — plus `matchAuthzAck` / `matchAuthzHttpStatus` mappers, added to `tournamentAuth.ts`. Reads the match fresh every call; a fetch that throws propagates (caller decides retry vs give-up); ack strings kept wire-compatible with existing clients.

Replaces the hand-rolled, drifted inline fetch/null-check/completed-check/participant-check in three call sites:
1. `registerTournamentAttachHandlers` (`tournament:attach_assigned_match`)
2. `roomForfeit.ts` — PR #91's forfeit participant check
3. `roomSocketAttach.ts` — PR #91's `room:join` tournament ACL (fail-closed semantics preserved exactly: a regex-shaped code with no bracket row still falls through to "ordinary private room", unchanged from #91)

`isTournamentRoomCode` + `makeTournamentRoomCode` extracted to a dependency-free leaf module (`tournamentRoomCode.ts`) so the authz layer doesn't drag the persistence/engine graph; `matchDispatch` re-exports them.

## Closes

Gaps **T-5** (seat hijack) and **T-6** from §1.3.

## Verification

- `tsc -p server/tsconfig.json --noEmit` clean
- Full server suite: 196 files / 1121 tests pass
- `grep console.` across all 7 files: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)