### PR TITLE
test(tournament): assertBracketConsistent invariant helper (Step 5 / PR-E)

### DIFF
--- a/server/src/scheduledTournament/assertBracketConsistent.testkit.test.ts
+++ b/server/src/scheduledTournament/assertBracketConsistent.testkit.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect } from 'vitest';
+import {
+  assertBracketConsistent,
+  collectBracketConsistencyViolations,
+  type BracketConsistencyInput,
+} from './assertBracketConsistent.testkit';
+import type { MatchRow, RegistrationRow } from './types';
+
+function match(round: 1 | 2 | 3, matchNumber: number, over: Partial<MatchRow> = {}): MatchRow {
+  return {
+    id: `m-${round}-${matchNumber}`,
+    tournament_id: 'tour-1',
+    round,
+    match_number: matchNumber,
+    player1_id: null,
+    player2_id: null,
+    winner_id: null,
+    room_code: null,
+    status: 'waiting',
+    ready_at: null,
+    ready_deadline_at: null,
+    started_at: null,
+    completed_at: null,
+    player1_joined_at: null,
+    player2_joined_at: null,
+    winner_source: null,
+    status_reason: null,
+    forfeit_user_id: null,
+    no_show_user_id: null,
+    bot_tier: null,
+    player1_score: null,
+    player2_score: null,
+    ...over,
+  };
+}
+
+function reg(userId: string, over: Partial<RegistrationRow> = {}): RegistrationRow {
+  return {
+    id: `reg-${userId}`,
+    tournament_id: 'tour-1',
+    user_id: userId,
+    registered_at: '2026-05-14T23:00:00Z',
+    seed: null,
+    placement: null,
+    status: 'active',
+    ...over,
+  };
+}
+
+const completed = (winner: string, p1: string, p2: string, round: 1 | 2 | 3, n: number) =>
+  match(round, n, {
+    player1_id: p1,
+    player2_id: p2,
+    winner_id: winner,
+    status: 'completed',
+    completed_at: '2026-05-15T00:10:00Z',
+    winner_source: 'game_over',
+  });
+
+/** A fully played-out 8-human bracket: u1 champion, u2 runner-up. */
+function playedOutBracket(): BracketConsistencyInput {
+  const matches: MatchRow[] = [
+    completed('u1', 'u1', 'u8', 1, 1),
+    completed('u4', 'u4', 'u5', 1, 2),
+    completed('u3', 'u3', 'u6', 1, 3),
+    completed('u2', 'u2', 'u7', 1, 4),
+    completed('u1', 'u1', 'u4', 2, 1),
+    completed('u2', 'u3', 'u2', 2, 2),
+    completed('u1', 'u1', 'u2', 3, 1),
+  ];
+  const registrations: RegistrationRow[] = [
+    reg('u1', { status: 'winner', placement: 1 }),
+    reg('u2', { status: 'eliminated', placement: 2 }),
+    reg('u3', { status: 'eliminated', placement: 3 }),
+    reg('u4', { status: 'eliminated', placement: 3 }),
+    reg('u5', { status: 'eliminated', placement: 5 }),
+    reg('u6', { status: 'eliminated', placement: 5 }),
+    reg('u7', { status: 'eliminated', placement: 5 }),
+    reg('u8', { status: 'eliminated', placement: 5 }),
+  ];
+  return {
+    tournament: { id: 'tour-1', status: 'completed', winner_id: 'u1' },
+    matches,
+    registrations,
+  };
+}
+
+describe('assertBracketConsistent', () => {
+  it('passes a fully consistent played-out bracket', () => {
+    expect(collectBracketConsistencyViolations(playedOutBracket())).toEqual([]);
+    expect(() => assertBracketConsistent(playedOutBracket())).not.toThrow();
+  });
+
+  it('passes a mid-tournament bracket (QF done, one SF ready)', () => {
+    const matches: MatchRow[] = [
+      completed('u1', 'u1', 'u8', 1, 1),
+      completed('u4', 'u4', 'u5', 1, 2),
+      match(1, 3, { player1_id: 'u3', player2_id: 'u6', status: 'in_progress' }),
+      match(1, 4, { player1_id: 'u2', player2_id: 'u7', status: 'ready' }),
+      match(2, 1, { player1_id: 'u1', player2_id: 'u4', status: 'ready' }),
+      match(2, 2, { status: 'waiting' }),
+      match(3, 1, { status: 'waiting' }),
+    ];
+    const registrations = ['u1', 'u2', 'u3', 'u4', 'u5', 'u6', 'u7', 'u8'].map((u) =>
+      reg(u, { status: u === 'u8' || u === 'u5' ? 'eliminated' : 'active' }),
+    );
+    expect(
+      collectBracketConsistencyViolations({
+        tournament: { id: 'tour-1', status: 'in_progress', winner_id: null },
+        matches,
+        registrations,
+      }),
+    ).toEqual([]);
+  });
+
+  it('catches a completed match with a non-participant winner (T-INV-2)', () => {
+    const input = playedOutBracket();
+    input.matches[0] = { ...input.matches[0], winner_id: 'stranger' };
+    const v = collectBracketConsistencyViolations(input);
+    expect(v.some((s) => s.includes('not a participant'))).toBe(true);
+  });
+
+  it('catches a winner not advanced into the feeder slot (T-INV-5)', () => {
+    const input = playedOutBracket();
+    // SF1.player1 should be u1 (QF1 winner); corrupt it.
+    input.matches[4] = { ...input.matches[4], player1_id: 'u4', winner_id: 'u4' };
+    const v = collectBracketConsistencyViolations(input);
+    expect(v.some((s) => s.includes('is not in 2/1.player1'))).toBe(true);
+  });
+
+  it('catches a target match past waiting with feeders not both terminal (T-INV-6)', () => {
+    const input = playedOutBracket();
+    input.matches[1] = { ...input.matches[1], status: 'in_progress', winner_id: null, completed_at: null };
+    const v = collectBracketConsistencyViolations(input);
+    expect(v.some((s) => s.includes('feeders are') && s.includes('not both terminal'))).toBe(true);
+  });
+
+  it('catches a user live in two matches at once (T-INV-7)', () => {
+    const input = playedOutBracket();
+    input.matches[5] = { ...input.matches[5], status: 'in_progress', winner_id: null, completed_at: null };
+    input.matches[6] = { ...input.matches[6], status: 'in_progress', winner_id: null, completed_at: null };
+    // u2 is player in both SF2 and the Final now.
+    const v = collectBracketConsistencyViolations(input);
+    expect(v.some((s) => s.includes('u2 is in 2 ready/in_progress matches'))).toBe(true);
+  });
+
+  it('catches a loser whose registration is not eliminated (T-INV-10)', () => {
+    const input = playedOutBracket();
+    input.registrations[7] = reg('u8', { status: 'active' });
+    const v = collectBracketConsistencyViolations(input);
+    expect(v.some((s) => s.includes('u8') && s.includes('expected eliminated'))).toBe(true);
+  });
+
+  it('catches a wrong placement for exit round (T-INV-10)', () => {
+    const input = playedOutBracket();
+    input.registrations[2] = reg('u3', { status: 'eliminated', placement: 5 }); // lost SF, should be 3
+    const v = collectBracketConsistencyViolations(input);
+    expect(v.some((s) => s.includes('u3 lost in round 2') && s.includes('expected 3'))).toBe(true);
+  });
+
+  it('catches tournament marked completed while the final is unfinished', () => {
+    const input = playedOutBracket();
+    input.matches[6] = match(3, 1, { player1_id: 'u1', player2_id: 'u2', status: 'in_progress' });
+    const v = collectBracketConsistencyViolations(input);
+    expect(v.some((s) => s.includes('status is completed but the final match'))).toBe(true);
+  });
+
+  it('T-INV-3 / D-3: flags a spurious tournament_match_winner_conflict log', () => {
+    const input = playedOutBracket();
+    input.capturedLogs = [{ event: 'tournament_match_winner_conflict', matchId: 'm-1-1' }];
+    const v = collectBracketConsistencyViolations(input);
+    expect(v.some((s) => s.includes('expected 0 tournament_match_winner_conflict'))).toBe(true);
+  });
+
+  it('T-INV-3 / D-3: allows an expected conflict log when the test declares it', () => {
+    const input = playedOutBracket();
+    input.capturedLogs = [{ event: 'tournament_match_winner_conflict' }];
+    input.expectedConflictLogs = 1;
+    expect(collectBracketConsistencyViolations(input)).toEqual([]);
+  });
+
+  it('catches a bracket that is not 7 rows', () => {
+    const input = playedOutBracket();
+    input.matches = input.matches.slice(0, 6);
+    const v = collectBracketConsistencyViolations(input);
+    expect(v.some((s) => s.includes('expected 7 match rows'))).toBe(true);
+  });
+});

--- a/server/src/scheduledTournament/assertBracketConsistent.testkit.ts
+++ b/server/src/scheduledTournament/assertBracketConsistent.testkit.ts
@@ -1,0 +1,267 @@
+/**
+ * `assertBracketConsistent` — the invariant-assertion helper called at the end
+ * of tournament engine / harness tests (HARDENING_PLAN.md §1.6, Step 5).
+ *
+ * It checks the *observable* consequences of T-INV-1..10 against a set of rows,
+ * so a test that drives a bracket through completions / no-shows / a cold-wake
+ * catch-up tick can assert "and the bracket is still internally consistent"
+ * without hand-writing the same 20 expectations each time.
+ *
+ * It also catches a spurious `tournament_match_winner_conflict` warn (D-3):
+ * that log is the alert mechanism for a genuine two-producer winner
+ * disagreement, so it must NOT fire on the non-conflict paths (single producer,
+ * idempotent replay, cold-wake catch-up). Pass `capturedLogs` (see the
+ * `vi.mock('../logger', …)` pattern used elsewhere) to enable that check.
+ */
+
+import type { MatchRow, RegistrationRow } from './types';
+
+const isBot = (id: string | null | undefined): boolean =>
+  typeof id === 'string' && id.startsWith('bot:fritz:');
+
+/** QF1→SF1.p1, QF2→SF1.p2, QF3→SF2.p1, QF4→SF2.p2; SF1→F.p1, SF2→F.p2. */
+function advanceTarget(
+  round: number,
+  matchNumber: number,
+): { nextRound: number; nextMatchNumber: number; nextSlot: 'player1' | 'player2' } | null {
+  if (round === 1) {
+    return {
+      nextRound: 2,
+      nextMatchNumber: Math.floor((matchNumber + 1) / 2),
+      nextSlot: matchNumber % 2 === 1 ? 'player1' : 'player2',
+    };
+  }
+  if (round === 2) {
+    return { nextRound: 3, nextMatchNumber: 1, nextSlot: matchNumber === 1 ? 'player1' : 'player2' };
+  }
+  return null;
+}
+
+const TERMINAL: ReadonlyArray<MatchRow['status']> = ['completed', 'bye'];
+const PLAYABLE: ReadonlyArray<MatchRow['status']> = ['ready', 'in_progress'];
+
+export type CapturedLog = { event?: unknown; msg?: unknown; [k: string]: unknown };
+
+export type BracketConsistencyInput = {
+  tournament: { id: string; status: string; winner_id: string | null };
+  matches: MatchRow[];
+  registrations: RegistrationRow[];
+  /**
+   * Warn/log records captured by the test (the `vi.mock('../logger', …)`
+   * pattern). When provided, the helper asserts the number of
+   * `tournament_match_winner_conflict` entries equals `expectedConflictLogs`.
+   */
+  capturedLogs?: CapturedLog[];
+  /** Expected count of legitimate `tournament_match_winner_conflict` logs. Default 0. */
+  expectedConflictLogs?: number;
+};
+
+export function collectBracketConsistencyViolations(input: BracketConsistencyInput): string[] {
+  const v: string[] = [];
+  const { tournament, matches, registrations } = input;
+  const tMatches = matches.filter((m) => m.tournament_id === tournament.id);
+  const byRoundNumber = new Map<string, MatchRow>();
+
+  // ── shape (T-INV-8) ──────────────────────────────────────────────────────
+  if (tMatches.length !== 7) {
+    v.push(`expected 7 match rows, found ${tMatches.length}`);
+  }
+  for (const [round, count] of [[1, 4], [2, 2], [3, 1]] as const) {
+    const got = tMatches.filter((m) => m.round === round).length;
+    if (got !== count) v.push(`round ${round}: expected ${count} matches, found ${got}`);
+  }
+  for (const m of tMatches) {
+    const key = `${m.round}/${m.match_number}`;
+    if (byRoundNumber.has(key)) v.push(`duplicate match at round ${key}`);
+    byRoundNumber.set(key, m);
+  }
+
+  // ── per-match winner integrity (T-INV-1, T-INV-2) ─────────────────────────
+  for (const m of tMatches) {
+    const terminal = TERMINAL.includes(m.status);
+    if (terminal && m.status === 'completed') {
+      if (m.winner_id == null) {
+        v.push(`match ${m.round}/${m.match_number} is completed with a null winner_id`);
+      } else if (m.winner_id !== m.player1_id && m.winner_id !== m.player2_id) {
+        v.push(
+          `match ${m.round}/${m.match_number} winner_id ${m.winner_id} is not a participant ` +
+            `(${m.player1_id} / ${m.player2_id})`,
+        );
+      }
+      if (m.completed_at == null) {
+        v.push(`match ${m.round}/${m.match_number} is completed without a completed_at`);
+      }
+    }
+    if (!terminal && (m.winner_id != null || m.completed_at != null)) {
+      v.push(
+        `match ${m.round}/${m.match_number} is ${m.status} but carries winner_id/completed_at`,
+      );
+    }
+  }
+
+  // ── advancement (T-INV-5) + feeder gating (T-INV-6) ───────────────────────
+  for (const m of tMatches) {
+    const tgt = advanceTarget(m.round, m.match_number);
+    if (!tgt) continue;
+    const feederB = tMatches.find(
+      (x) =>
+        advanceTarget(x.round, x.match_number)?.nextRound === tgt.nextRound &&
+        advanceTarget(x.round, x.match_number)?.nextMatchNumber === tgt.nextMatchNumber &&
+        x.id !== m.id,
+    );
+    const target = byRoundNumber.get(`${tgt.nextRound}/${tgt.nextMatchNumber}`);
+    if (!target) {
+      v.push(`match ${m.round}/${m.match_number} has no advancement target row`);
+      continue;
+    }
+    const slotVal = tgt.nextSlot === 'player1' ? target.player1_id : target.player2_id;
+
+    if (m.status === 'completed' && m.winner_id != null) {
+      if (slotVal !== m.winner_id) {
+        v.push(
+          `match ${m.round}/${m.match_number} winner ${m.winner_id} is not in ` +
+            `${tgt.nextRound}/${tgt.nextMatchNumber}.${tgt.nextSlot} (found ${slotVal})`,
+        );
+      }
+    } else if (!TERMINAL.includes(m.status) && slotVal != null) {
+      v.push(
+        `${tgt.nextRound}/${tgt.nextMatchNumber}.${tgt.nextSlot} is filled (${slotVal}) but its ` +
+          `feeder ${m.round}/${m.match_number} is only ${m.status}`,
+      );
+    }
+
+    // T-INV-6: target is past `waiting` only if BOTH feeders are terminal.
+    if (PLAYABLE.includes(target.status) || target.status === 'completed') {
+      const bothFeedersTerminal =
+        TERMINAL.includes(m.status) && !!feederB && TERMINAL.includes(feederB.status);
+      if (!bothFeedersTerminal) {
+        v.push(
+          `match ${target.round}/${target.match_number} is ${target.status} but its feeders are ` +
+            `not both terminal (${m.round}/${m.match_number}=${m.status}` +
+            `${feederB ? `, ${feederB.round}/${feederB.match_number}=${feederB.status}` : ', <missing>'})`,
+        );
+      }
+    }
+  }
+
+  // ── one live match per user (T-INV-7) ────────────────────────────────────
+  const liveCountByUser = new Map<string, number>();
+  for (const m of tMatches) {
+    if (!PLAYABLE.includes(m.status)) continue;
+    for (const pid of [m.player1_id, m.player2_id]) {
+      if (pid == null || isBot(pid)) continue;
+      liveCountByUser.set(pid, (liveCountByUser.get(pid) ?? 0) + 1);
+    }
+  }
+  for (const [user, count] of liveCountByUser) {
+    if (count > 1) v.push(`user ${user} is in ${count} ready/in_progress matches at once`);
+  }
+
+  // ── elimination / placement / champion (T-INV-10) ────────────────────────
+  const regByUser = new Map(registrations.map((r) => [r.user_id, r]));
+  for (const m of tMatches) {
+    if (m.status !== 'completed' || m.winner_id == null) continue;
+    const loser =
+      m.winner_id === m.player1_id ? m.player2_id : m.winner_id === m.player2_id ? m.player1_id : null;
+    if (loser == null || isBot(loser)) continue;
+    const reg = regByUser.get(loser);
+    if (!reg) {
+      v.push(`loser ${loser} of ${m.round}/${m.match_number} has no registration row`);
+    } else if (reg.status !== 'eliminated' && reg.status !== 'winner') {
+      v.push(
+        `loser ${loser} of ${m.round}/${m.match_number} has registration status ${reg.status}, ` +
+          `expected eliminated`,
+      );
+    }
+  }
+
+  const final = byRoundNumber.get('3/1');
+  const finalDone = final?.status === 'completed' && final.winner_id != null;
+  if (finalDone) {
+    if (tournament.status !== 'completed') {
+      v.push(`final is completed but tournament status is ${tournament.status}`);
+    }
+    if (tournament.winner_id !== final!.winner_id) {
+      v.push(
+        `tournament winner_id ${tournament.winner_id} does not match final winner ${final!.winner_id}`,
+      );
+    }
+    if (!isBot(final!.winner_id)) {
+      const champReg = regByUser.get(final!.winner_id!);
+      if (champReg?.status !== 'winner') {
+        v.push(`champion ${final!.winner_id} registration status is ${champReg?.status}, expected winner`);
+      }
+      if (champReg?.placement !== 1) {
+        v.push(`champion ${final!.winner_id} placement is ${champReg?.placement}, expected 1`);
+      }
+    }
+    // Every human who played a completed match has a placement by exit round.
+    const exitRoundByUser = new Map<string, number>();
+    for (const m of tMatches) {
+      if (m.status !== 'completed' || m.winner_id == null) continue;
+      const loser =
+        m.winner_id === m.player1_id ? m.player2_id : m.winner_id === m.player2_id ? m.player1_id : null;
+      if (loser == null || isBot(loser)) continue;
+      exitRoundByUser.set(loser, m.round);
+    }
+    for (const [user, round] of exitRoundByUser) {
+      const expected = round === 3 ? 2 : round === 2 ? 3 : 5;
+      const got = regByUser.get(user)?.placement;
+      if (got !== expected) {
+        v.push(`user ${user} lost in round ${round}, placement is ${got}, expected ${expected}`);
+      }
+    }
+  } else {
+    if (tournament.status === 'completed') {
+      v.push(`tournament status is completed but the final match is ${final?.status ?? '<missing>'}`);
+    }
+  }
+
+  // ── T-INV-3 / D-3: no spurious winner-conflict logging ───────────────────
+  if (input.capturedLogs) {
+    const expected = input.expectedConflictLogs ?? 0;
+    const conflicts = input.capturedLogs.filter(
+      (l) => l.event === 'tournament_match_winner_conflict' || l.msg === 'tournament_match_winner_conflict',
+    );
+    if (conflicts.length !== expected) {
+      v.push(
+        `expected ${expected} tournament_match_winner_conflict log(s), found ${conflicts.length}`,
+      );
+    }
+  }
+
+  return v;
+}
+
+export function assertBracketConsistent(
+  input: BracketConsistencyInput,
+  context = 'bracket',
+): void {
+  const violations = collectBracketConsistencyViolations(input);
+  if (violations.length === 0) return;
+  throw new Error(
+    `[invariant:${context}] ${violations.length} bracket-consistency violation(s):\n` +
+      violations.map((s) => `  - ${s}`).join('\n'),
+  );
+}
+
+/** Convenience: assert against the `{ tournament, matches, regs }` store shape used by the testkit. */
+export function assertBracketConsistentForStore(
+  store: {
+    tournament: { id: string; status: string; winner_id: string | null };
+    matches: MatchRow[];
+    regs: RegistrationRow[];
+  },
+  opts?: { capturedLogs?: CapturedLog[]; expectedConflictLogs?: number; context?: string },
+): void {
+  assertBracketConsistent(
+    {
+      tournament: store.tournament,
+      matches: store.matches,
+      registrations: store.regs,
+      capturedLogs: opts?.capturedLogs,
+      expectedConflictLogs: opts?.expectedConflictLogs,
+    },
+    opts?.context,
+  );
+}

--- a/server/src/scheduledTournament/engine.test.ts
+++ b/server/src/scheduledTournament/engine.test.ts
@@ -47,6 +47,7 @@ import {
 } from './engine';
 import type { EnginePersistence } from './persistenceInterface';
 import { inMemoryMatchRpcForArrayStore, recordMatchResultForTest } from './inMemoryMatchRpc.testkit';
+import { assertBracketConsistentForStore } from './assertBracketConsistent.testkit';
 import type {
   MatchRow,
   RegistrationRow,
@@ -601,6 +602,8 @@ describe('full bracket lifecycle (8 players)', () => {
     expect(completed).toHaveLength(1);
     expect(completed[0].payload).toEqual({ tournamentId: 'tour-1', winnerId: 'u8' });
     expect(events.some((e) => e.event === 'tournament:round_completed' && (e.payload as any).round === 2)).toBe(true);
+
+    assertBracketConsistentForStore(store, { context: 'engine:full-lifecycle' });
   });
 
   it('applyMatchResult is idempotent — replay does not re-fire completed', async () => {
@@ -629,6 +632,12 @@ describe('full bracket lifecycle (8 players)', () => {
 
     expect(before).toBe(1);
     expect(after).toBe(1);
+
+    // Same-winner replay is not a conflict — no tournament_match_winner_conflict
+    // log should have fired (D-3). engine.test does not mock the logger, so this
+    // relies on the bracket-state checks; the log-count assertion is exercised
+    // directly in assertBracketConsistent.testkit.test.ts and live in PR-F.
+    assertBracketConsistentForStore(store, { context: 'engine:idempotent-replay' });
   });
 });
 


### PR DESCRIPTION
Step 5 (tests prove closure) / PR-E — the invariant-assertion helper §1.6 calls for. PR-F (concurrency + recovery harness) and PR-G (pg16 serialization script) both consume it, so it lands first.

## What

`server/src/scheduledTournament/assertBracketConsistent.testkit.ts`:
- `collectBracketConsistencyViolations(input) → string[]`
- `assertBracketConsistent(input, context?)` — throws a bulleted violation list (mirrors `assertValidGameState`)
- `assertBracketConsistentForStore(store, opts?)` — for the `{ tournament, matches, regs }` testkit store shape

Checks the **observable consequences** of the ratified invariants against a set of rows:

| Invariant | Check |
|---|---|
| T-INV-8 | 7 rows, 4/2/1 by round, unique `(round, match_number)` |
| T-INV-1/2 | `completed` ⇒ non-null `winner_id` that is a participant + `completed_at`; non-terminal ⇒ no `winner_id`/`completed_at` |
| T-INV-5 | each completed winner is in the correct round-(N+1) feeder slot (`_tournament_advance_target` mapping) |
| T-INV-6 | a target match is past `waiting` only if **both** feeders are terminal |
| T-INV-7 | no user is a participant in >1 `ready`/`in_progress` match |
| T-INV-10 | every human loser ⇒ reg `eliminated`; final done ⇒ tournament `completed` + `winner_id` set + champion reg `winner`/placement 1 + placements by exit round (2/3/3/5…) |
| **D-3** | given `capturedLogs`, no spurious `tournament_match_winner_conflict` entries (`expectedConflictLogs`, default 0) — per addition #2, the helper catches false-positive conflict logging, not just bracket corruption |

## Wiring

Into `engine.test.ts`'s two full-bracket tests (full-lifecycle + idempotent-replay). The reconciliation / partial-bracket tests get covered in PR-F where the harness builds full brackets on purpose.

## Verification
- 12 helper unit tests: one consistent-bracket pass, one per violation class, both directions of the conflict-log check
- `grep console.` clean · `tsc` clean
- Full server suite: **199 files / 1142 tests** (+12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)