### PR TITLE
refactor(multiplayer): one room-kind classifier (PR-D, T-12)

### DIFF
--- a/server/src/multiplayer/mpAuthorityTelemetry.ts
+++ b/server/src/multiplayer/mpAuthorityTelemetry.ts
@@ -7,6 +7,7 @@ import {
   queueMpAuthorityEventPersist,
   type MpAuthorityEventRecord,
 } from './mpAuthorityEventStore';
+import { roomKind } from './roomKind';
 
 export type MpAuthorityFunnelEvent =
   | 'private_lobby_created'
@@ -54,11 +55,17 @@ type EmitPayload = {
 export function resolveMpAuthoritySourceType(room: {
   matchmakingMatchId?: string | null;
   scheduledTournamentMatchId?: string | null;
-  config?: { tournamentId?: string };
+  config?: { tournamentId?: string | null } | null;
 }): MpAuthoritySourceType {
-  if (room.scheduledTournamentMatchId || room.config?.tournamentId) return 'tournament';
-  if (room.matchmakingMatchId) return 'quick';
-  return 'private';
+  switch (roomKind(room)) {
+    case 'scheduled_tournament':
+    case 'legacy_league':
+      return 'tournament';
+    case 'matchmaking':
+      return 'quick';
+    case 'private':
+      return 'private';
+  }
 }
 
 export function emitMpAuthorityFunnel(

--- a/server/src/multiplayer/registerRematchPregameHandlers.ts
+++ b/server/src/multiplayer/registerRematchPregameHandlers.ts
@@ -17,6 +17,7 @@ import {
 } from './roomSession';
 import { comparePregameDrawTiles } from './preGameDraw';
 import { emitMpAuthorityFunnel } from './mpAuthorityTelemetry';
+import { isAnyTournamentRoom } from './roomKind';
 import { clearGameActionIdempotencyForRoom } from './gameActionIdempotency';
 import { MATCH_RESULT_STILL_SAVING_MESSAGE } from './gameOverPersistPolicy';
 
@@ -36,9 +37,12 @@ export function registerRematchPregameHandlers(
     try {
       const room = getRoom(roomCode);
       assertRoomDurabilityOperationAllowed(room, 'rematch');
-      const cfg = room.config;
 
-      if (cfg.tournamentId) {
+      // Both tournament systems: a rematch would start a fresh game in a room
+      // whose bracket/league match is already finished, floating free of it.
+      // Previously only the legacy league (`config.tournamentId`) was blocked;
+      // scheduled-tournament rooms slipped through. See HARDENING_PLAN.md T-12.
+      if (isAnyTournamentRoom(room)) {
         return cb?.({ ok: false, error: 'Rematch is unavailable in tournament rooms.' });
       }
       const playerSeatId = resolveActorSeatId(roomCode, socket);

--- a/server/src/multiplayer/roomKind.test.ts
+++ b/server/src/multiplayer/roomKind.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import {
+  roomKind,
+  isScheduledTournamentRoom,
+  isLegacyLeagueRoom,
+  isAnyTournamentRoom,
+} from './roomKind';
+
+describe('roomKind', () => {
+  it('classifies by precedence: scheduled_tournament > legacy_league > matchmaking > private', () => {
+    expect(roomKind({})).toBe('private');
+    expect(roomKind({ matchmakingMatchId: 'mm-1' })).toBe('matchmaking');
+    expect(roomKind({ config: { tournamentId: 'league-1' } })).toBe('legacy_league');
+    expect(roomKind({ scheduledTournamentMatchId: 'm-1' })).toBe('scheduled_tournament');
+
+    // A room carrying more than one marker resolves to the highest-precedence one.
+    expect(
+      roomKind({ scheduledTournamentMatchId: 'm-1', config: { tournamentId: 'league-1' } }),
+    ).toBe('scheduled_tournament');
+    expect(
+      roomKind({ config: { tournamentId: 'league-1' }, matchmakingMatchId: 'mm-1' }),
+    ).toBe('legacy_league');
+  });
+
+  it('treats empty-string / null markers as absent', () => {
+    expect(roomKind({ scheduledTournamentMatchId: '', matchmakingMatchId: null })).toBe('private');
+    expect(roomKind({ config: { tournamentId: null } })).toBe('private');
+  });
+
+  it('helper predicates agree with roomKind', () => {
+    const scheduled = { scheduledTournamentMatchId: 'm-1' };
+    const legacy = { config: { tournamentId: 'league-1' } };
+    const priv = {};
+
+    expect(isScheduledTournamentRoom(scheduled)).toBe(true);
+    expect(isLegacyLeagueRoom(scheduled)).toBe(false);
+    expect(isAnyTournamentRoom(scheduled)).toBe(true);
+
+    expect(isScheduledTournamentRoom(legacy)).toBe(false);
+    expect(isLegacyLeagueRoom(legacy)).toBe(true);
+    expect(isAnyTournamentRoom(legacy)).toBe(true);
+
+    expect(isAnyTournamentRoom(priv)).toBe(false);
+  });
+});

--- a/server/src/multiplayer/roomKind.ts
+++ b/server/src/multiplayer/roomKind.ts
@@ -1,0 +1,48 @@
+import type { Room } from '../rooms';
+
+/**
+ * The one place that answers "what kind of room is this?".
+ *
+ * Before this existed the question was re-derived ad hoc in ~4 places with
+ * predicates that disagreed — `Boolean(cfg.tournamentId)` (legacy league only),
+ * `scheduledTournamentMatchId || cfg.tournamentId` (both), `scheduledTournamentMatchId`
+ * alone (missed legacy). See HARDENING_PLAN.md T-12.
+ *
+ * Two distinct tournament systems exist:
+ *   - `scheduled_tournament` — the 8-player bracket system
+ *     (`room.scheduledTournamentMatchId`).
+ *   - `legacy_league` — the older ad-hoc league behind `ENABLE_LEGACY_TOURNAMENTS`
+ *     (`room.config.tournamentId`).
+ * They take different game-over paths and must not be conflated.
+ */
+export type RoomKind =
+  | 'private'
+  | 'matchmaking'
+  | 'scheduled_tournament'
+  | 'legacy_league';
+
+type RoomKindInput = {
+  scheduledTournamentMatchId?: string | null;
+  matchmakingMatchId?: string | null;
+  config?: { tournamentId?: string | null } | null;
+};
+
+export function roomKind(room: RoomKindInput | Room): RoomKind {
+  const r = room as RoomKindInput;
+  if (r.scheduledTournamentMatchId) return 'scheduled_tournament';
+  if (r.config?.tournamentId) return 'legacy_league';
+  if (r.matchmakingMatchId) return 'matchmaking';
+  return 'private';
+}
+
+export const isScheduledTournamentRoom = (room: RoomKindInput | Room): boolean =>
+  roomKind(room) === 'scheduled_tournament';
+
+export const isLegacyLeagueRoom = (room: RoomKindInput | Room): boolean =>
+  roomKind(room) === 'legacy_league';
+
+/** True for either tournament system. Use for cross-cutting concerns (telemetry, rematch block). */
+export const isAnyTournamentRoom = (room: RoomKindInput | Room): boolean => {
+  const kind = roomKind(room);
+  return kind === 'scheduled_tournament' || kind === 'legacy_league';
+};

--- a/server/src/multiplayer/roomLivePersistence.ts
+++ b/server/src/multiplayer/roomLivePersistence.ts
@@ -17,6 +17,7 @@ import type { RoomMatchEvent } from '../roomEvents';
 import { supabaseFetch } from '../supabaseUtils';
 import { childLogger } from '../logger';
 import { applyLiveSessionRow } from './applyLiveSessionRoom';
+import { roomKind } from './roomKind';
 
 const log = childLogger('room-live-persistence');
 import {
@@ -217,9 +218,18 @@ export function assertUnmaskedGameStateForPersistence(state: GameState): void {
 }
 
 export function inferLiveSessionSourceType(room: Room): RoomLiveSessionSourceType {
-  if (room.scheduledTournamentMatchId) return 'tournament';
-  if (room.matchmakingMatchId) return 'matchmaking';
-  return 'private';
+  switch (roomKind(room)) {
+    case 'scheduled_tournament':
+    case 'legacy_league':
+      // Previously legacy-league rooms fell through to 'private' here — a
+      // latent mismatch with resolveMpAuthoritySourceType. Now consistent.
+      // (ENABLE_LEGACY_TOURNAMENTS is off in prod, so this changes no live data.)
+      return 'tournament';
+    case 'matchmaking':
+      return 'matchmaking';
+    case 'private':
+      return 'private';
+  }
 }
 
 export function inferLiveSessionStatus(room: Room): RoomLiveSessionStatus {

--- a/server/src/multiplayer/roomSession.gameOverRouting.test.ts
+++ b/server/src/multiplayer/roomSession.gameOverRouting.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  createReservedRoom,
+  deleteRoom,
+  getRoom,
+  joinRoom,
+  startGame,
+} from '../rooms';
+import {
+  broadcastStateUpdate,
+  initRoomSession,
+  setRoomRoster,
+} from './roomSession';
+
+vi.mock('../supabaseUtils', () => ({
+  supabaseFetch: vi.fn(async () => undefined),
+}));
+
+function makeIo() {
+  return {
+    sockets: { sockets: new Map(), adapter: { rooms: new Map() } },
+    to: () => ({ emit: vi.fn(), except: () => ({ emit: vi.fn() }) }),
+  } as any;
+}
+
+const onGameOver = vi.fn(() => null);
+const finalizeTournamentMatch = vi.fn();
+
+function initSession() {
+  initRoomSession(makeIo(), {
+    resolveSocketIdentity: async () => ({ username: 'Guest', userId: null }),
+    normalizeUsername: (v: unknown) => (typeof v === 'string' ? v : 'Guest'),
+    normalizeUserId: (v: unknown) => (typeof v === 'string' ? v : null),
+    tryHydrateMatchmakingRoomShell: async () => 'skipped',
+    waitUntilMatchmakingRoomSocketsReady: async () => undefined,
+    onAfterMatchStarted: async () => undefined,
+    notifyRoomPlayersInGame: () => undefined,
+    maybeFinalizeTournamentMatch: () => undefined,
+    persistRoomMatchLog: async () => undefined,
+    onGameOver,
+    finalizeTournamentMatch,
+  });
+}
+
+async function makeGameOverRoom(code: string) {
+  const room = createReservedRoom(code, { winningScore: 30 });
+  joinRoom(code, 'p1');
+  joinRoom(code, 'p2');
+  setRoomRoster(code, [
+    { id: 'p1', socketId: '', username: 'P1', userId: 'u1' },
+    { id: 'p2', socketId: '', username: 'P2', userId: 'u2' },
+  ]);
+  await startGame(code, makeIo());
+  const started = getRoom(code);
+  started.state!.gameOver = true;
+  started.state!.handOver = true;
+  started.state!.winnerId = started.state!.playerIds[0];
+  return started;
+}
+
+describe('broadcastStateUpdate game-over routing (T-12)', () => {
+  beforeEach(() => {
+    onGameOver.mockClear();
+    finalizeTournamentMatch.mockClear();
+    initSession();
+  });
+  afterEach(() => {
+    ['GOR_SCHED', 'GOR_LEGACY', 'GOR_PRIV'].forEach(deleteRoom);
+    vi.useRealTimers();
+  });
+
+  it('scheduled-tournament room routes game-over through onGameOver, not the legacy finalizer', async () => {
+    const room = await makeGameOverRoom('GOR_SCHED');
+    room.scheduledTournamentMatchId = 'match-1';
+
+    broadcastStateUpdate('GOR_SCHED');
+    await new Promise((r) => setImmediate(r));
+
+    expect(onGameOver).toHaveBeenCalledTimes(1);
+    expect(finalizeTournamentMatch).not.toHaveBeenCalled();
+  });
+
+  it('legacy-league room routes game-over through finalizeTournamentMatch, not onGameOver', async () => {
+    const room = await makeGameOverRoom('GOR_LEGACY');
+    room.config.tournamentId = 'league-1';
+
+    broadcastStateUpdate('GOR_LEGACY');
+    await new Promise((r) => setImmediate(r));
+
+    expect(finalizeTournamentMatch).toHaveBeenCalledTimes(1);
+    expect(onGameOver).not.toHaveBeenCalled();
+  });
+
+  it('private room routes game-over through onGameOver only', async () => {
+    await makeGameOverRoom('GOR_PRIV');
+
+    broadcastStateUpdate('GOR_PRIV');
+    await new Promise((r) => setImmediate(r));
+
+    expect(onGameOver).toHaveBeenCalledTimes(1);
+    expect(finalizeTournamentMatch).not.toHaveBeenCalled();
+  });
+});
+

--- a/server/src/multiplayer/roomSession.ts
+++ b/server/src/multiplayer/roomSession.ts
@@ -28,6 +28,7 @@ import {
 import type { MatchStartDeps } from './matchStartReady';
 import { drawAudit } from './drawAudit';
 import { maskPregameDrawForRecipient } from './preGameDraw';
+import { isLegacyLeagueRoom } from './roomKind';
 import { publishMultiplayerSpectatorSnapshotIfEnabled } from '../spectator/spectatorIntegration';
 import type {
   LegacyMatchmakingRoomShellHydrationResult,
@@ -716,7 +717,10 @@ export function broadcastStateUpdate(roomCode: string): void {
   );
 
   const cfg = room.config;
-  const isTournamentRoom = Boolean(cfg.tournamentId);
+  // ONLY the legacy league (`cfg.tournamentId`). Scheduled-tournament rooms are
+  // `roomKind === 'scheduled_tournament'` and are deliberately NOT this — see
+  // the game-over branch below.
+  const legacyLeagueRoom = isLegacyLeagueRoom(room);
   const pidsForLead = room.state.playerIds;
   if (Array.isArray(pidsForLead) && pidsForLead.length === 2) {
     const aId = pidsForLead[0];
@@ -733,7 +737,16 @@ export function broadcastStateUpdate(roomCode: string): void {
     }
   }
 
-  if (room.state.gameOver && !isTournamentRoom && !room.matchLogged) {
+  // DO NOT widen this guard to `!isAnyTournamentRoom`. A scheduled-tournament
+  // match's normal play-to-completion result reaches the bracket ONLY by
+  // flowing through this branch: `onGameOver` -> `persistGameOverOnce` ->
+  // `applyTournamentGameOverFromRoom`, which is the single call site of that
+  // function for game-over-from-play. Excluding scheduled-tournament rooms here
+  // (the obvious-looking "consolidation") silently stops bracket advancement
+  // for played-out matches — forfeit / no-show paths still work, so it passes a
+  // smoke test. Only the legacy league (`legacyLeagueRoom`) is excluded, because
+  // it runs its own finalizer via `deps.finalizeTournamentMatch` below.
+  if (room.state.gameOver && !legacyLeagueRoom && !room.matchLogged) {
     const status = room.gameOverPersistStatus ?? 'idle';
     // Do not re-schedule while pending, after success, or after give-up.
     if (status === 'idle') {
@@ -942,7 +955,10 @@ export function broadcastStateUpdate(roomCode: string): void {
   if (room.state.gameOver) {
     const finRoom = room;
     const finCode = roomCode;
-    const shouldFinalizeTour = isTournamentRoom;
+    // Legacy league only — `finalizeTournamentMatchHook` is wired solely under
+    // ENABLE_LEGACY_TOURNAMENTS. Scheduled-tournament rooms finalize via the
+    // game-over branch above, not here.
+    const shouldFinalizeTour = legacyLeagueRoom;
     setImmediate(() => {
       if (shouldFinalizeTour) deps.finalizeTournamentMatch?.(finRoom);
       evaluateRoomLifecycle(finCode);

--- a/server/src/realtime/gameOverPersistence.ts
+++ b/server/src/realtime/gameOverPersistence.ts
@@ -23,6 +23,7 @@ import {
 } from '../shared/fritzMatchLifecycle';
 import type { GameOverPersistInput } from '../multiplayer/roomSession';
 import { emitMpAuthorityFunnel } from '../multiplayer/mpAuthorityTelemetry';
+import { isAnyTournamentRoom } from '../multiplayer/roomKind';
 import type { GhostMoveLogEntry } from '../ghost/service';
 import type { GhostMoveLogVerificationResult } from '../ghost/verifier';
 import {
@@ -115,6 +116,11 @@ async function persistGameOverOnce(io: Server, input: GameOverPersistInput): Pro
   // Scheduled tournament: applyMatchResult must succeed or throw (retry / give-up).
   // Never mark success when the bracket was not advanced.
   // Ops repair after give-up: docs/ops/tournament-apply-match-result-repair.md
+  //
+  // These branches read `room.scheduledTournamentMatchId` directly (not
+  // `roomKind`) on purpose: they are the *routing* to bracket advancement, and
+  // only the scheduled-tournament system routes here (legacy league is excluded
+  // upstream in roomSession's game-over branch and runs its own finalizer).
   if (winnerUserId) {
     const applied = await applyTournamentGameOverFromRoom(io, room, {
       winnerUserId,
@@ -406,7 +412,10 @@ function emitGameOverPersistFailed(io: Server, room: Room, sourceMatchId: string
   const sequence = room.state?.sequence ?? null;
   const errorMessage = err instanceof Error ? err.message : String(err);
   const isTournament =
-    Boolean(room.scheduledTournamentMatchId) ||
+    isAnyTournamentRoom(room) ||
+    // room-code fallback: a rehydrated room shell carries no match-id marker,
+    // so `applyTournamentGameOverFromRoom` signals "this was a tournament" via
+    // the error code instead.
     errorMessage === TOURNAMENT_MISSING_WINNER_ERROR ||
     errorMessage === TOURNAMENT_APPLY_FAILED_ERROR;
   const message = isTournament


### PR DESCRIPTION
Step 4 / PR-D of the tournament hardening plan. Closes gap **T-12**.

## Problem

"Is this a tournament room, and which kind?" was answered by 4 disagreeing ad-hoc predicates:

| Location | Predicate | legacy-league? | scheduled? |
|---|---|---|---|
| `roomSession.ts` `isTournamentRoom` | `Boolean(cfg.tournamentId)` | ✅ | ❌ |
| `mpAuthorityTelemetry.ts` | `scheduledTournamentMatchId \|\| cfg.tournamentId` | ✅ | ✅ |
| `roomLivePersistence.ts` `inferLiveSessionSourceType` | `scheduledTournamentMatchId` only | ❌ | ✅ |
| `registerRematchPregameHandlers.ts` | `cfg.tournamentId` only | ✅ | ❌ |

The load-bearing fragility: a scheduled-tournament match's **normal play-to-completion** result reaches the bracket **only** by flowing through the `!isTournamentRoom` branch at `roomSession.ts` game-over → `onGameOver` → `persistGameOverOnce` → `applyTournamentGameOverFromRoom` (confirmed the sole call site for game-over-from-play). "Fixing" `isTournamentRoom` to also mean scheduled rooms silently stops bracket advancement for played-out matches — forfeit/no-show paths still work, so it passes a smoke test.

## Change

- **`server/src/multiplayer/roomKind.ts`** — one leaf module: `roomKind(room) → 'private' | 'matchmaking' | 'scheduled_tournament' | 'legacy_league'` + `isScheduledTournamentRoom` / `isLegacyLeagueRoom` / `isAnyTournamentRoom`.
- **`roomSession.ts`** — `isTournamentRoom` → `isLegacyLeagueRoom(room)` (same value today, named for what it gates). The **loud non-widening comment** on the game-over branch is the actual deliverable. `shouldFinalizeTour` → `isLegacyLeagueRoom(room)` (`finalizeTournamentMatchHook` is wired only under `ENABLE_LEGACY_TOURNAMENTS`).
- **`resolveMpAuthoritySourceType` / `inferLiveSessionSourceType`** — reimplemented on `roomKind`; they stop disagreeing. `inferLiveSessionSourceType` now counts legacy-league as `'tournament'` — inert in prod (`ENABLE_LEGACY_TOURNAMENTS` off), noted in code.
- **`gameOverPersistence.ts`** `emitGameOverPersistFailed` — `isAnyTournamentRoom(room)`; the error-code fallback (`TOURNAMENT_MISSING_WINNER_ERROR` / `TOURNAMENT_APPLY_FAILED_ERROR`, for rehydrated rooms with no match-id marker) is kept. The `room.scheduledTournamentMatchId` *routing* branches in `persistGameOverOnce` stay as direct field reads (load-bearing) + a clarifying comment.

## Behavior change (verified empirically, not folded into "consolidate predicates")

**`registerRematchPregameHandlers.ts`** — rematch was blocked only in legacy-league rooms (`cfg.tournamentId`); scheduled-tournament rooms slipped past. Traced: a `game:rematch` on a scheduled-tournament room during the post-game-over cleanup window (`evaluateRoomLifecycle` *schedules* cleanup, not immediate) ran the full rematch path — reset `matchLogged`/`gameOverPersistStatus`, archived the finished game, called `initiatePregameDrawOrStartUnlocked(..., { allowRestart: true })` → **a fresh game started in the bracket-match room**, floating free of the bracket. The `scheduled_tournament_matches` row is already `completed` (PR-A idempotency protects the bracket itself), but the rematch game re-triggers `applyTournamentGameOverFromRoom` (RPC returns `applied:false`, possibly a `tournament_match_winner_conflict` warn) and mislabels telemetry as `private_rematch_started`. Reachable today only via a crafted socket message (the tournament client shows no rematch button), but it's exactly the T-12 failure shape. Now blocked via `isAnyTournamentRoom`.

## Out of scope (flagged, not touched)
The `isPrivate` checks in `roomForfeit.ts:240` and `registerMatchStartHandlers.ts:87` — different predicates for different reasons, not wrong.

## Verification
- `grep console.` on touched files: 2 hits, both **pre-existing** (`mpAuthorityTelemetry.ts` `console.info`, `registerRematchPregameHandlers.ts` `console.error`) and untouched — `git diff` adds no `console.` line.
- `tsc -p server/tsconfig.json --noEmit`: clean
- Server eslint on touched files: same 4 findings as `main` (line-shifted), none new
- Full server suite: **198 files / 1130 tests** pass (+6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)