### PR TITLE
feat(tournament): TOURNAMENT_SCHEDULER_ENABLED singleton gate (PR-C, D-7)

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -9,3 +9,7 @@ QA_ALLOW_NONLOCAL_STAGING=0
 SENTRY_DSN=your_sentry_dsn
 # Enable only after all four 2026-08-01 Daily Fritz migrations are applied.
 DAILY_FRITZ_TRANSACTIONAL_COMMANDS=false
+# Scheduled-tournament scheduler tick + no-show reconciler. Default true.
+# Must be true on exactly ONE process — set false on web dynos once a dedicated
+# scheduler worker exists (HARDENING_PLAN.md §1.4.6).
+TOURNAMENT_SCHEDULER_ENABLED=true

--- a/server/src/config.test.ts
+++ b/server/src/config.test.ts
@@ -39,4 +39,22 @@ describe('Server Configuration Module', () => {
 
     expect(() => validateAndLoadConfig()).toThrow(/SUPABASE_URL must be a valid absolute URL/);
   });
+
+  it('tournamentSchedulerEnabled defaults to true and is disabled only by an explicit false/0', () => {
+    process.env.NODE_ENV = 'development';
+    process.env.SUPABASE_URL = 'http://localhost:54321';
+    process.env.SUPABASE_SERVICE_KEY = 'mock-key';
+
+    delete process.env.TOURNAMENT_SCHEDULER_ENABLED;
+    expect(validateAndLoadConfig().tournamentSchedulerEnabled).toBe(true);
+
+    process.env.TOURNAMENT_SCHEDULER_ENABLED = 'false';
+    expect(validateAndLoadConfig().tournamentSchedulerEnabled).toBe(false);
+
+    process.env.TOURNAMENT_SCHEDULER_ENABLED = '0';
+    expect(validateAndLoadConfig().tournamentSchedulerEnabled).toBe(false);
+
+    process.env.TOURNAMENT_SCHEDULER_ENABLED = 'true';
+    expect(validateAndLoadConfig().tournamentSchedulerEnabled).toBe(true);
+  });
 });

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -14,6 +14,13 @@ export interface Config {
   clientUrl: string | null;
   serverUrl: string | null;
   enableLegacyTournaments: boolean;
+  /**
+   * Boot-time singleton gate for the scheduled-tournament scheduler tick +
+   * no-show reconciler (D-7 / HARDENING_PLAN.md §1.4.6). Default true. Set
+   * false on web dynos once a dedicated scheduler worker is split out, so the
+   * tick runs on exactly one process.
+   */
+  tournamentSchedulerEnabled: boolean;
   matchmakingDebug: boolean;
   matchmakingDevMode: string | null;
   mpDrawAudit: boolean;
@@ -97,6 +104,7 @@ export function validateAndLoadConfig(): Config {
     clientUrl: getEnv('CLIENT_URL'),
     serverUrl: getEnv('SERVER_URL'),
     enableLegacyTournaments: getEnvBool('ENABLE_LEGACY_TOURNAMENTS', false),
+    tournamentSchedulerEnabled: getEnvBool('TOURNAMENT_SCHEDULER_ENABLED', true),
     matchmakingDebug: getEnvBool('MATCHMAKING_DEBUG', false),
     matchmakingDevMode: getEnv('MATCHMAKING_DEV_MODE'),
     mpDrawAudit: getEnvBool('MP_DRAW_AUDIT', false),

--- a/server/src/scheduledTournament/scheduler.test.ts
+++ b/server/src/scheduledTournament/scheduler.test.ts
@@ -65,4 +65,25 @@ describe('startTournamentScheduler stale cleanup', () => {
     expect(mocks.dispatchScheduledStartMatches).not.toHaveBeenCalled();
     stopTournamentScheduler();
   });
+
+  it('does not tick when TOURNAMENT_SCHEDULER_ENABLED=false (D-7 singleton gate)', async () => {
+    process.env.TOURNAMENT_SCHEDULER_ENABLED = 'false';
+    try {
+      const { startTournamentScheduler, stopTournamentScheduler } = await import('./scheduler');
+      const io = { emit: vi.fn() } as any;
+
+      startTournamentScheduler(io);
+      await Promise.resolve();
+      await Promise.resolve();
+      await vi.advanceTimersByTimeAsync(60_000);
+
+      expect(mocks.fetchTournamentsByStatus).not.toHaveBeenCalled();
+      expect(mocks.reconcileExpiredReadyMatches).not.toHaveBeenCalled();
+      expect(mocks.cancelTournament).not.toHaveBeenCalled();
+      expect(mocks.supabaseFetch).not.toHaveBeenCalled();
+      stopTournamentScheduler();
+    } finally {
+      delete process.env.TOURNAMENT_SCHEDULER_ENABLED;
+    }
+  });
 });

--- a/server/src/scheduledTournament/scheduler.ts
+++ b/server/src/scheduledTournament/scheduler.ts
@@ -1,5 +1,6 @@
 import { childLogger } from '../logger';
 import type { Server } from 'socket.io';
+import { config } from '../config';
 import { isTournamentPastActiveWindow } from './activeWindow';
 import { fetchTournamentsByStatus } from './persistence';
 import {
@@ -26,13 +27,33 @@ let seedTimer: ReturnType<typeof setInterval> | null = null;
  *   - If now >= scheduled_start and status='in_progress' → dispatchScheduledStartMatches
  *
  * Idempotent: status transitions guarded by the current status check, so a slow
- * tick or a restart won't double-fire. No-show resolution also runs off
- * persisted deadlines here; this is acceptable for the current single-instance
- * Render deployment, but multi-instance scale needs a DB-backed lease/lock so
- * only one worker resolves expired matches.
+ * tick or a restart won't double-fire.
+ *
+ * SINGLETON (D-7 / HARDENING_PLAN.md §1.4.6): this whole tick — registration
+ * open/close, scheduled-start dispatch, expired-tournament cancel, AND the
+ * no-show reconciler (`reconcileExpiredReadyMatches`) — must run on exactly one
+ * process. The per-match RPC row lock (D-2) makes each `complete_tournament_match`
+ * call safe, but it does NOT stop two instances from each *scheduling* a call
+ * for different stale matches in the same tick (duplicated work + log noise).
+ * Gated on `TOURNAMENT_SCHEDULER_ENABLED` (default true): Render runs one
+ * instance so this is structurally moot today; when a dedicated scheduler worker
+ * is split out, the flag is false on the web dynos and true on that worker.
+ *
+ * A pg advisory lock was evaluated and REJECTED — the server has no holdable
+ * Postgres session (every DB call is PostgREST over HTTP on a different pooled
+ * connection), so a session-scoped lock releases before the tick's next call.
+ * Only `pg_try_advisory_xact_lock` works over PostgREST, and only inside one RPC.
+ * See §1.4.6 for the full rationale so this is not re-proposed.
  */
 export function startTournamentScheduler(io: Server): void {
   if (timer) return;
+  if (!config.tournamentSchedulerEnabled) {
+    log.info(
+      { flag: 'TOURNAMENT_SCHEDULER_ENABLED', value: false },
+      'tournament scheduler + no-show reconciler disabled on this instance — not ticking',
+    );
+    return;
+  }
   const tick = async () => {
     try {
       const now = Date.now();


### PR DESCRIPTION
Step 4 / PR-C of the tournament hardening plan (D-7 / §1.4.6). Closes gap **T-16**.

## What

The scheduled-tournament scheduler tick — registration open/close, scheduled-start dispatch, expired-tournament cancel, and the **no-show reconciler** — runs on `setInterval` in every server process. The per-match RPC row lock (PR-A / D-2) makes each `complete_tournament_match` call safe, but does **not** stop two instances from each *scheduling* a call for different stale matches in the same tick (duplicated work + log noise).

**D-7:** gate `startTournamentScheduler` on a boot-time flag `TOURNAMENT_SCHEDULER_ENABLED`, default `true`. `startTournamentScheduler` no-ops with a boot log line when false. Render runs one instance so this is structurally moot today; when a dedicated scheduler worker is split out, the flag is `false` on the web dynos and `true` on that worker.

A `pg_try_advisory_lock` at the top of the tick was evaluated and **rejected** — the server has no holdable Postgres session (every call is PostgREST over HTTP on a different pooled connection), so a session-scoped lock releases before the tick's next call. Rationale preserved in the code comment and §1.4.6.

## Changes

- `config.tournamentSchedulerEnabled` = `getEnvBool('TOURNAMENT_SCHEDULER_ENABLED', true)`
- `startTournamentScheduler` early-returns (with a log line) when disabled — gates the whole tick incl. the reconciler and the seed fallback
- `.env.example` documents it
- Tests: config flag parsing (`false`/`0` disable, default + `true` enable); scheduler does not tick / fetch / reconcile / seed when disabled

## Not in scope

**T-11** (`fetchActiveAssignedMatchForUser` latest-row pick) and **T-12** (two "tournament room" concepts) — the plan lists these as "while doing PR-A/PR-B"; that window passed. Flagged still-open in the doc update rather than folded in here.

## Verification

- `tsc -p server/tsconfig.json --noEmit` clean
- Full server suite: 196 files / **1123** tests pass (+2 new)
- `grep console.` across all touched files: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)