### PR TITLE
wip(share): unified emoji-grid share cards + Puzzle Rush results dossier

### DIFF
--- a/client/src/bot/botMatch.css
+++ b/client/src/bot/botMatch.css
@@ -1144,22 +1144,24 @@
 /* ─── Score callout: +N chip — gold you / electric blue Fritz ─── */
 .bot-match-screen .rh-score-chip {
   position: absolute;
-  top: 14px;
+  top: 12px;
   left: 50%;
-  transform: translate(-50%, -6px) scale(0.96);
+  transform: translate(-50%, -8px) scale(0.92);
   opacity: 0;
-  transition: opacity 180ms ease, transform 220ms cubic-bezier(0.22, 1, 0.36, 1);
   z-index: 14;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-width: 52px;
-  height: 34px;
-  padding: 0 14px;
+  min-width: 88px;
+  height: 56px;
+  padding: 0 22px;
   border-radius: 10px;
   background: rgba(8, 14, 24, 0.94) !important;
   border: 1px solid rgba(148, 170, 204, 0.22);
-  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.32);
+  box-shadow:
+    0 12px 30px rgba(0, 0, 0, 0.36),
+    0 0 0 1px rgba(255, 255, 255, 0.03) inset;
+  will-change: transform, opacity;
   pointer-events: none;
   white-space: nowrap;
 }
@@ -1167,16 +1169,30 @@
 .bot-match-screen .rh-score-chip.is-visible {
   opacity: 1;
   transform: translate(-50%, 0) scale(1);
-  animation: rh-score-chip-enter 220ms cubic-bezier(0.22, 1, 0.36, 1);
+  animation:
+    rh-score-chip-enter 280ms cubic-bezier(0.2, 0.9, 0.2, 1),
+    rh-score-chip-settle 520ms cubic-bezier(0.16, 1, 0.3, 1) 180ms 1;
 }
 
 @keyframes rh-score-chip-enter {
   from {
     opacity: 0;
-    transform: translate(-50%, -6px) scale(0.96);
+    transform: translate(-50%, -16px) scale(0.84);
   }
   to {
     opacity: 1;
+    transform: translate(-50%, 0) scale(1);
+  }
+}
+
+@keyframes rh-score-chip-settle {
+  0% {
+    transform: translate(-50%, 0) scale(1);
+  }
+  45% {
+    transform: translate(-50%, 0) scale(1.04);
+  }
+  100% {
     transform: translate(-50%, 0) scale(1);
   }
 }
@@ -1209,11 +1225,12 @@
 
 .bot-match-screen .rh-score-chip__value {
   font-family: 'Barlow Condensed', var(--font-display), sans-serif;
-  font-size: 1.35rem;
+  font-size: 2rem;
   font-weight: 850;
-  letter-spacing: 0.03em;
+  letter-spacing: 0;
   line-height: 1;
   color: rgba(244, 247, 251, 0.96);
+  text-shadow: 0 1px 0 rgba(0, 0, 0, 0.22);
 }
 
 .bot-match-screen .rh-score-chip--bot .rh-score-chip__value {
@@ -1225,15 +1242,15 @@
 }
 
 .bot-match-screen .rh-score-chip__value--text {
-  font-size: 0.82rem;
+  font-size: 1.05rem;
   font-weight: 700;
-  letter-spacing: 0.03em;
+  letter-spacing: 0;
+  text-wrap: balance;
 }
 
 @media (prefers-reduced-motion: reduce) {
   .bot-match-screen .rh-score-chip {
     animation: none;
-    transition: opacity 120ms ease;
     transform: translate(-50%, 0);
   }
 

--- a/client/src/dailyFritz/DailyFritzLeaderboardScreen.tsx
+++ b/client/src/dailyFritz/DailyFritzLeaderboardScreen.tsx
@@ -368,7 +368,7 @@ export default function DailyFritzLeaderboardScreen({
     };
     if (typeof navigator !== 'undefined' && typeof navigator.share === 'function') {
       void navigator
-        .share({ title: 'Daily Fritz', text: resultShareText })
+        .share({ text: resultShareText })
         .then(() => {
           markShared();
         })

--- a/client/src/dailyFritz/buildDailyFritzSetOverlayViewModel.ts
+++ b/client/src/dailyFritz/buildDailyFritzSetOverlayViewModel.ts
@@ -259,6 +259,7 @@ export function buildDailyFritzSetOverlayViewModel(
       resultValue: setWonPlayer ? 'Victory' : 'Defeat',
       rankValue: formatOrdinalPlace(setOverlay.rank),
       shareDate: formatDateLabel(context.activeRunDate ?? context.todayRunDate ?? setOverlay.setResult.run_date ?? ''),
+      shareRunDate: context.activeRunDate ?? context.todayRunDate ?? setOverlay.setResult.run_date,
       shareTier: titleCaseTier(context.activeFritzTier ?? context.todayFritzTier ?? ''),
       shareRating: typeof profileRating === 'number' && Number.isFinite(profileRating) ? Math.round(profileRating) : undefined,
       shareStreak: context.todayStreak ?? 0,

--- a/client/src/dailyFritz/buildFinalOverlayViewModel.ts
+++ b/client/src/dailyFritz/buildFinalOverlayViewModel.ts
@@ -132,6 +132,7 @@ export function buildDailyFritzFinalOverlayViewModel({
     rankValue: ranked ? formatOrdinalPlace(rank) : null,
     rankShort: ranked ? formatOrdinal(rank) : null,
     shareDate: formatDateLabel(runDate),
+    shareRunDate: runDate,
     shareTier: titleCaseTier(fritzTier),
     shareRating,
     shareStreak,

--- a/client/src/dailyFritz/setOverlayViewModel.ts
+++ b/client/src/dailyFritz/setOverlayViewModel.ts
@@ -38,6 +38,7 @@ export interface DailyFritzSetOverlayViewModel {
   /** Bare ordinal rank for the dossier stat grid, e.g. "1st". */
   rankShort?: string | null;
   shareDate?: string;
+  shareRunDate?: string;
   shareTier?: string;
   shareRating?: number;
   shareStreak?: number;

--- a/client/src/dailyFritz/shareCard.ts
+++ b/client/src/dailyFritz/shareCard.ts
@@ -1,40 +1,47 @@
-import { buildShareGridRow, pointsShare } from '../lib/shareGrid';
 import type { DailyFritzSetGameNumber } from './api';
 
 const SET_GAME_NUMBERS: DailyFritzSetGameNumber[] = [1, 2, 3];
+const DAILY_FRITZ_LAUNCH_DATE = new Date('2026-04-10');
 
 import { SITE_DOMAIN } from '../lib/siteUrl';
 import type { DailyFritzSetOverlayViewModel } from './setOverlayViewModel';
 
-export function buildShareText(vm: DailyFritzSetOverlayViewModel): string {
-  const date = vm.shareDate ?? '';
-  const result = vm.resultValue ?? '';
-  const tier = vm.shareTier?.trim() || 'Fritz';
-  const margin = vm.marginValue ?? '';
-  const rating = vm.shareRating ? `${vm.shareRating} rating` : '';
-  const streak = vm.shareStreak ? `${vm.shareStreak}-day streak` : '';
+function calculatePuzzleNumber(runDate: string): number {
+  const date = new Date(`${runDate}T00:00:00Z`);
+  if (Number.isNaN(date.getTime())) return 1;
+  const daysSinceLaunch = Math.floor(
+    (date.getTime() - DAILY_FRITZ_LAUNCH_DATE.getTime()) / (1000 * 60 * 60 * 24)
+  );
+  return Math.max(1, daysSinceLaunch + 1);
+}
 
-  // Three rows always, so the block is the same height whether the set went two
-  // games or three — an unplayed decider reads as unplayed, not as absent.
+function buildEmojiGrid(vm: DailyFritzSetOverlayViewModel): string {
   const byNumber = new Map((vm.games ?? []).map((game) => [game.gameNumber, game] as const));
-  const gameLines = SET_GAME_NUMBERS
+  const emojis = SET_GAME_NUMBERS
     .map((gameNumber) => {
       const game = byNumber.get(gameNumber);
-      if (!game) return buildShareGridRow(null, 'none');
+      if (!game) return '⬜';
       const won = game.playerScore > game.fritzScore;
-      const tone = game.skunk && won ? 'skunk' : won ? 'win' : 'loss';
-      return buildShareGridRow(pointsShare(game.playerScore, game.fritzScore), tone);
+      return won ? '🟩' : '🟥';
     })
-    .join('\n');
+    .join('');
+  return emojis;
+}
 
-  const lines = [
-    `Daily Fritz · ${date}`,
-    `${result} vs ${tier} Fritz`,
-    gameLines,
-    `${margin} margin${rating ? ' · ' + rating : ''}`,
-    streak,
+export function buildShareText(vm: DailyFritzSetOverlayViewModel): string {
+  const runDate = vm.shareRunDate ?? '';
+  const margin = vm.marginValue ?? '';
+  const streak = vm.shareStreak ? `${vm.shareStreak} day streak` : '';
+  const puzzleNumber = calculatePuzzleNumber(runDate);
+
+  const emojiGrid = buildEmojiGrid(vm);
+  const statLine = [margin, streak].filter(Boolean).join(' · ');
+
+  return [
+    `Racehorse Daily Fritz #${puzzleNumber}`,
+    emojiGrid,
+    '',
+    statLine,
     SITE_DOMAIN,
-  ].filter(Boolean);
-
-  return lines.join('\n');
+  ].filter(Boolean).join('\n');
 }

--- a/client/src/puzzleRush/PuzzleRushLeaderboardScreen.tsx
+++ b/client/src/puzzleRush/PuzzleRushLeaderboardScreen.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useMemo, useState } from 'react';
+import { track } from '../lib/analytics';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { GlobalNav } from '../components';
 import FilterPills from '../social/hub/FilterPills';
 import { avatarHue, getInitials } from '../components/hub/playerInitialsAvatarUtils';
@@ -158,6 +159,7 @@ export function PuzzleRushLeaderboardScreen({
   const [loading, setLoading] = useState(true);
   const [filter, setFilter] = useState<Filter>('today');
   const [resetSeconds, setResetSeconds] = useState(() => secondsUntilNextPacificMidnight(new Date()));
+  const [shareDone, setShareDone] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -196,6 +198,56 @@ export function PuzzleRushLeaderboardScreen({
     [rows],
   );
 
+  const PUZZLE_RUSH_LAUNCH_DATE = new Date('2026-04-10');
+
+  const shareText = useMemo(() => {
+    if (filter !== 'today' || !data?.personalBest) return '';
+
+    const puzzleNumber = (() => {
+      const date = new Date(`${data.runDate}T00:00:00Z`);
+      if (Number.isNaN(date.getTime())) return 1;
+      const daysSinceLaunch = Math.floor(
+        (date.getTime() - PUZZLE_RUSH_LAUNCH_DATE.getTime()) / (1000 * 60 * 60 * 24)
+      );
+      return Math.max(1, daysSinceLaunch + 1);
+    })();
+
+    const emojiBoxes = Array(data.personalBest.puzzlesSolved)
+      .fill('🟩')
+      .join('');
+
+    return [
+      `Racehorse Puzzle Rush #${puzzleNumber}`,
+      emojiBoxes,
+      '',
+      `${data.personalBest.puzzlesSolved} solved`,
+      'playracehorse.com',
+    ].filter(Boolean).join('\n');
+  }, [data, filter]);
+
+  const handleShareResult = useCallback(() => {
+    if (!shareText) return;
+    track('share_initiated', { mode: 'puzzle_rush', context: 'leaderboard' });
+    const markShared = (): void => {
+      setShareDone(true);
+      window.setTimeout(() => setShareDone(false), 2000);
+    };
+    if (typeof navigator !== 'undefined' && typeof navigator.share === 'function') {
+      void navigator
+        .share({ title: 'Puzzle Rush', text: shareText })
+        .then(() => {
+          markShared();
+        })
+        .catch(() => {
+          /* user dismissed native share */
+        });
+      return;
+    }
+    void navigator.clipboard.writeText(shareText).then(() => {
+      markShared();
+    });
+  }, [shareText]);
+
   return (
     <div className="rh-hub-screen dfl-page pr-board">
       <div className="rh-hub-shell">
@@ -219,6 +271,15 @@ export function PuzzleRushLeaderboardScreen({
                     <span aria-hidden>←</span>
                     Puzzle Rush
                   </button>
+                  {filter === 'today' && data?.personalBest ? (
+                    <button
+                      type="button"
+                      className="dfl-btn dfl-btn--accent"
+                      onClick={handleShareResult}
+                    >
+                      {shareDone ? 'Copied' : 'Share Result'}
+                    </button>
+                  ) : null}
                 </div>
               </header>
 

--- a/client/src/puzzleRush/PuzzleRushScreen.tsx
+++ b/client/src/puzzleRush/PuzzleRushScreen.tsx
@@ -202,8 +202,15 @@ function PuzzleRushActiveRun({
           <div className="home-bg__texture" />
         </div>
         {run.phase === 'completing' ? (
-          <div className="pr-results pr-results--pending" data-ui="rush-completing">
-            <span className="pr-results__eyebrow">Scoring your run…</span>
+          <div className="game-over-overlay pr-result-overlay" data-ui="rush-completing">
+            <div className="prd">
+              <div className="prd__body">
+                <span className="prd__eyebrow">Run complete</span>
+                <p style={{ marginTop: '16px', fontSize: '13px', color: 'rgba(255,255,255,0.5)' }}>
+                  Scoring your run…
+                </p>
+              </div>
+            </div>
           </div>
         ) : (
           <RushResultsView

--- a/client/src/puzzleRush/RushResultsView.tsx
+++ b/client/src/puzzleRush/RushResultsView.tsx
@@ -1,10 +1,9 @@
 import { track } from '../lib/analytics';
 import { useCallback, useMemo, useState } from 'react';
-import { Button } from '../components/primitives';
-import { AnimatedScore } from '../components/AnimatedScore';
 import type { PuzzleRushCompleteResponse, PuzzleRushStage, RushPuzzleResult } from './types';
 import { stageProgress } from './rushScoring';
 import { buildRushShareText } from './rushShareCard';
+import './rushResultsDossier.css';
 
 /**
  * End-of-run results.
@@ -36,23 +35,11 @@ export function RushResultsView({
   onBack: () => void;
 }) {
   const serverScore = completion?.run.totalScore ?? completion?.authoritativeScore ?? null;
-  // Only the server can count solves: a solve is now a share of the puzzle's
-  // best_possible_score, and the client is deliberately never told that number.
-  // With no completion there is nothing honest to show, so show nothing — the
-  // client's own per-puzzle `solved` flag is the old "scored anything" rule and
-  // would read high exactly when the real figure is missing.
   const solved = completion?.run.puzzlesSolved ?? null;
   const invalidated = Boolean(completion?.invalidated) || completion?.run.status === 'invalidated';
-  // The in-run number is a raw board score and the server's is a points total,
-  // so they are not the same measure and normally differ — that is not worth
-  // alarming about. Only a client that claimed *more* than the server verified
-  // is notable.
   const overclaimed = serverScore !== null && clientTally > serverScore;
   const completedOrdinals = results.map((result) => result.ordinal);
 
-  // Deepest stage the run actually reached, read off the stage list rather
-  // than the last result's own key — a stage counts as reached once any of
-  // its ordinals is behind you.
   const deepestStage =
     [...stages].reverse().find((stage) => stageProgress(stage, completedOrdinals).done > 0) ?? null;
   const secondsBanked = results.reduce((sum, result) => sum + (result.bonusSeconds || 0), 0);
@@ -63,29 +50,23 @@ export function RushResultsView({
         stage,
         ...stageProgress(stage, completedOrdinals),
       })),
-    // completedOrdinals is rebuilt each render from `results`; key off that.
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [stages, results],
   );
 
-  // A run the server rejected, or never scored, has no score worth sharing.
   const shareable = serverScore !== null && !invalidated && !completeError;
   const shareText = useMemo(
     () =>
       shareable
         ? buildRushShareText({
             score: serverScore,
-            solved,
-            stages: stageRows.map(({ stage, done, total }) => ({
-              label: stage.label,
-              done,
-              total,
-            })),
+            solved: solved ?? 0,
+            puzzles: results.map((r) => ({ solved: r.solved })),
             secondsBanked,
-            playedAt: completion?.run.endedAt ?? completion?.run.startedAt ?? null,
+            runDate: completion?.run.runDate,
           })
         : '',
-    [shareable, serverScore, solved, stageRows, secondsBanked, completion],
+    [shareable, serverScore, solved, results, secondsBanked, completion],
   );
 
   const [shareDone, setShareDone] = useState(false);
@@ -98,7 +79,7 @@ export function RushResultsView({
     };
     if (typeof navigator !== 'undefined' && typeof navigator.share === 'function') {
       void navigator
-        .share({ title: 'Puzzle Rush', text: shareText })
+        .share({ text: shareText })
         .then(markShared)
         .catch(() => {
           /* user dismissed native share */
@@ -109,117 +90,104 @@ export function RushResultsView({
   }, [shareText]);
 
   return (
-    <div className="pr-results" data-ui="rush-results">
-      <header className="pr-results__head">
-        <div className="pr-results__head-copy">
-          <span className="pr-results__eyebrow">Run complete</span>
-          <div className="pr-results__score" data-ui="rush-final-score">
-            {serverScore == null ? (
-              <span className="pr-results__score-value">—</span>
-            ) : (
-              <AnimatedScore value={serverScore} from={0} className="pr-results__score-value" />
-            )}
-            <span className="pr-results__score-suffix">PTS</span>
-          </div>
-          <span className="pr-results__solved">
-            {solved === null
-              ? 'Solves unavailable'
-              : `${solved} puzzle${solved === 1 ? '' : 's'} solved`}
-          </span>
-        </div>
-        {shareable ? (
-          <button
-            type="button"
-            className="pr-results__share"
-            onClick={handleShare}
-            data-ui="rush-share"
-          >
-            {shareDone ? 'Copied' : 'Share result'}
-          </button>
-        ) : null}
-      </header>
+    <div className="game-over-overlay pr-result-overlay" role="dialog" aria-label="Puzzle Rush result">
+      <div className="prd" onClick={(event) => event.stopPropagation()}>
+        <div className="prd__body">
+          <header>
+            <span className="prd__eyebrow">Run complete</span>
+            <h2 className="prd__headline" tabIndex={-1} autoFocus>
+              {solved === null ? 'Run finished' : `You solved ${solved} puzzle${solved === 1 ? '' : 's'}`}
+            </h2>
+            <p className="prd__sub">
+              {deepestStage
+                ? `Reached ${deepestStage.label} stage with ${serverScore ?? 0} points.`
+                : `Final score: ${serverScore ?? 0} points.`}
+            </p>
+          </header>
 
-      {/* Three facts the run earned, all derived from what the client already
-          holds — no invented stats. */}
-      <dl className="pr-results__tiles">
-        <div className="pr-results__tile">
-          <dd className="pr-results__tile-value">{solved ?? '—'}</dd>
-          <dt className="pr-results__tile-key">Solved</dt>
-        </div>
-        <div className="pr-results__tile">
-          <dd className="pr-results__tile-value">{deepestStage?.label ?? '—'}</dd>
-          <dt className="pr-results__tile-key">Furthest stage</dt>
-        </div>
-        <div className="pr-results__tile">
-          <dd className="pr-results__tile-value">
-            {secondsBanked > 0 ? `+${secondsBanked}s` : '—'}
-          </dd>
-          <dt className="pr-results__tile-key">Time banked</dt>
-        </div>
-      </dl>
-
-      {completeError && (
-        <p className="pr-results__error" role="alert" data-ui="rush-complete-error">
-          {completeError} Your run was played — this is a problem saving it.
-        </p>
-      )}
-
-      {invalidated && (
-        <p className="pr-results__flag" role="alert" data-ui="rush-invalidated">
-          This run was flagged and does not count
-          {completion?.invalidatedReason ? ` (${completion.invalidatedReason})` : ''}.
-        </p>
-      )}
-
-      {overclaimed && !completeError && (
-        <p className="pr-results__mismatch" data-ui="rush-score-mismatch">
-          Final score is <strong>{serverScore}</strong>, verified on the server. Your
-          screen showed <strong>{clientTally}</strong>. The in-run number is the raw
-          board score; points are only computed server-side.
-        </p>
-      )}
-
-      {reportFailures > 0 && (
-        <p className="pr-results__note" data-ui="rush-report-failures">
-          {reportFailures} puzzle{reportFailures === 1 ? '' : 's'} could not be sent during the
-          run and may not be counted above.
-        </p>
-      )}
-
-      <div className="pr-results__section-label">Stages</div>
-      <ul className="pr-results__stages">
-        {stageRows.map(({ stage, done, total }) => {
-          const pct = total === 0 ? 0 : Math.round((done / total) * 100);
-          return (
-            <li key={stage.key} className="pr-results__stage-row" data-stage={stage.key}>
-              <div className="pr-results__stage-top">
-                <span className="pr-results__stage-label">{stage.label}</span>
-                <span className="pr-results__stage-count">
-                  {done}
-                  <span className="pr-results__stage-total">/{total}</span>
+          <ul className="prd__stages" aria-label="Stages in this run">
+            {stageRows.map(({ stage, done, total }) => (
+              <li key={stage.key} className="prd__stage">
+                <span className="prd__stage-name">{stage.label}</span>
+                <span className="prd__track">
+                  {done > 0 ? (
+                    <span
+                      className="prd__fill"
+                      style={{ width: `${Math.round((done / total) * 100)}%` }}
+                    />
+                  ) : null}
                 </span>
-              </div>
-              {/* Same weighted-fill language as the in-run HUD meter, so the
-                  summary reads as the run you just watched. */}
-              <div className="pr-results__stage-meter" role="presentation">
-                <span className="pr-results__stage-fill" style={{ width: `${pct}%` }} />
-              </div>
-            </li>
-          );
-        })}
-      </ul>
+                <span className="prd__stage-count">
+                  {done}/{total}
+                </span>
+              </li>
+            ))}
+          </ul>
 
-      <footer className="pr-results__actions">
-        {/* Two ways out, not three. "Home" duplicated "Back to hub" — the hub
-            it lands on carries its own "Back to home" — so the run-complete
-            screen offers the two moves that belong to a finished run. */}
-        <Button variant="tier-standard" size="lg" onClick={onPlayAgain}>
-          Play again
-        </Button>
-        <Button variant="outline" size="lg" onClick={onBack}>
-          Back to hub
-        </Button>
-      </footer>
+          <dl className="prd__stats">
+            <div className="prd__stat">
+              <dt>Score</dt>
+              <dd>{serverScore ?? '—'}</dd>
+            </div>
+            <div className="prd__stat">
+              <dt>Solved</dt>
+              <dd>{solved ?? '—'}</dd>
+            </div>
+            <div className="prd__stat">
+              <dt>Furthest</dt>
+              <dd>{deepestStage?.label ?? '—'}</dd>
+            </div>
+            <div className="prd__stat">
+              <dt>Time banked</dt>
+              <dd>{secondsBanked > 0 ? `+${secondsBanked}s` : '—'}</dd>
+            </div>
+          </dl>
+
+          {completeError && (
+            <p className="prd__note" role="alert" data-ui="rush-complete-error">
+              {completeError} Your run was played — this is a problem saving it.
+            </p>
+          )}
+
+          {invalidated && (
+            <p className="prd__note" role="alert" data-ui="rush-invalidated">
+              This run was flagged and does not count
+              {completion?.invalidatedReason ? ` (${completion.invalidatedReason})` : ''}.
+            </p>
+          )}
+
+          {overclaimed && !completeError && (
+            <p className="prd__note" data-ui="rush-score-mismatch">
+              Final score is <strong>{serverScore}</strong>, verified on the server. Your screen showed
+              <strong>{clientTally}</strong>. The in-run number is the raw board score; points are only
+              computed server-side.
+            </p>
+          )}
+
+          {reportFailures > 0 && (
+            <p className="prd__note" data-ui="rush-report-failures">
+              {reportFailures} puzzle{reportFailures === 1 ? '' : 's'} could not be sent during the run and may
+              not be counted above.
+            </p>
+          )}
+
+          <div className="prd__actions">
+            {shareable && (
+              <button type="button" className="prd__btn prd__btn--primary" onClick={handleShare}>
+                {shareDone ? 'Copied' : 'Share Result'}
+              </button>
+            )}
+            <div className="prd__row">
+              <button type="button" className="prd__btn" onClick={onPlayAgain}>
+                Play again
+              </button>
+              <button type="button" className="prd__btn" onClick={onBack}>
+                Back to hub
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
   );
 }

--- a/client/src/puzzleRush/rushResultsDossier.css
+++ b/client/src/puzzleRush/rushResultsDossier.css
@@ -1,0 +1,224 @@
+/*
+ * Puzzle Rush result — dossier treatment matching Daily Fritz.
+ *
+ * Same card language: header strip with eyebrow/headline/subheadline,
+ * then stage progress rows (thin bars), then stat grid (2x2), then actions.
+ */
+
+.prd {
+  --prd-line: rgba(255, 255, 255, 0.07);
+  --prd-line-strong: rgba(255, 255, 255, 0.14);
+  --prd-ink: var(--df-paper);
+  --prd-muted: rgba(255, 255, 255, 0.5);
+  --prd-dim: rgba(255, 255, 255, 0.36);
+  --prd-accent: var(--tier-elite);
+  --prd-fill: var(--tier-standard);
+
+  width: min(100%, 420px);
+  border: 1px solid rgba(231, 182, 74, 0.22);
+  border-radius: var(--radius-record);
+  overflow: hidden;
+  background-color: var(--df-card);
+  /* Faint plan grid, reads as a record not a panel. */
+  background-image:
+    linear-gradient(rgba(255, 255, 255, 0.022) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255, 255, 255, 0.022) 1px, transparent 1px);
+  background-size: 28px 28px;
+  box-shadow: 0 40px 90px -24px rgba(0, 0, 0, 0.95);
+  color: var(--prd-ink);
+  font-family: var(--font-body);
+}
+
+.prd__body {
+  padding: 22px 20px 20px;
+}
+
+/* ── headline ── */
+
+.prd__eyebrow {
+  display: block;
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--prd-dim);
+}
+
+.prd__headline {
+  margin: 8px 0 0;
+  font-family: var(--font-display);
+  font-size: 34px;
+  font-weight: 800;
+  line-height: 1;
+  letter-spacing: -0.01em;
+  color: var(--prd-ink);
+  text-wrap: balance;
+}
+
+.prd__headline::after {
+  content: ".";
+  color: var(--prd-accent);
+}
+
+.prd__sub {
+  margin: 10px 0 0;
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--prd-muted);
+}
+
+/* ── stage rows ── */
+
+.prd__stages {
+  display: flex;
+  flex-direction: column;
+  margin-top: 18px;
+  list-style: none;
+  padding: 0;
+}
+
+.prd__stage {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 11px 0;
+  border-top: 1px solid var(--prd-line);
+}
+
+.prd__stage:last-child {
+  border-bottom: 1px solid var(--prd-line);
+}
+
+.prd__stage-name {
+  font-size: 11.5px;
+  letter-spacing: 0.06em;
+  color: var(--prd-muted);
+  min-width: 65px;
+  font-variant-numeric: tabular-nums;
+}
+
+.prd__track {
+  position: relative;
+  flex: 1;
+  height: 2px;
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.prd__fill {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  background: var(--prd-fill);
+}
+
+.prd__stage-count {
+  min-width: 38px;
+  text-align: right;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--prd-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+/* ── stat grid ── */
+
+.prd__stats {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  margin: 18px 0 0;
+  border: 1px solid var(--prd-line);
+}
+
+.prd__stat {
+  padding: 11px 14px 13px;
+  border-top: 1px solid var(--prd-line);
+  border-left: 1px solid var(--prd-line);
+  min-width: 0;
+}
+
+.prd__stat:nth-child(-n + 2) {
+  border-top: 0;
+}
+
+.prd__stat:nth-child(odd) {
+  border-left: 0;
+}
+
+.prd__stat dt {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--prd-dim);
+}
+
+.prd__stat dd {
+  margin: 5px 0 0;
+  font-family: var(--font-display);
+  font-size: 22px;
+  font-weight: 700;
+  line-height: 1;
+  color: var(--prd-ink);
+  font-variant-numeric: tabular-nums;
+}
+
+/* ── messages ── */
+
+.prd__note {
+  margin: 14px 0 0;
+  font-size: 12px;
+  line-height: 1.55;
+  color: var(--prd-dim);
+}
+
+/* ── actions ── */
+
+.prd__actions {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-top: 18px;
+}
+
+.prd__btn {
+  padding: 12px 16px;
+  border-radius: var(--radius-control);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  background: transparent;
+  color: rgba(255, 255, 255, 0.95);
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  transition: transform 120ms cubic-bezier(0.2, 0, 0, 1), box-shadow 120ms cubic-bezier(0.2, 0, 0, 1);
+}
+
+.prd__btn:hover {
+  transform: translateY(-1px);
+}
+
+.prd__btn:active {
+  transform: scale(0.97);
+}
+
+.prd__btn--primary {
+  background: var(--prd-accent);
+  border-color: var(--prd-accent);
+  color: var(--bg-obsidian);
+  font-weight: 700;
+}
+
+.prd__btn--primary:hover {
+  box-shadow: 0 0 20px 0 rgba(231, 182, 74, 0.4);
+}
+
+.prd__row {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.prd__row .prd__btn {
+  margin: 0;
+}

--- a/client/src/puzzleRush/rushShareCard.test.ts
+++ b/client/src/puzzleRush/rushShareCard.test.ts
@@ -1,65 +1,98 @@
 import { describe, it, expect } from 'vitest';
 import { buildRushShareText } from './rushShareCard';
 import { SITE_DOMAIN } from '../lib/siteUrl';
-import { buildShareGridRow } from '../lib/shareGrid';
-
-const STAGES = [
-  { label: 'Warm-Up', done: 2, total: 3 },
-  { label: 'Building', done: 0, total: 5 },
-  { label: 'Master', done: 0, total: 7 },
-];
 
 describe('buildRushShareText', () => {
-  it('leads with the score and solved count, then every stage', () => {
+  it('shows puzzle number, one emoji per puzzle, solve count, and time', () => {
     const text = buildRushShareText({
       score: 250,
       solved: 2,
-      stages: STAGES,
+      puzzles: [
+        { solved: true },
+        { solved: false },
+        { solved: true },
+      ],
       secondsBanked: 2,
-      playedAt: '2026-08-27T22:12:00.000Z',
+      runDate: '2026-08-31',
     });
-    expect(text).toContain('250 pts · 2 solved');
-    // Warm-Up is 2 of 3, so a partly-filled row; the two untouched stages read
-    // as unplayed rather than as failures.
-    expect(text).toContain(buildShareGridRow(2 / 3, 'win'));
-    expect(text.split('\n').filter((line) => line.startsWith('⬜'))).toHaveLength(2);
-    expect(text).toContain('+2s banked');
-    expect(text.endsWith(SITE_DOMAIN)).toBe(true);
+    expect(text).toContain('Racehorse Puzzle Rush #144');
+    expect(text).toContain('🟩🟥🟩');
+    expect(text).toContain('2 solved');
+    expect(text).toContain('2s');
+    expect(text).toContain(SITE_DOMAIN);
   });
 
-  it('marks a fully cleared stage as exceptional', () => {
+  it('formats minutes and seconds correctly', () => {
     const text = buildRushShareText({
-      score: 900, solved: 15, secondsBanked: 0,
-      stages: [{ label: 'Warm-Up', done: 3, total: 3 }],
+      score: 900,
+      solved: 7,
+      puzzles: [
+        { solved: true },
+        { solved: true },
+        { solved: true },
+        { solved: true },
+        { solved: true },
+        { solved: true },
+        { solved: true },
+      ],
+      secondsBanked: 125, // 2m 5s
+      runDate: '2026-08-31',
     });
-    expect(text).toContain(buildShareGridRow(1, 'skunk'));
+    expect(text).toContain('2m 5s');
   });
 
-  it('omits the solve count when the server did not report one', () => {
-    const text = buildRushShareText({ score: 250, solved: null, stages: STAGES, secondsBanked: 0 });
-    expect(text).toContain('250 pts');
-    expect(text).not.toContain('solved');
-  });
-
-  it('drops the banked line when nothing was banked', () => {
-    const text = buildRushShareText({ score: 250, solved: 2, stages: STAGES, secondsBanked: 0 });
-    expect(text).not.toContain('banked');
-  });
-
-  it('falls back to a bare title when the run has no usable timestamp', () => {
-    for (const playedAt of [null, undefined, 'not-a-date']) {
-      const text = buildRushShareText({ score: 10, solved: 1, stages: [], secondsBanked: 0, playedAt });
-      expect(text.split('\n')[0]).toBe('Puzzle Rush');
-    }
-  });
-
-  it('omits stages that served no puzzles in this run', () => {
+  it('omits time when no bonuses earned', () => {
     const text = buildRushShareText({
       score: 250,
       solved: 2,
-      stages: [...STAGES, { label: 'Unused', done: 0, total: 0 }],
+      puzzles: [
+        { solved: true },
+        { solved: false },
+      ],
+      secondsBanked: 0,
+      runDate: '2026-08-31',
+    });
+    // Should only show solve count, no time bonuses
+    const lines = text.split('\n');
+    expect(lines[2]).toBe('2 solved');
+    expect(text).not.toMatch(/\d+[ms]\s/); // No "5s " or "2m " pattern
+  });
+
+  it('calculates puzzle number from run_date', () => {
+    const text = buildRushShareText({
+      score: 10,
+      solved: 1,
+      puzzles: [{ solved: true }],
+      secondsBanked: 0,
+      runDate: '2026-04-10',
+    });
+    expect(text).toContain('#1');
+  });
+
+  it('defaults to puzzle #1 when run_date is missing', () => {
+    const text = buildRushShareText({
+      score: 10,
+      solved: 1,
+      puzzles: [{ solved: true }],
       secondsBanked: 0,
     });
-    expect(text).not.toContain('Unused');
+    expect(text).toContain('#1');
+  });
+
+  it('handles max-length run (15 puzzles) without truncation', () => {
+    const puzzles = Array(15).fill(null).map((_, i) => ({ solved: i < 13 }));
+    const text = buildRushShareText({
+      score: 1200,
+      solved: 13,
+      puzzles,
+      secondsBanked: 45,
+      runDate: '2026-08-31',
+    });
+    const emojiLine = text.split('\n')[1];
+    const greenCount = (emojiLine.match(/🟩/g) ?? []).length;
+    const redCount = (emojiLine.match(/🟥/g) ?? []).length;
+    expect(greenCount).toBe(13);
+    expect(redCount).toBe(2);
+    expect(text).toContain('13 solved');
   });
 });

--- a/client/src/puzzleRush/rushShareCard.ts
+++ b/client/src/puzzleRush/rushShareCard.ts
@@ -1,61 +1,66 @@
-import { buildShareGridRow } from '../lib/shareGrid';
 import { SITE_DOMAIN } from '../lib/siteUrl';
+
+const PUZZLE_RUSH_LAUNCH_DATE = new Date('2026-04-10');
+
 /**
  * Share text for a finished Puzzle Rush run.
  *
- * Mirrors Daily Fritz's share card (see dailyFritz/shareCard.ts): the headline
- * facts, then the per-stage breakdown, then the site. Only what the run
- * actually earned goes in — a line is dropped rather than padded with a dash.
+ * Puzzle number, one emoji per puzzle attempted (🟩 = solved, 🟥 = missed/skipped),
+ * solve count, and site URL.
  */
 
-export interface RushShareStage {
-  label: string;
-  done: number;
-  total: number;
+export interface RushSharePuzzle {
+  /** Whether this puzzle was solved (true) or missed/skipped (false). */
+  solved: boolean;
 }
 
 export interface RushShareInput {
   /** The server's replayed total. The only score worth sharing. */
   score: number;
-  /** Null when the server did not report a solve count for the run. */
-  solved: number | null;
-  stages: RushShareStage[];
+  /** Server's actual solve count for the run. */
+  solved: number;
+  /** Per-puzzle result (ordinal order). */
+  puzzles: RushSharePuzzle[];
+  /** Seconds gained from time bonuses. */
   secondsBanked: number;
-  /** ISO timestamp the run ended, for the date line. */
-  playedAt?: string | null;
+  /** YYYY-MM-DD run date for puzzle numbering. */
+  runDate?: string;
 }
 
-function formatShareDate(iso: string | null | undefined): string | null {
-  if (!iso) return null;
-  const parsed = new Date(iso);
-  if (Number.isNaN(parsed.getTime())) return null;
-  return parsed.toLocaleDateString(undefined, {
-    month: 'short',
-    day: 'numeric',
-    year: 'numeric',
-  });
+function calculatePuzzleNumber(runDate: string | undefined): number {
+  if (!runDate) return 1;
+  const date = new Date(`${runDate}T00:00:00Z`);
+  if (Number.isNaN(date.getTime())) return 1;
+  const daysSinceLaunch = Math.floor(
+    (date.getTime() - PUZZLE_RUSH_LAUNCH_DATE.getTime()) / (1000 * 60 * 60 * 24)
+  );
+  return Math.max(1, daysSinceLaunch + 1);
+}
+
+function buildEmojiRow(puzzles: RushSharePuzzle[]): string {
+  return puzzles.map((p) => (p.solved ? '🟩' : '🟥')).join('');
+}
+
+function formatTime(secondsBanked: number): string {
+  if (secondsBanked <= 0) return '';
+  const minutes = Math.floor(secondsBanked / 60);
+  const seconds = secondsBanked % 60;
+  if (minutes > 0) return `${minutes}m ${seconds}s`;
+  return `${seconds}s`;
 }
 
 export function buildRushShareText(input: RushShareInput): string {
-  const date = formatShareDate(input.playedAt);
-  const stageLines = input.stages
-    .filter((stage) => stage.total > 0)
-    .map((stage) =>
-      stage.done === 0
-        ? buildShareGridRow(null, 'none')
-        : buildShareGridRow(stage.done / stage.total, stage.done === stage.total ? 'skunk' : 'win'),
-    )
-    .join('\n');
+  const puzzleNumber = calculatePuzzleNumber(input.runDate);
+  const emojiRow = buildEmojiRow(input.puzzles);
+  const solveText = `${input.solved} solved`;
+  const timeText = formatTime(input.secondsBanked);
+  const statLine = [solveText, timeText].filter(Boolean).join(' · ');
 
-  const lines = [
-    date ? `Puzzle Rush · ${date}` : 'Puzzle Rush',
-    input.solved === null
-      ? `${input.score} pts`
-      : `${input.score} pts · ${input.solved} solved`,
-    stageLines,
-    input.secondsBanked > 0 ? `+${input.secondsBanked}s banked` : '',
+  return [
+    `Racehorse Puzzle Rush #${puzzleNumber}`,
+    emojiRow,
+    '',
+    statLine,
     SITE_DOMAIN,
-  ].filter(Boolean);
-
-  return lines.join('\n');
+  ].filter(Boolean).join('\n');
 }

--- a/client/src/puzzleRush/types.ts
+++ b/client/src/puzzleRush/types.ts
@@ -56,6 +56,7 @@ export interface PuzzleRushRun {
   clientReportedScore: number;
   invalidatedReason: string | null;
   configVersion: number;
+  runDate?: string;
 }
 
 export interface PuzzleRushClockConfig {

--- a/client/src/social/ActivityFeedScreen.tsx
+++ b/client/src/social/ActivityFeedScreen.tsx
@@ -26,6 +26,7 @@ import ActivityFeedPanel, {
 import { fetchGlobalLeaderboard } from './socialApi';
 import './hub/hubShared.css';
 import './activityFeedScreen.css';
+import './socialBoard.css';
 
 interface ActivityFeedScreenProps {
   user: User | null;
@@ -383,8 +384,9 @@ export default function ActivityFeedScreen({
         <div className="rh-hub-grid rh-sf-layout-grid social-layout-grid">
           <main className="rh-hub-main rh-sf-main-column social-main-column">
             <SocialPageHero
+              eyebrow="Community"
               title="Social"
-              subtitle="Follow rivals, track wins, and see what’s happening across Racehorse."
+              subtitle="Every result your circle posts, in the order it happened."
               meta={user ? (
                 <>
                   {socialHeroStats.map((stat) => (

--- a/client/src/social/SocialPageHero.tsx
+++ b/client/src/social/SocialPageHero.tsx
@@ -4,6 +4,10 @@ import './socialPageHero.css';
 interface SocialPageHeroProps {
   title: string;
   subtitle: string;
+  /** Small-caps kicker above the headline, as on the Daily Fritz leaderboard. */
+  eyebrow?: string;
+  /** Actions rendered opposite the headline (back link, primary CTA). */
+  actions?: ReactNode;
   meta?: ReactNode;
   filters?: ReactNode;
 }
@@ -11,17 +15,28 @@ interface SocialPageHeroProps {
 export default function SocialPageHero({
   title,
   subtitle,
+  eyebrow,
+  actions,
   meta,
   filters,
 }: SocialPageHeroProps) {
   return (
-    <header className="social-hero">
-      <div className="social-hero__head">
-        <h1 className="social-hero__title">{title}</h1>
-        <p className="social-hero__subtitle">{subtitle}</p>
-      </div>
+    <>
+      <header className="social-hero">
+        <div className="social-hero__head">
+          {eyebrow ? <span className="social-hero__eyebrow">{eyebrow}</span> : null}
+          <h1 className="social-hero__title">
+            {title}
+            <span className="social-hero__title-dot" aria-hidden="true">.</span>
+          </h1>
+          <p className="social-hero__subtitle">{subtitle}</p>
+        </div>
+        {actions ? <div className="social-hero__actions">{actions}</div> : null}
+      </header>
+      {/* The stat strip is fused to the masthead's bottom edge, so it sits
+          outside <header> rather than inside it. */}
       {meta ? <div className="social-hero__meta">{meta}</div> : null}
       {filters ? <div className="social-hero__filters">{filters}</div> : null}
-    </header>
+    </>
   );
 }

--- a/client/src/social/socialBoard.css
+++ b/client/src/social/socialBoard.css
@@ -1,0 +1,724 @@
+/*
+ * Social — board treatment.
+ *
+ * Carries the Daily Fritz leaderboard's visual system onto the Social page:
+ * square records instead of rounded cards, a display masthead fused to a
+ * connected stat strip, hairline table rows instead of floating tiles, and
+ * gold reserved for signal (your own row, rank 1, a skunk, the primary CTA)
+ * rather than sprinkled on every badge.
+ *
+ * Values mirror dailyFritzLeaderboardBoard.css so the two screens read as one
+ * system. Loaded last by ActivityFeedScreen so it wins over the card-era rules
+ * in activityFeedScreen.css / activityFeed.css / socialPageHero.css at equal
+ * specificity; everything here is scoped under .rh-sf-page so it cannot leak.
+ *
+ * Content model is unchanged — same feed, same filters, same rail panels.
+ */
+
+.rh-sf-page {
+  --sb-line: var(--border-subtle);
+  --sb-line-soft: rgba(255, 255, 255, 0.05);
+  --sb-line-strong: var(--border-light);
+  --sb-ink: var(--text-primary);
+  --sb-subtle: rgba(255, 255, 255, 0.72);
+  --sb-muted: var(--text-secondary);
+  --sb-label: rgba(255, 255, 255, 0.42);
+  --sb-dim: var(--text-dim);
+  --sb-grid: rgba(255, 255, 255, 0.03);
+  --sb-surface: rgba(255, 255, 255, 0.015);
+  --sb-glass: var(--glass-bg);
+
+  --sb-accent: var(--tier-elite);
+  --sb-accent-border: rgba(var(--tier-elite-rgb), 0.42);
+  --sb-accent-dim: rgba(var(--tier-elite-rgb), 0.14);
+  --sb-accent-row: rgba(var(--tier-elite-rgb), 0.045);
+  --sb-accent-row-hover: rgba(var(--tier-elite-rgb), 0.065);
+  --sb-accent-head: rgba(var(--tier-elite-rgb), 0.09);
+  --sb-accent-head-border: rgba(var(--tier-elite-rgb), 0.22);
+  --sb-accent-ink: var(--text-on-elite);
+
+  --sb-win: var(--accent-green);
+  --sb-loss: var(--accent-red);
+}
+
+/* ------------------------------------------------------------- masthead */
+
+.rh-sf-page .social-hero {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--hub-space-3, 24px);
+  padding: 26px 26px 22px;
+  border: 1px solid var(--sb-line);
+  border-radius: var(--radius-record) var(--radius-record) 0 0;
+  background-color: rgba(255, 255, 255, 0.012);
+  background-image:
+    linear-gradient(var(--sb-grid) 1px, transparent 1px),
+    linear-gradient(90deg, var(--sb-grid) 1px, transparent 1px);
+  background-size: 44px 44px, 44px 44px;
+  box-shadow: none;
+}
+
+.rh-sf-page .social-hero__head {
+  display: block;
+  min-width: 0;
+}
+
+.rh-sf-page .social-hero__eyebrow {
+  display: block;
+  margin: 0 0 6px;
+  font-family: var(--font-display);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--sb-label);
+}
+
+.rh-sf-page .social-hero__title {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: clamp(40px, 5vw, 62px);
+  font-weight: 800;
+  line-height: 0.92;
+  letter-spacing: -0.01em;
+  color: var(--sb-ink);
+  text-transform: none;
+}
+
+.rh-sf-page .social-hero__title-dot {
+  color: var(--sb-accent);
+}
+
+.rh-sf-page .social-hero__subtitle {
+  margin: 10px 0 0;
+  max-width: 52ch;
+  font-size: 13px;
+  color: var(--sb-muted);
+}
+
+/* ----------------------------------------------------------- stat strip */
+
+/*
+ * The four stat tiles become one connected bar fused to the masthead's bottom
+ * edge — the leaderboard's DATE / RACERS / SKUNKS / RESETS IN treatment. The
+ * hero's own gap is removed so the two boxes read as a single unit.
+ */
+.rh-sf-page .social-hero {
+  margin-bottom: 0;
+}
+
+.rh-sf-page .social-hero__meta {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0;
+  margin: 0 0 14px;
+  padding: 0;
+  border: 1px solid var(--sb-line);
+  border-top: 0;
+  border-radius: 0 0 var(--radius-record) var(--radius-record);
+  background: var(--sb-surface);
+}
+
+.rh-sf-page .social-hero__stat {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  min-width: 0;
+  height: 34px;
+  padding: 0 18px;
+  border: 0;
+  border-left: 1px solid var(--sb-line-soft);
+  border-radius: 0;
+  background: none;
+  box-shadow: none;
+}
+
+.rh-sf-page .social-hero__stat:first-child {
+  border-left: 0;
+}
+
+.rh-sf-page .social-hero__stat-label {
+  flex-shrink: 0;
+  font-family: var(--font-display);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--sb-label);
+}
+
+.rh-sf-page .social-hero__stat-value {
+  font-family: var(--font-display);
+  font-size: 14px;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+  color: var(--sb-ink);
+  font-variant-numeric: tabular-nums;
+}
+
+.rh-sf-page .social-hero__stat--accent .social-hero__stat-value {
+  color: var(--sb-accent);
+}
+
+/* The note becomes a dim qualifier beside the value, not a third line. */
+.rh-sf-page .social-hero__stat-note {
+  min-width: 0;
+  overflow: hidden;
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--sb-dim);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.rh-sf-page .social-hero__actions {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+  gap: 10px;
+}
+
+/* -------------------------------------------------------------- filters */
+
+.rh-sf-page .social-hero__filters {
+  margin: 0 0 14px;
+  padding: 0;
+  border: 0;
+}
+
+.rh-sf-page .rh-af-filters {
+  gap: 6px;
+  padding: 0;
+  border: 0;
+  background: none;
+}
+
+.rh-sf-page .rh-af-filter {
+  height: 30px;
+  padding: 0 14px;
+  border: 1px solid var(--sb-line);
+  border-radius: var(--radius-record);
+  background: var(--sb-glass);
+  color: var(--sb-muted);
+  font-family: var(--font-body);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  box-shadow: none;
+}
+
+.rh-sf-page .rh-af-filter:hover {
+  border-color: var(--sb-accent-border);
+  background: var(--sb-glass);
+  color: var(--sb-subtle);
+}
+
+.rh-sf-page .rh-af-filter--active {
+  border-color: var(--sb-accent-border);
+  background: var(--sb-accent-dim);
+  color: var(--sb-accent);
+  box-shadow: none;
+}
+
+/* The tab icons were carrying most of the pill-era colour. */
+.rh-sf-page .rh-af-filter-icon {
+  color: currentColor;
+  opacity: 0.8;
+}
+
+/* --------------------------------------------------------------- layout */
+
+.rh-sf-page .rh-hub-grid {
+  grid-template-columns: minmax(0, 1fr) 288px;
+  gap: 16px;
+}
+
+/* ----------------------------------------------------------- feed table */
+
+.rh-sf-page .rh-af-panel,
+.rh-sf-page .social-feed-panel {
+  padding: 0;
+  border: 0;
+  background: none;
+}
+
+.rh-sf-page .rh-af-feed-card {
+  border: 1px solid var(--sb-line);
+  border-radius: var(--radius-record);
+  background: var(--sb-surface);
+  box-shadow: none;
+  overflow: hidden;
+}
+
+.rh-sf-page .rh-af-feed {
+  padding: 0;
+  gap: 0;
+}
+
+/*
+ * Rows, not cards. The existing five-child grid (avatar / icon / main /
+ * stats / time) already matches the board's column rhythm, so this only has
+ * to strip the card chrome and swap the separator to a hairline.
+ */
+.rh-sf-page .rh-af-rich-row {
+  grid-template-columns: 28px 18px minmax(0, 1fr) auto 68px;
+  gap: 11px;
+  min-height: 60px;
+  margin: 0;
+  padding: 11px 20px;
+  border: 0;
+  border-bottom: 1px solid var(--sb-line-soft);
+  border-radius: 0;
+  background: none;
+  transition: background 140ms cubic-bezier(0.2, 0, 0, 1);
+}
+
+.rh-sf-page .rh-af-rich-row:last-child {
+  border-bottom: 0;
+}
+
+.rh-sf-page .rh-af-rich-row:hover {
+  border-color: var(--sb-line-soft);
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.rh-sf-page .rh-af-rich-avatar {
+  width: 28px;
+  height: 28px;
+  border-radius: var(--radius-record);
+  font-family: var(--font-display);
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.rh-sf-page .rh-af-rich-line {
+  margin: 0;
+  font-size: 13px;
+  color: var(--sb-subtle);
+}
+
+.rh-sf-page .rh-af-rich-user {
+  padding: 0;
+  border: 0;
+  background: none;
+  color: var(--sb-ink);
+  font-family: var(--font-body);
+  font-size: 13px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.rh-sf-page .rh-af-rich-user:hover {
+  color: var(--sb-accent);
+}
+
+.rh-sf-page .rh-af-rich-action {
+  color: var(--sb-subtle);
+}
+
+.rh-sf-page .rh-af-rich-meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 2px;
+}
+
+.rh-sf-page .rh-af-rich-secondary {
+  margin: 0;
+  font-size: 11.5px;
+  color: var(--sb-muted);
+}
+
+.rh-sf-page .rh-af-rich-stats {
+  gap: 10px;
+}
+
+.rh-sf-page .rh-af-rich-score {
+  font-family: var(--font-display);
+  font-size: 22px;
+  font-weight: 700;
+  line-height: 1.05;
+  color: var(--sb-ink);
+  font-variant-numeric: tabular-nums;
+}
+
+.rh-sf-page .rh-af-rich-points,
+.rh-sf-page .rh-af-rich-delta {
+  font-size: 11.5px;
+  font-weight: 600;
+  color: var(--sb-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.rh-sf-page .rh-af-rich-end {
+  justify-content: flex-end;
+  gap: 6px;
+}
+
+.rh-sf-page .rh-af-rich-end time {
+  font-size: 12px;
+  color: var(--sb-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.rh-sf-page .rh-af-rich-chevron {
+  color: var(--sb-dim);
+}
+
+/* ---------------------------------------------------------------- badges */
+
+/*
+ * Gold is a signal, not decoration. A mode badge says which mode a result came
+ * from — routine information — so it drops to a neutral hairline tag whatever
+ * tone the row model assigned it. Only the outcome badge in the stats column
+ * keeps its colour, and only a skunk gets gold.
+ */
+.rh-sf-page .rh-af-rich-badge {
+  height: 20px;
+  padding: 0 7px;
+  border-radius: 2px;
+  font-family: var(--font-display);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  box-shadow: none;
+}
+
+.rh-sf-page .rh-af-rich-meta .rh-af-rich-badge {
+  border: 1px solid var(--sb-line);
+  background: none;
+  color: var(--sb-muted);
+}
+
+.rh-sf-page .rh-af-rich-stats .rh-af-rich-badge--gold {
+  border: 1px solid var(--sb-accent-border);
+  background: var(--sb-accent-dim);
+  color: var(--sb-accent);
+}
+
+.rh-sf-page .rh-af-rich-stats .rh-af-rich-badge--teal,
+.rh-sf-page .rh-af-rich-stats .rh-af-rich-badge--green {
+  border: 1px solid rgba(52, 211, 153, 0.4);
+  background: none;
+  color: var(--sb-win);
+}
+
+.rh-sf-page .rh-af-rich-stats .rh-af-rich-badge--red {
+  border: 1px solid rgba(242, 71, 71, 0.36);
+  background: none;
+  color: var(--sb-loss);
+}
+
+.rh-sf-page .rh-af-rich-stats .rh-af-rich-badge--gray,
+.rh-sf-page .rh-af-rich-stats .rh-af-rich-badge--purple {
+  border: 1px solid var(--sb-line);
+  background: none;
+  color: var(--sb-muted);
+}
+
+/* ------------------------------------------------------- feed states */
+
+.rh-sf-page .rh-af-status,
+.rh-sf-page .rh-af-empty,
+.rh-sf-page .rh-sf-signin {
+  margin: 0;
+  padding: 30px 22px;
+  border: 0;
+  border-radius: 0;
+  background: none;
+  color: var(--sb-muted);
+}
+
+.rh-sf-page .rh-sf-signin {
+  border: 1px solid var(--sb-line);
+  border-radius: var(--radius-record);
+  background: var(--sb-surface);
+}
+
+.rh-sf-page .rh-af-status-kicker {
+  font-family: var(--font-display);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--sb-label);
+}
+
+.rh-sf-page .rh-af-load-more-wrap {
+  padding: 12px;
+  border-top: 1px solid var(--sb-line);
+}
+
+.rh-sf-page .rh-af-load-more,
+.rh-sf-page .rh-sf-widget-link,
+.rh-sf-page .rh-af-status-btn {
+  height: 34px;
+  padding: 0 14px;
+  border: 1px solid var(--sb-line);
+  border-radius: var(--radius-record);
+  background: var(--sb-glass);
+  color: var(--sb-muted);
+  font-family: var(--font-body);
+  font-size: 12px;
+  font-weight: 600;
+  box-shadow: none;
+}
+
+.rh-sf-page .rh-af-load-more:hover,
+.rh-sf-page .rh-sf-widget-link:hover,
+.rh-sf-page .rh-af-status-btn:hover {
+  border-color: var(--sb-line-strong);
+  background: var(--sb-glass);
+  color: var(--sb-ink);
+}
+
+/* ------------------------------------------------------------------ rail */
+
+.rh-sf-page .rh-sf-right-rail {
+  gap: 16px;
+}
+
+.rh-sf-page .rh-sf-widget,
+.rh-sf-page .rh-hub-rail-card,
+.rh-sf-page .rh-social-card {
+  padding: 0;
+  border: 1px solid var(--sb-line);
+  border-radius: var(--radius-record);
+  background: var(--sb-surface);
+  box-shadow: none;
+}
+
+.rh-sf-page .rh-sf-widget-head {
+  align-items: center;
+  margin: 0;
+  padding: 9px 14px;
+  border-bottom: 1px solid var(--sb-line);
+}
+
+.rh-sf-page .rh-sf-widget-title,
+.rh-sf-page .rh-hub-rail-title {
+  margin: 0;
+  padding: 9px 14px;
+  font-family: var(--font-display);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--sb-label);
+}
+
+/* A title inside a head row must not double the head's own padding. */
+.rh-sf-page .rh-sf-widget-head .rh-sf-widget-title {
+  padding: 0;
+}
+
+.rh-sf-page .rh-sf-widget-online {
+  font-family: var(--font-display);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--sb-dim);
+}
+
+.rh-sf-page .rh-sf-online-strip,
+.rh-sf-page .rh-sf-widget-list,
+.rh-sf-page .rh-sf-ranked-list,
+.rh-sf-page .rh-sf-rivals-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  padding: 0;
+}
+
+.rh-sf-page .rh-sf-online-chip,
+.rh-sf-page .rh-sf-ranked-row,
+.rh-sf-page .rh-sf-rival-card,
+.rh-sf-page .rh-sf-tournament {
+  margin: 0;
+  padding: 9px 14px;
+  border: 0;
+  border-bottom: 1px solid var(--sb-line-soft);
+  border-radius: 0;
+  background: none;
+  box-shadow: none;
+}
+
+.rh-sf-page .rh-sf-online-chip:last-child,
+.rh-sf-page .rh-sf-ranked-row:last-child,
+.rh-sf-page .rh-sf-rival-card:last-child,
+.rh-sf-page .rh-sf-tournament:last-child {
+  border-bottom: 0;
+}
+
+.rh-sf-page .rh-sf-avatar,
+.rh-sf-page .rh-social-avatar {
+  border-radius: var(--radius-record);
+  font-family: var(--font-display);
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+/* Rank 1 is the only gold row in the rail. */
+.rh-sf-page .rh-sf-ranked-num {
+  font-family: var(--font-display);
+  font-size: 15px;
+  font-weight: 700;
+  color: var(--sb-dim);
+  font-variant-numeric: tabular-nums;
+}
+
+.rh-sf-page .rh-sf-ranked-num.rank-1 {
+  color: var(--sb-accent);
+}
+
+.rh-sf-page .rh-sf-ranked-row:has(.rank-1) {
+  background: var(--sb-accent-row);
+}
+
+.rh-sf-page .rh-sf-ranked-crown {
+  color: var(--sb-dim);
+}
+
+.rh-sf-page .rh-sf-ranked-crown.rank-1 {
+  color: var(--sb-accent);
+}
+
+.rh-sf-page .rh-sf-ranked-delta {
+  font-family: var(--font-display);
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--sb-win);
+  font-variant-numeric: tabular-nums;
+}
+
+/* Weekly highlights — the sub-stat rhythm from "Your position". */
+.rh-sf-page .rh-sf-highlights-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0;
+  padding: 0;
+}
+
+.rh-sf-page .rh-sf-highlights-grid > * {
+  min-width: 0;
+  padding: 10px 12px 11px;
+  border: 0;
+  border-left: 1px solid var(--sb-line-soft);
+  border-radius: 0;
+  background: none;
+  text-align: left;
+}
+
+.rh-sf-page .rh-sf-highlights-grid > *:first-child {
+  border-left: 0;
+}
+
+.rh-sf-page .rh-sf-highlights-grid strong {
+  display: block;
+  margin: 4px 0 0;
+  font-family: var(--font-display);
+  font-size: 20px;
+  font-weight: 800;
+  line-height: 1;
+  color: var(--sb-ink);
+  font-variant-numeric: tabular-nums;
+}
+
+.rh-sf-page .rh-sf-highlights-grid p {
+  order: -1;
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.13em;
+  text-transform: uppercase;
+  color: var(--sb-label);
+}
+
+.rh-sf-page .rh-sf-highlights-grid small {
+  display: block;
+  margin-top: 4px;
+  overflow: hidden;
+  font-size: 11px;
+  color: var(--sb-muted);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.rh-sf-page .rh-sf-weekly-reset {
+  font-family: var(--font-display);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--sb-dim);
+}
+
+/* The only gold control on the page is the primary action. */
+.rh-sf-page .rh-sf-challenge-btn--gold {
+  height: 24px;
+  padding: 0 9px;
+  border: 1px solid var(--sb-accent-border);
+  border-radius: var(--radius-record);
+  background: var(--sb-accent-dim);
+  color: var(--sb-accent);
+  font-family: var(--font-body);
+  font-size: 11px;
+  font-weight: 600;
+  box-shadow: none;
+}
+
+.rh-sf-page .rh-sf-challenge-btn--gold:hover:not(:disabled) {
+  border-color: var(--sb-accent);
+  background: var(--sb-accent-dim);
+  color: var(--sb-accent);
+}
+
+/* ---------------------------------------------------------- responsive */
+
+@media (max-width: 1080px) {
+  .rh-sf-page .rh-hub-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .rh-sf-page .rh-sf-right-rail {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(268px, 1fr));
+    align-items: start;
+  }
+}
+
+@media (max-width: 760px) {
+  .rh-sf-page .social-hero {
+    flex-direction: column;
+    gap: 18px;
+    padding: 20px 18px 18px;
+  }
+
+  .rh-sf-page .social-hero__meta {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .rh-sf-page .social-hero__stat:nth-child(3) {
+    border-left: 0;
+  }
+
+  .rh-sf-page .social-hero__stat:nth-child(n + 3) {
+    border-top: 1px solid var(--sb-line-soft);
+  }
+
+  .rh-sf-page .rh-af-rich-row {
+    grid-template-columns: 28px 18px minmax(0, 1fr) auto;
+    padding: 11px 14px;
+  }
+
+  .rh-sf-page .rh-af-rich-end {
+    grid-column: 3 / -1;
+    justify-content: flex-start;
+  }
+}


### PR DESCRIPTION
**Draft — not ready to merge.** Parking a pile of WIP that had been sitting uncommitted in the working tree across several sessions, unrelated to the tournament hardening work, so `main` has a clean tree.

## Scope
- **Share text redesign** — Puzzle Rush / Daily Fritz / daily-puzzle share strings become Wordle-style: `Racehorse Puzzle Rush #<n>` + one emoji per puzzle (🟩 solved / 🟥 missed), puzzle number from a `2026-04-10` launch date. Drops the `shareGrid` point-bar rows.
- **RushResultsView** rewritten as a `.prd` dossier card inside `game-over-overlay` (new `rushResultsDossier.css`).
- **Social page** — "board" masthead (new `socialBoard.css`) + `SocialPageHero` gains `eyebrow` / `actions` / title-dot.
- **botMatch.css** — score-chip animation polish.
- `types.ts`: `PuzzleRushRun.runDate?`; Daily Fritz viewmodels thread `shareRunDate`.

## CI status / what blocks merge
1. **Client lint fails** — one net-new warning (`PuzzleRushLeaderboardScreen.tsx:226`, `useMemo` missing dep `PUZZLE_RUSH_LAUNCH_DATE`, a `new Date()` declared in the component body) tips the `--max-warnings 401` budget to 402. Fix: hoist `PUZZLE_RUSH_LAUNCH_DATE` to module scope (as `rushShareCard.ts` already does). Lint runs *before* tests, so this masks:
2. **5 tests fail** in `client/src/puzzleRush/puzzleRushRun.test.tsx` — the RushResultsView rewrite dropped `data-ui="rush-final-score"` / `data-ui="rush-share"` and the `AnimatedScore` count-up without updating those tests. `rushShareCard.test.ts` *was* updated and passes.
3. `tsc -b` (client) is clean.

## To finish
1. Hoist the launch-date constant → lint green.
2. Update `puzzleRushRun.test.tsx` for the new dossier markup (or restore the `data-ui` hooks + AnimatedScore).
3. Decide whether `shareGrid` / `shareGrid.test.ts` stay (still used by `dailyPuzzle/ladderShareCard.ts`).
4. Design review of the dossier + board treatments.

Tracked in `HARDENING_PLAN.md` (Current focus → "Parked, unrelated" block).

🤖 Generated with [Claude Code](https://claude.com/claude-code)