### PR TITLE
feat(share): Wordle-style numbered emoji share cards (Daily Fritz + Puzzle Rush)

### DIFF
--- a/client/src/dailyFritz/DailyFritzLeaderboardScreen.tsx
+++ b/client/src/dailyFritz/DailyFritzLeaderboardScreen.tsx
@@ -368,7 +368,7 @@ export default function DailyFritzLeaderboardScreen({
     };
     if (typeof navigator !== 'undefined' && typeof navigator.share === 'function') {
       void navigator
-        .share({ title: 'Daily Fritz', text: resultShareText })
+        .share({ text: resultShareText })
         .then(() => {
           markShared();
         })

--- a/client/src/dailyFritz/buildDailyFritzSetOverlayViewModel.ts
+++ b/client/src/dailyFritz/buildDailyFritzSetOverlayViewModel.ts
@@ -259,6 +259,7 @@ export function buildDailyFritzSetOverlayViewModel(
       resultValue: setWonPlayer ? 'Victory' : 'Defeat',
       rankValue: formatOrdinalPlace(setOverlay.rank),
       shareDate: formatDateLabel(context.activeRunDate ?? context.todayRunDate ?? setOverlay.setResult.run_date ?? ''),
+      shareRunDate: context.activeRunDate ?? context.todayRunDate ?? setOverlay.setResult.run_date,
       shareTier: titleCaseTier(context.activeFritzTier ?? context.todayFritzTier ?? ''),
       shareRating: typeof profileRating === 'number' && Number.isFinite(profileRating) ? Math.round(profileRating) : undefined,
       shareStreak: context.todayStreak ?? 0,

--- a/client/src/dailyFritz/buildFinalOverlayViewModel.ts
+++ b/client/src/dailyFritz/buildFinalOverlayViewModel.ts
@@ -132,6 +132,7 @@ export function buildDailyFritzFinalOverlayViewModel({
     rankValue: ranked ? formatOrdinalPlace(rank) : null,
     rankShort: ranked ? formatOrdinal(rank) : null,
     shareDate: formatDateLabel(runDate),
+    shareRunDate: runDate,
     shareTier: titleCaseTier(fritzTier),
     shareRating,
     shareStreak,

--- a/client/src/dailyFritz/setOverlayViewModel.ts
+++ b/client/src/dailyFritz/setOverlayViewModel.ts
@@ -38,6 +38,7 @@ export interface DailyFritzSetOverlayViewModel {
   /** Bare ordinal rank for the dossier stat grid, e.g. "1st". */
   rankShort?: string | null;
   shareDate?: string;
+  shareRunDate?: string;
   shareTier?: string;
   shareRating?: number;
   shareStreak?: number;

--- a/client/src/dailyFritz/shareCard.ts
+++ b/client/src/dailyFritz/shareCard.ts
@@ -1,40 +1,47 @@
-import { buildShareGridRow, pointsShare } from '../lib/shareGrid';
 import type { DailyFritzSetGameNumber } from './api';
 
 const SET_GAME_NUMBERS: DailyFritzSetGameNumber[] = [1, 2, 3];
+const DAILY_FRITZ_LAUNCH_DATE = new Date('2026-04-10');
 
 import { SITE_DOMAIN } from '../lib/siteUrl';
 import type { DailyFritzSetOverlayViewModel } from './setOverlayViewModel';
 
-export function buildShareText(vm: DailyFritzSetOverlayViewModel): string {
-  const date = vm.shareDate ?? '';
-  const result = vm.resultValue ?? '';
-  const tier = vm.shareTier?.trim() || 'Fritz';
-  const margin = vm.marginValue ?? '';
-  const rating = vm.shareRating ? `${vm.shareRating} rating` : '';
-  const streak = vm.shareStreak ? `${vm.shareStreak}-day streak` : '';
+function calculatePuzzleNumber(runDate: string): number {
+  const date = new Date(`${runDate}T00:00:00Z`);
+  if (Number.isNaN(date.getTime())) return 1;
+  const daysSinceLaunch = Math.floor(
+    (date.getTime() - DAILY_FRITZ_LAUNCH_DATE.getTime()) / (1000 * 60 * 60 * 24)
+  );
+  return Math.max(1, daysSinceLaunch + 1);
+}
 
-  // Three rows always, so the block is the same height whether the set went two
-  // games or three — an unplayed decider reads as unplayed, not as absent.
+function buildEmojiGrid(vm: DailyFritzSetOverlayViewModel): string {
   const byNumber = new Map((vm.games ?? []).map((game) => [game.gameNumber, game] as const));
-  const gameLines = SET_GAME_NUMBERS
+  const emojis = SET_GAME_NUMBERS
     .map((gameNumber) => {
       const game = byNumber.get(gameNumber);
-      if (!game) return buildShareGridRow(null, 'none');
+      if (!game) return '⬜';
       const won = game.playerScore > game.fritzScore;
-      const tone = game.skunk && won ? 'skunk' : won ? 'win' : 'loss';
-      return buildShareGridRow(pointsShare(game.playerScore, game.fritzScore), tone);
+      return won ? '🟩' : '🟥';
     })
-    .join('\n');
+    .join('');
+  return emojis;
+}
 
-  const lines = [
-    `Daily Fritz · ${date}`,
-    `${result} vs ${tier} Fritz`,
-    gameLines,
-    `${margin} margin${rating ? ' · ' + rating : ''}`,
-    streak,
+export function buildShareText(vm: DailyFritzSetOverlayViewModel): string {
+  const runDate = vm.shareRunDate ?? '';
+  const margin = vm.marginValue ?? '';
+  const streak = vm.shareStreak ? `${vm.shareStreak} day streak` : '';
+  const puzzleNumber = calculatePuzzleNumber(runDate);
+
+  const emojiGrid = buildEmojiGrid(vm);
+  const statLine = [margin, streak].filter(Boolean).join(' · ');
+
+  return [
+    `Racehorse Daily Fritz #${puzzleNumber}`,
+    emojiGrid,
+    '',
+    statLine,
     SITE_DOMAIN,
-  ].filter(Boolean);
-
-  return lines.join('\n');
+  ].filter(Boolean).join('\n');
 }

--- a/client/src/puzzleRush/PuzzleRushLeaderboardScreen.tsx
+++ b/client/src/puzzleRush/PuzzleRushLeaderboardScreen.tsx
@@ -1,10 +1,13 @@
-import { useEffect, useMemo, useState } from 'react';
+import { track } from '../lib/analytics';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { GlobalNav } from '../components';
 import FilterPills from '../social/hub/FilterPills';
 import { avatarHue, getInitials } from '../components/hub/playerInitialsAvatarUtils';
 import { formatCountdownHms, secondsUntilNextPacificMidnight } from '../dailyFritz/format';
 import type { AppMode } from '../types';
 import { fetchPuzzleRushLeaderboard } from './api';
+import { calculatePuzzleNumber } from './rushShareCard';
+import { SITE_DOMAIN } from '../lib/siteUrl';
 import type { PuzzleRushLeaderboardEntry, PuzzleRushLeaderboardResponse } from './types';
 // Fritz's board depends on all three, in this order: the tokens the dfl-*
 // rules reference, then the rh-hub-* page/panel/FilterPills layout, then the
@@ -158,6 +161,7 @@ export function PuzzleRushLeaderboardScreen({
   const [loading, setLoading] = useState(true);
   const [filter, setFilter] = useState<Filter>('today');
   const [resetSeconds, setResetSeconds] = useState(() => secondsUntilNextPacificMidnight(new Date()));
+  const [shareDone, setShareDone] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -196,6 +200,42 @@ export function PuzzleRushLeaderboardScreen({
     [rows],
   );
 
+  const shareText = useMemo(() => {
+    if (filter !== 'today' || !data?.personalBest) return '';
+    const puzzleNumber = calculatePuzzleNumber(data.runDate);
+    const emojiBoxes = Array(data.personalBest.puzzlesSolved).fill('🟩').join('');
+    return [
+      `Racehorse Puzzle Rush #${puzzleNumber}`,
+      emojiBoxes,
+      '',
+      `${data.personalBest.puzzlesSolved} solved`,
+      SITE_DOMAIN,
+    ].filter(Boolean).join('\n');
+  }, [data, filter]);
+
+  const handleShareResult = useCallback(() => {
+    if (!shareText) return;
+    track('share_initiated', { mode: 'puzzle_rush', context: 'leaderboard' });
+    const markShared = (): void => {
+      setShareDone(true);
+      window.setTimeout(() => setShareDone(false), 2000);
+    };
+    if (typeof navigator !== 'undefined' && typeof navigator.share === 'function') {
+      void navigator
+        .share({ title: 'Puzzle Rush', text: shareText })
+        .then(() => {
+          markShared();
+        })
+        .catch(() => {
+          /* user dismissed native share */
+        });
+      return;
+    }
+    void navigator.clipboard.writeText(shareText).then(() => {
+      markShared();
+    });
+  }, [shareText]);
+
   return (
     <div className="rh-hub-screen dfl-page pr-board">
       <div className="rh-hub-shell">
@@ -219,6 +259,15 @@ export function PuzzleRushLeaderboardScreen({
                     <span aria-hidden>←</span>
                     Puzzle Rush
                   </button>
+                  {filter === 'today' && data?.personalBest ? (
+                    <button
+                      type="button"
+                      className="dfl-btn dfl-btn--accent"
+                      onClick={handleShareResult}
+                    >
+                      {shareDone ? 'Copied' : 'Share Result'}
+                    </button>
+                  ) : null}
                 </div>
               </header>
 

--- a/client/src/puzzleRush/RushResultsView.tsx
+++ b/client/src/puzzleRush/RushResultsView.tsx
@@ -75,17 +75,13 @@ export function RushResultsView({
       shareable
         ? buildRushShareText({
             score: serverScore,
-            solved,
-            stages: stageRows.map(({ stage, done, total }) => ({
-              label: stage.label,
-              done,
-              total,
-            })),
+            solved: solved ?? 0,
+            puzzles: results.map((r) => ({ solved: r.solved })),
             secondsBanked,
-            playedAt: completion?.run.endedAt ?? completion?.run.startedAt ?? null,
+            runDate: completion?.run.runDate,
           })
         : '',
-    [shareable, serverScore, solved, stageRows, secondsBanked, completion],
+    [shareable, serverScore, solved, results, secondsBanked, completion],
   );
 
   const [shareDone, setShareDone] = useState(false);

--- a/client/src/puzzleRush/puzzleRushRun.test.tsx
+++ b/client/src/puzzleRush/puzzleRushRun.test.tsx
@@ -427,7 +427,9 @@ describe('results', () => {
       share!.click();
     });
     expect(writeText).toHaveBeenCalledTimes(1);
-    expect(writeText.mock.calls[0][0]).toContain('870 pts');
+    // The share card is the numbered emoji-grid format, not a bare "N pts" line.
+    expect(writeText.mock.calls[0][0]).toContain('Racehorse Puzzle Rush #');
+    expect(writeText.mock.calls[0][0]).toContain('solved');
     unmount();
   });
 

--- a/client/src/puzzleRush/rushShareCard.test.ts
+++ b/client/src/puzzleRush/rushShareCard.test.ts
@@ -1,65 +1,98 @@
 import { describe, it, expect } from 'vitest';
 import { buildRushShareText } from './rushShareCard';
 import { SITE_DOMAIN } from '../lib/siteUrl';
-import { buildShareGridRow } from '../lib/shareGrid';
-
-const STAGES = [
-  { label: 'Warm-Up', done: 2, total: 3 },
-  { label: 'Building', done: 0, total: 5 },
-  { label: 'Master', done: 0, total: 7 },
-];
 
 describe('buildRushShareText', () => {
-  it('leads with the score and solved count, then every stage', () => {
+  it('shows puzzle number, one emoji per puzzle, solve count, and time', () => {
     const text = buildRushShareText({
       score: 250,
       solved: 2,
-      stages: STAGES,
+      puzzles: [
+        { solved: true },
+        { solved: false },
+        { solved: true },
+      ],
       secondsBanked: 2,
-      playedAt: '2026-08-27T22:12:00.000Z',
+      runDate: '2026-08-31',
     });
-    expect(text).toContain('250 pts · 2 solved');
-    // Warm-Up is 2 of 3, so a partly-filled row; the two untouched stages read
-    // as unplayed rather than as failures.
-    expect(text).toContain(buildShareGridRow(2 / 3, 'win'));
-    expect(text.split('\n').filter((line) => line.startsWith('⬜'))).toHaveLength(2);
-    expect(text).toContain('+2s banked');
-    expect(text.endsWith(SITE_DOMAIN)).toBe(true);
+    expect(text).toContain('Racehorse Puzzle Rush #144');
+    expect(text).toContain('🟩🟥🟩');
+    expect(text).toContain('2 solved');
+    expect(text).toContain('2s');
+    expect(text).toContain(SITE_DOMAIN);
   });
 
-  it('marks a fully cleared stage as exceptional', () => {
+  it('formats minutes and seconds correctly', () => {
     const text = buildRushShareText({
-      score: 900, solved: 15, secondsBanked: 0,
-      stages: [{ label: 'Warm-Up', done: 3, total: 3 }],
+      score: 900,
+      solved: 7,
+      puzzles: [
+        { solved: true },
+        { solved: true },
+        { solved: true },
+        { solved: true },
+        { solved: true },
+        { solved: true },
+        { solved: true },
+      ],
+      secondsBanked: 125, // 2m 5s
+      runDate: '2026-08-31',
     });
-    expect(text).toContain(buildShareGridRow(1, 'skunk'));
+    expect(text).toContain('2m 5s');
   });
 
-  it('omits the solve count when the server did not report one', () => {
-    const text = buildRushShareText({ score: 250, solved: null, stages: STAGES, secondsBanked: 0 });
-    expect(text).toContain('250 pts');
-    expect(text).not.toContain('solved');
-  });
-
-  it('drops the banked line when nothing was banked', () => {
-    const text = buildRushShareText({ score: 250, solved: 2, stages: STAGES, secondsBanked: 0 });
-    expect(text).not.toContain('banked');
-  });
-
-  it('falls back to a bare title when the run has no usable timestamp', () => {
-    for (const playedAt of [null, undefined, 'not-a-date']) {
-      const text = buildRushShareText({ score: 10, solved: 1, stages: [], secondsBanked: 0, playedAt });
-      expect(text.split('\n')[0]).toBe('Puzzle Rush');
-    }
-  });
-
-  it('omits stages that served no puzzles in this run', () => {
+  it('omits time when no bonuses earned', () => {
     const text = buildRushShareText({
       score: 250,
       solved: 2,
-      stages: [...STAGES, { label: 'Unused', done: 0, total: 0 }],
+      puzzles: [
+        { solved: true },
+        { solved: false },
+      ],
+      secondsBanked: 0,
+      runDate: '2026-08-31',
+    });
+    // Should only show solve count, no time bonuses
+    const lines = text.split('\n');
+    expect(lines[2]).toBe('2 solved');
+    expect(text).not.toMatch(/\d+[ms]\s/); // No "5s " or "2m " pattern
+  });
+
+  it('calculates puzzle number from run_date', () => {
+    const text = buildRushShareText({
+      score: 10,
+      solved: 1,
+      puzzles: [{ solved: true }],
+      secondsBanked: 0,
+      runDate: '2026-04-10',
+    });
+    expect(text).toContain('#1');
+  });
+
+  it('defaults to puzzle #1 when run_date is missing', () => {
+    const text = buildRushShareText({
+      score: 10,
+      solved: 1,
+      puzzles: [{ solved: true }],
       secondsBanked: 0,
     });
-    expect(text).not.toContain('Unused');
+    expect(text).toContain('#1');
+  });
+
+  it('handles max-length run (15 puzzles) without truncation', () => {
+    const puzzles = Array(15).fill(null).map((_, i) => ({ solved: i < 13 }));
+    const text = buildRushShareText({
+      score: 1200,
+      solved: 13,
+      puzzles,
+      secondsBanked: 45,
+      runDate: '2026-08-31',
+    });
+    const emojiLine = text.split('\n')[1];
+    const greenCount = (emojiLine.match(/🟩/g) ?? []).length;
+    const redCount = (emojiLine.match(/🟥/g) ?? []).length;
+    expect(greenCount).toBe(13);
+    expect(redCount).toBe(2);
+    expect(text).toContain('13 solved');
   });
 });

--- a/client/src/puzzleRush/rushShareCard.ts
+++ b/client/src/puzzleRush/rushShareCard.ts
@@ -1,61 +1,66 @@
-import { buildShareGridRow } from '../lib/shareGrid';
 import { SITE_DOMAIN } from '../lib/siteUrl';
+
+const PUZZLE_RUSH_LAUNCH_DATE = new Date('2026-04-10');
+
 /**
  * Share text for a finished Puzzle Rush run.
  *
- * Mirrors Daily Fritz's share card (see dailyFritz/shareCard.ts): the headline
- * facts, then the per-stage breakdown, then the site. Only what the run
- * actually earned goes in — a line is dropped rather than padded with a dash.
+ * Puzzle number, one emoji per puzzle attempted (🟩 = solved, 🟥 = missed/skipped),
+ * solve count, and site URL.
  */
 
-export interface RushShareStage {
-  label: string;
-  done: number;
-  total: number;
+export interface RushSharePuzzle {
+  /** Whether this puzzle was solved (true) or missed/skipped (false). */
+  solved: boolean;
 }
 
 export interface RushShareInput {
   /** The server's replayed total. The only score worth sharing. */
   score: number;
-  /** Null when the server did not report a solve count for the run. */
-  solved: number | null;
-  stages: RushShareStage[];
+  /** Server's actual solve count for the run. */
+  solved: number;
+  /** Per-puzzle result (ordinal order). */
+  puzzles: RushSharePuzzle[];
+  /** Seconds gained from time bonuses. */
   secondsBanked: number;
-  /** ISO timestamp the run ended, for the date line. */
-  playedAt?: string | null;
+  /** YYYY-MM-DD run date for puzzle numbering. */
+  runDate?: string;
 }
 
-function formatShareDate(iso: string | null | undefined): string | null {
-  if (!iso) return null;
-  const parsed = new Date(iso);
-  if (Number.isNaN(parsed.getTime())) return null;
-  return parsed.toLocaleDateString(undefined, {
-    month: 'short',
-    day: 'numeric',
-    year: 'numeric',
-  });
+export function calculatePuzzleNumber(runDate: string | undefined): number {
+  if (!runDate) return 1;
+  const date = new Date(`${runDate}T00:00:00Z`);
+  if (Number.isNaN(date.getTime())) return 1;
+  const daysSinceLaunch = Math.floor(
+    (date.getTime() - PUZZLE_RUSH_LAUNCH_DATE.getTime()) / (1000 * 60 * 60 * 24)
+  );
+  return Math.max(1, daysSinceLaunch + 1);
+}
+
+function buildEmojiRow(puzzles: RushSharePuzzle[]): string {
+  return puzzles.map((p) => (p.solved ? '🟩' : '🟥')).join('');
+}
+
+function formatTime(secondsBanked: number): string {
+  if (secondsBanked <= 0) return '';
+  const minutes = Math.floor(secondsBanked / 60);
+  const seconds = secondsBanked % 60;
+  if (minutes > 0) return `${minutes}m ${seconds}s`;
+  return `${seconds}s`;
 }
 
 export function buildRushShareText(input: RushShareInput): string {
-  const date = formatShareDate(input.playedAt);
-  const stageLines = input.stages
-    .filter((stage) => stage.total > 0)
-    .map((stage) =>
-      stage.done === 0
-        ? buildShareGridRow(null, 'none')
-        : buildShareGridRow(stage.done / stage.total, stage.done === stage.total ? 'skunk' : 'win'),
-    )
-    .join('\n');
+  const puzzleNumber = calculatePuzzleNumber(input.runDate);
+  const emojiRow = buildEmojiRow(input.puzzles);
+  const solveText = `${input.solved} solved`;
+  const timeText = formatTime(input.secondsBanked);
+  const statLine = [solveText, timeText].filter(Boolean).join(' · ');
 
-  const lines = [
-    date ? `Puzzle Rush · ${date}` : 'Puzzle Rush',
-    input.solved === null
-      ? `${input.score} pts`
-      : `${input.score} pts · ${input.solved} solved`,
-    stageLines,
-    input.secondsBanked > 0 ? `+${input.secondsBanked}s banked` : '',
+  return [
+    `Racehorse Puzzle Rush #${puzzleNumber}`,
+    emojiRow,
+    '',
+    statLine,
     SITE_DOMAIN,
-  ].filter(Boolean);
-
-  return lines.join('\n');
+  ].filter(Boolean).join('\n');
 }

--- a/client/src/puzzleRush/types.ts
+++ b/client/src/puzzleRush/types.ts
@@ -56,6 +56,7 @@ export interface PuzzleRushRun {
   clientReportedScore: number;
   invalidatedReason: string | null;
   configVersion: number;
+  runDate?: string;
 }
 
 export interface PuzzleRushClockConfig {


### PR DESCRIPTION
Recovered from the closed **PR #100** (commit `8649dbbf`) — the one salvageable idea from that pile, shipped as a focused, green, **share-text-only** change.

## Daily Fritz — `dailyFritz/shareCard.ts`

```
Racehorse Daily Fritz #146
🟩🟥🟩

+40 margin · 18 day streak
playracehorse.com
```

- one square per game (🟩 won / 🟥 lost / ⬜ unplayed), replacing the 10-wide points bar
- puzzle number from a `2026-04-10` launch date
- `shareRunDate` threaded through `buildDailyFritzSetOverlayViewModel` / `buildFinalOverlayViewModel` / `setOverlayViewModel`
- drops the now-unused `shareGrid` import (`shareGrid` itself stays — `dailyPuzzle/ladderShareCard` still uses it)

## Puzzle Rush — `puzzleRush/rushShareCard.ts`

```
Racehorse Puzzle Rush #144
🟩🟩🟩🟩🟩🟥

6 solved · 45s
playracehorse.com
```

- one square per puzzle attempted, solve count + time bonus
- `calculatePuzzleNumber` exported and reused by the leaderboard **Share Result** button — it was a duplicated in-component `new Date()`, which is the lint-budget warning that made PR #100 red; hoisted here
- `RushResultsView` keeps its current design (AnimatedScore, `pr-results`, `<Button>` primitives, every `data-ui` hook) — only its `buildRushShareText` call is updated to the new signature

## NOT in this PR — the Puzzle Rush results-screen dossier

You asked for this too. As recovered from PR #100, the `.prd` dossier rewrite of `RushResultsView` replaces the `<Button>` primitives with raw `<button>` elements and a hand-rolled `.prd` CSS namespace — which conflicts with the binding rules in `client/CLAUDE.md` ("Never use a raw `<button>` element for a user-facing action", "Class names for new components use the `rh-` prefix", "check if a primitive exists"). Restoring it verbatim would regress the current compliant version. It needs a proper design pass (adapt to `<Button>` / `GlassCard` / tokens), not a `git checkout` — flagged for that.

## Verification
- client `tsc -b` + `npm run build`: clean
- full client suite: **216 files / 1484 tests**
- server suite (imports client source): 200 / 1148, unaffected
- lint budget: **401**, unchanged from `main`
- `grep console.` on touched files: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)