### PR TITLE
fix(tournament): harden fetchActiveAssignedMatchForUser selection (T-11)

### DIFF
--- a/server/src/scheduledTournament/persistence.test.ts
+++ b/server/src/scheduledTournament/persistence.test.ts
@@ -284,6 +284,67 @@ describe('fetchActiveAssignedMatchForUser', () => {
     vi.useRealTimers();
   });
 
+  it('prefers a match the player has already joined over a newer-scheduled one (T-11)', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(ACTIVE_TOURNAMENT_NOW);
+    const userId = '11111111-1111-4111-8111-111111111111';
+    const joinedTournamentId = '22222222-2222-4222-8222-222222222222';
+    const newerTournamentId = '33333333-3333-4333-8333-333333333333';
+
+    const baseMatch = {
+      round: 1,
+      match_number: 1,
+      player2_id: 'bot:fritz:x:1',
+      winner_id: null,
+      status: 'ready' as const,
+      ready_at: new Date().toISOString(),
+      ready_deadline_at: new Date(Date.now() + 60_000).toISOString(),
+      started_at: null,
+      completed_at: null,
+      player2_joined_at: new Date().toISOString(),
+      winner_source: null,
+      status_reason: null,
+      forfeit_user_id: null,
+      no_show_user_id: null,
+      bot_tier: 'standard' as const,
+      player1_score: null,
+      player2_score: null,
+    };
+
+    supabaseFetchMock.mockImplementation(async (url: string) => {
+      if (url.includes('scheduled_tournament_matches')) {
+        return [
+          // Older tournament, but the player has entered this room.
+          { ...baseMatch, id: 'match-joined', tournament_id: joinedTournamentId,
+            player1_id: userId, room_code: 'TJOINR1M1', player1_joined_at: new Date().toISOString() },
+          // Newer tournament, player has not joined.
+          { ...baseMatch, id: 'match-newer', tournament_id: newerTournamentId,
+            player1_id: userId, room_code: 'TNEWR1M1', player1_joined_at: null },
+        ];
+      }
+      if (url.includes(`id=eq.${encodeURIComponent(joinedTournamentId)}`)) {
+        return [{ id: joinedTournamentId, scheduled_start: '2026-05-17T02:00:00.000Z',
+          registration_open_at: '2026-05-17T01:30:00.000Z', registration_close_at: '2026-05-17T01:58:00.000Z',
+          status: 'in_progress', format: 'single_elimination', win_target: 30, max_players: 8,
+          winner_id: null, created_at: '2026-05-17T00:00:00.000Z' }];
+      }
+      if (url.includes(`id=eq.${encodeURIComponent(newerTournamentId)}`)) {
+        return [{ id: newerTournamentId, scheduled_start: '2026-05-17T02:30:00.000Z',
+          registration_open_at: '2026-05-17T02:00:00.000Z', registration_close_at: '2026-05-17T02:28:00.000Z',
+          status: 'in_progress', format: 'single_elimination', win_target: 30, max_players: 8,
+          winner_id: null, created_at: '2026-05-17T00:30:00.000Z' }];
+      }
+      return [];
+    });
+
+    const { fetchActiveAssignedMatchForUser } = await import('./persistence');
+    const result = await fetchActiveAssignedMatchForUser(userId);
+
+    expect(result?.match.id).toBe('match-joined');
+    expect(result?.tournament.id).toBe(joinedTournamentId);
+    vi.useRealTimers();
+  });
+
   it('does not recover matches from tournaments past the active window', async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-05-17T06:00:00.000Z'));

--- a/server/src/scheduledTournament/persistence.ts
+++ b/server/src/scheduledTournament/persistence.ts
@@ -479,7 +479,32 @@ export async function fetchActiveAssignedMatchForUser(userId: string): Promise<{
     return true;
   });
 
+  if (filtered.length > 1) {
+    // A user with 2+ concurrently-active assigned matches is an anomaly, not a
+    // normal state: within one tournament the atomic completion RPC (T-INV-1..5)
+    // guarantees exactly one active match, so this only happens across two
+    // tournaments whose active windows overlap. Warn so it is visible — this is
+    // the kind of anomaly gap T-15 flags as currently having no metric/alert.
+    log.warn({
+      userId,
+      count: filtered.length,
+      matches: filtered.map(({ match, tournament }) => ({
+        tournamentId: tournament.id,
+        matchId: match.id,
+        status: match.status,
+        scheduledStart: tournament.scheduled_start,
+        humanJoined: Boolean(humanJoinedAt(match, userId)),
+      })),
+    }, 'multiple active assigned matches for one user (see HARDENING_PLAN.md T-11 / T-15)');
+  }
+
   filtered.sort((a, b) => {
+    // A room the player has actually entered is the strongest signal of "the
+    // match I'm in right now" — stronger than which tournament is newest.
+    const joinWeight = (entry: { match: MatchRow }) =>
+      humanJoinedAt(entry.match, userId) ? 0 : 1;
+    const joinDiff = joinWeight(a) - joinWeight(b);
+    if (joinDiff !== 0) return joinDiff;
     const scheduledDiff =
       Date.parse(b.tournament.scheduled_start) - Date.parse(a.tournament.scheduled_start);
     if (scheduledDiff !== 0) return scheduledDiff;


### PR DESCRIPTION
Step 4 follow-up. **T-11** downgraded to low-priority hardening — this is that hardening.

## Why T-11 is mostly already closed (per §1.3)

- **"masks T-6"** — obsolete. T-6 (forfeit defaulting the win to player1) was closed at its source by PR-B's `authorizeMatchParticipant` in the forfeit path.
- **Intra-tournament "two active matches"** — closed by PR-A. The only way a user was in 2+ non-completed matches of the *same* tournament was a T-3/T-4 partial-write state; the atomic `complete_tournament_match` RPC eliminates those.
- **Cross-tournament overlap** — still possible (a user in two tournaments with overlapping active windows), and the newest-scheduled tie-breaker is a deliberate, tested heuristic (`persistence.test.ts` → "prefers the newest attachable tournament match…").

## This PR

1. `humanJoinedAt(match, userId)` becomes the **top** sort key, ahead of `tournament.scheduled_start` — a room the player has actually entered beats "which tournament is newest" as a signal.
2. `log.warn` (was silent) when `filtered.length > 1` — an anomaly worth surfacing; message + comment reference **T-11 / T-15** so it's traceable back to the plan (T-15 = "no metric/alert on anomalies").
3. Test: prefers a joined match over a newer-scheduled unjoined one.

## Verification
- `grep console.` on touched files: clean
- `tsc -p server/tsconfig.json --noEmit`: clean
- Full server suite: **196 files / 1124 tests** pass (+1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)