### PR TITLE
test(tournament): local pg16 DB verification script (Step 5 / PR-G)

### DIFF
--- a/docs/ops/tournament-db-verify.md
+++ b/docs/ops/tournament-db-verify.md
@@ -1,0 +1,105 @@
+# tournament-db-verify
+
+`scripts/tournament-db-verify.sh` — a **local-only** verification of the
+tournament database layer. Step 5 / PR-G of the tournament hardening plan.
+
+## Why it is not in CI
+
+CI has no PostgreSQL service and no migration runner. That gap is the reason
+three reviewed lockdown migrations sat unapplied in this repo before anyone
+noticed (T-1, the ghost/bot RLS tables, the `commit_glicko` RPC — see
+`HARDENING_PLAN.md` → "Infra / liveness"). The weekly `security-posture.yml`
+workflow catches the *consequences* against prod; this script verifies the
+*mechanics* against a fresh database. Run it:
+
+- before merging a PR that changes any `supabase/migrations/*tournament*` file,
+  `2026-08-31_tournament_match_rpcs.sql`, or the RLS lockdown migration
+- when touching `complete_tournament_match` / `promote_tournament_match` /
+  `generate_tournament_bracket`
+- if you just want to know the tournament schema still stands up greenfield
+
+## Prerequisites
+
+PostgreSQL 16 on `PATH` (or at `/opt/homebrew/opt/postgresql@16/bin`):
+
+```
+brew install postgresql@16
+```
+
+The script does **not** need a running server — it spins its own throwaway
+instance in a temp directory (`initdb` + `pg_ctl` on a random high port and a
+private socket), and deletes it on exit.
+
+## Run
+
+```
+bash scripts/tournament-db-verify.sh
+```
+
+Exit 0 + `ALL CHECKS PASSED` on success; non-zero with a `FAIL` line otherwise.
+
+## The prod-safety boundary
+
+This script **cannot reach production**:
+
+- It creates and uses only its own temp `initdb` instance. Every `psql` call
+  targets that instance's private socket.
+- There is no code path that reads `server/.env`, `client/.env`,
+  `SUPABASE_URL`, `VITE_SUPABASE_URL`, or any `postgres://` / `*.supabase.co`
+  string.
+- It **aborts (exit 2)** before doing anything if `PGHOST` / `PGHOSTADDR` /
+  `PGURL` / `PGURI` / `DATABASE_URL` / `SUPABASE_*_URL` is set to a URL or a
+  Supabase host, or if any argument looks like a remote connection target.
+- The one destructive step (§4 below — `alter table … disable row level
+  security`) runs against the throwaway instance and is re-enabled two
+  statements later.
+
+## What it checks
+
+1. **Greenfield apply.** A Supabase shim (`scripts/tournament-db-verify/shim.sql`
+   — `auth` schema, `auth.users`, `auth.uid()`, the `anon` / `authenticated` /
+   `service_role` roles) plus the curated tournament migration chain, applied
+   in order to a fresh pg16. The `2026-08-30` RLS lockdown migration
+   self-asserts as part of this — if a client-writable policy or grant would
+   survive, it raises and rolls back and the script fails.
+
+   The chain is a **curated subset**, not the full 42-file history (which needs
+   more of Supabase than a shim provides). It is the list in `CHAIN=( … )` in
+   the script — add a line when a new migration touches the tournament tables,
+   the RPCs, or the registrations RLS.
+
+2. **`SELECT … FOR UPDATE` serialization.** Two `psql` sessions call
+   `complete_tournament_match()` on the same match row with **different
+   winners**. Session A holds its transaction open; session B blocks on A's row
+   lock until A commits (measured — B must wait ≥ 1s), then takes the
+   idempotent/conflict branch (`applied:false`, `conflict:true`, recorded
+   winner = A's). The bracket is then asserted to show exactly one completion
+   and one advancement, loser eliminated once.
+
+   This guards against the **T-3 / T-4** bug — double bracket advancement,
+   wrong champion, un-eliminated loser — recurring if the row lock in
+   `complete_tournament_match` is ever weakened or bypassed. The JS in-memory
+   port (`inMemoryMatchRpc.testkit.ts`, exercised by
+   `concurrencyRecoveryHarness.test.ts`) cannot cover this: Node's event loop
+   serializes it for free.
+
+3. **RLS registrations lockdown.** The three diagnostics from
+   `supabase/tests/rls_registrations_lockdown.sql` run against the
+   freshly-migrated schema — 0 client-writable policies, 0 client write grants,
+   RLS enabled.
+
+4. **`assert_security_posture()` catches a planted violation.** On the clean
+   schema it returns `hard_fail_count = 0`; after
+   `alter table public.scheduled_tournament_matches disable row level security`
+   it returns `hard_fail_count = 1` naming that table with `rls_disabled`;
+   after re-enabling, `0` again. This is the runtime check the drift detector's
+   unit test (`server/src/securityPostureRpc.test.ts`, text-only, no Postgres)
+   defers to here.
+
+## Related
+
+- `supabase/tests/rls_registrations_lockdown.sql` — the same three RLS
+  diagnostics as a standalone artifact to paste into the Supabase SQL editor
+  against **prod**.
+- `.github/workflows/security-posture.yml` — weekly `assert_security_posture()`
+  against prod.

--- a/scripts/tournament-db-verify.sh
+++ b/scripts/tournament-db-verify.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+#
+# tournament-db-verify.sh — local-only verification of the tournament DB layer.
+#
+# LOCAL ONLY. This script spins its OWN throwaway PostgreSQL 16 instance in a
+# temp directory, does everything against that, and deletes it on exit. It has
+# NO code path that reads server/.env, client/.env, SUPABASE_URL,
+# VITE_SUPABASE_URL, or any postgres:// / *.supabase.co connection string, and
+# it aborts if one is present in the environment or arguments. Nothing here can
+# reach production.
+#
+# It is NOT run in CI (there is no Postgres service and no migration runner —
+# that gap is exactly why this exists as a manual check). See
+# docs/ops/tournament-db-verify.md.
+#
+# What it proves:
+#   1. Greenfield apply — the curated tournament migration chain applies
+#      cleanly, in order, to a fresh pg16 (the 2026-08-30 RLS lockdown
+#      self-asserts as part of this).
+#   2. FOR UPDATE serialization — two concurrent complete_tournament_match()
+#      calls on the same match row serialize: the second blocks until the first
+#      commits, then takes the idempotent/conflict branch. Guards against the
+#      T-3/T-4 double-advancement / wrong-champion / un-eliminated-loser bug
+#      recurring if the row lock is ever weakened.
+#   3. RLS registrations lockdown — the three diagnostics come back clean on
+#      the freshly-migrated schema.
+#   4. assert_security_posture() catches a planted RLS violation.
+
+set -euo pipefail
+
+# ── 0. refuse to run anywhere near a remote / Supabase target ────────────────
+for var in PGHOST PGHOSTADDR PGURL PGURI DATABASE_URL SUPABASE_URL SUPABASE_DB_URL VITE_SUPABASE_URL; do
+  val="${!var:-}"
+  if [[ -n "$val" && "$val" == *supabase* ]] || [[ -n "$val" && "$val" == *"://"* ]]; then
+    echo "ABORT: \$$var is set to a remote target ('$val'). This script is local-only." >&2
+    exit 2
+  fi
+done
+for arg in "$@"; do
+  if [[ "$arg" == *supabase* || "$arg" == *"://"* ]]; then
+    echo "ABORT: argument '$arg' looks like a remote connection target. Local-only." >&2
+    exit 2
+  fi
+done
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MIGRATIONS="$REPO_ROOT/supabase/migrations"
+HELPERS="$REPO_ROOT/scripts/tournament-db-verify"
+
+# ── 1. locate a pg16 toolchain ──────────────────────────────────────────────
+PGBIN=""
+for c in \
+  "$(command -v pg_ctl || true)" \
+  /opt/homebrew/opt/postgresql@16/bin/pg_ctl \
+  /usr/local/opt/postgresql@16/bin/pg_ctl \
+  /usr/lib/postgresql/16/bin/pg_ctl; do
+  if [[ -x "$c" ]] && "$c" --version 2>/dev/null | grep -q ' 16'; then
+    PGBIN="$(dirname "$c")"; break
+  fi
+done
+if [[ -z "$PGBIN" ]]; then
+  echo "ABORT: PostgreSQL 16 not found. brew install postgresql@16 (see docs/ops/tournament-db-verify.md)." >&2
+  exit 3
+fi
+echo "pg16 toolchain: $PGBIN"
+
+# ── 2. throwaway instance in a temp dir ─────────────────────────────────────
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/rh-dbverify.XXXXXX")"
+PGDATA="$WORK/data"
+SOCKDIR="$WORK/sock"
+PORT=$(( 20000 + RANDOM % 20000 ))
+mkdir -p "$SOCKDIR"
+
+cleanup() {
+  set +e
+  "$PGBIN/pg_ctl" -D "$PGDATA" -m immediate stop >/dev/null 2>&1
+  rm -rf "$WORK"
+}
+trap cleanup EXIT
+
+echo "initdb -> $PGDATA (port $PORT, socket $SOCKDIR)"
+"$PGBIN/initdb" -D "$PGDATA" -U postgres --auth=trust --no-sync -E UTF8 >/dev/null
+"$PGBIN/pg_ctl" -D "$PGDATA" -o "-p $PORT -k $SOCKDIR -c listen_addresses=''" -w start >/dev/null
+
+PSQL=( "$PGBIN/psql" -X -v ON_ERROR_STOP=1 -h "$SOCKDIR" -p "$PORT" -U postgres -d verify )
+RUN() { "${PSQL[@]}" "$@"; }
+Q()   { "${PSQL[@]}" -tAqc "$1"; }
+
+"$PGBIN/createdb" -h "$SOCKDIR" -p "$PORT" -U postgres verify
+
+pass() { echo "  PASS  $1"; }
+fail() { echo "  FAIL  $1" >&2; exit 1; }
+
+# ── 3. shim + curated migration chain (greenfield apply) ────────────────────
+echo
+echo "── 1/4  greenfield apply ─────────────────────────────────────────────"
+RUN -q -f "$HELPERS/shim.sql" >/dev/null
+pass "Supabase shim (auth schema, roles, auth.uid)"
+
+CHAIN=(
+  2026-05-14_scheduled_tournaments.sql
+  2026-05-14_auto_seed_tournaments.sql
+  2026-05-16_tournament_cadence_30_minutes.sql
+  2026-05-16_tournament_match_dispatch_fields.sql
+  2026-05-16_tournament_registration_placements.sql
+  2026-05-16_zz_tournament_bot_fill.sql
+  2026-05-17_tournament_registration_close_2_minutes.sql
+  2026-08-30_tournament_registration_rls_lockdown.sql
+  2026-08-31_tournament_match_rpcs.sql
+  2026-09-01_assert_security_posture_rpc.sql
+)
+for m in "${CHAIN[@]}"; do
+  [[ -f "$MIGRATIONS/$m" ]] || fail "migration missing from repo: $m"
+  if ! RUN -q -f "$MIGRATIONS/$m" >/dev/null 2>"$WORK/err"; then
+    echo "---- $m ----" >&2; cat "$WORK/err" >&2
+    fail "migration failed to apply: $m"
+  fi
+  pass "$m"
+done
+pass "2026-08-30 lockdown self-assertion did not roll back"
+
+# ── 4. two-session FOR UPDATE serialization ─────────────────────────────────
+echo
+echo "── 2/4  FOR UPDATE serialization ─────────────────────────────────────"
+RUN -q -f "$HELPERS/seed.sql" >/dev/null
+QF1="$(Q "select id from public.scheduled_tournament_matches where tournament_id='11111111-1111-4111-8111-111111111111' and round=1 and match_number=1")"
+[[ -n "$QF1" ]] || fail "seed did not produce QF1"
+pass "seeded 8-player bracket; QF1 = $QF1 (in_progress)"
+
+now() { python3 -c 'import time; print(time.time())'; }
+
+# Session A: complete QF1 as u1, then hold the transaction open ~3s before COMMIT.
+"$PGBIN/psql" -X -v ON_ERROR_STOP=1 -h "$SOCKDIR" -p "$PORT" -U postgres -d verify -q >/dev/null 2>&1 <<SQL_A &
+begin;
+select public.complete_tournament_match('$QF1'::uuid, '00000000-0000-4000-8000-000000000001', 'game_over', null, 30, 10, null, null, false, 'session-A');
+select pg_sleep(3);
+commit;
+SQL_A
+A_PID=$!
+
+sleep 1.5   # head start: session A's RPC finishes and it is sitting in pg_sleep(3), holding the row lock
+# Session B: try to complete the SAME match as a DIFFERENT winner (u8). Should block on A's row lock.
+B_START="$(now)"
+B_RESULT="$("$PGBIN/psql" -X -v ON_ERROR_STOP=1 -h "$SOCKDIR" -p "$PORT" -U postgres -d verify -tAqc \
+  "select public.complete_tournament_match('$QF1'::uuid, '00000000-0000-4000-8000-000000000008', 'game_over', null, 30, 20, null, null, false, 'session-B')")"
+B_END="$(now)"
+wait "$A_PID"
+
+B_WAIT="$(python3 -c "print(f'{$B_END - $B_START:.2f}')")"
+echo "  session B blocked for ${B_WAIT}s (session A held the row lock for ~1.5s more after B started)"
+python3 -c "import sys; sys.exit(0 if $B_WAIT >= 1.0 else 1)" \
+  || fail "session B did not block on session A's row lock (waited ${B_WAIT}s, expected >= 1s) — FOR UPDATE not serializing"
+pass "session B blocked until session A committed"
+
+echo "$B_RESULT" | grep -q '"applied" *: *false' || fail "session B result was not applied:false — got: $B_RESULT"
+echo "$B_RESULT" | grep -q '"conflict" *: *true'  || fail "session B result did not report conflict:true — got: $B_RESULT"
+echo "$B_RESULT" | grep -q '00000000-0000-4000-8000-000000000001' || fail "session B did not see u1 (session A's winner) as recorded — got: $B_RESULT"
+pass "session B took the idempotent/conflict branch (recorded winner = u1, applied:false, conflict:true)"
+
+# Bracket must reflect exactly one completion + one advancement.
+[[ "$(Q "select count(*) from public.scheduled_tournament_matches where tournament_id='11111111-1111-4111-8111-111111111111' and round=1 and match_number=1 and status='completed' and winner_id='00000000-0000-4000-8000-000000000001'")" == "1" ]] \
+  || fail "QF1 is not exactly one completed row with winner u1"
+[[ "$(Q "select player1_id from public.scheduled_tournament_matches where tournament_id='11111111-1111-4111-8111-111111111111' and round=2 and match_number=1")" == "00000000-0000-4000-8000-000000000001" ]] \
+  || fail "SF1.player1 is not u1 — advancement wrong or doubled"
+[[ "$(Q "select status from public.scheduled_tournament_registrations where tournament_id='11111111-1111-4111-8111-111111111111' and user_id='00000000-0000-4000-8000-000000000008'")" == "eliminated" ]] \
+  || fail "loser u8 not eliminated"
+[[ "$(Q "select status from public.scheduled_tournament_registrations where tournament_id='11111111-1111-4111-8111-111111111111' and user_id='00000000-0000-4000-8000-000000000001'")" != "eliminated" ]] \
+  || fail "winner u1 wrongly eliminated"
+pass "bracket consistent: one completion, one advancement, loser eliminated once"
+
+# ── 5. RLS registrations lockdown diagnostics ──────────────────────────────
+echo
+echo "── 3/4  RLS registrations lockdown ──────────────────────────────────"
+[[ "$(Q "select count(*) from pg_policies where schemaname='public' and tablename='scheduled_tournament_registrations' and cmd in ('INSERT','UPDATE','DELETE','ALL') and roles && array['anon','authenticated','public']::name[]")" == "0" ]] \
+  || fail "a client-writable policy survives on scheduled_tournament_registrations"
+[[ "$(Q "select count(*) from information_schema.role_table_grants where table_schema='public' and table_name='scheduled_tournament_registrations' and grantee in ('anon','authenticated','public') and privilege_type in ('INSERT','UPDATE','DELETE')")" == "0" ]] \
+  || fail "a client write grant survives on scheduled_tournament_registrations"
+[[ "$(Q "select relrowsecurity from pg_class where oid='public.scheduled_tournament_registrations'::regclass")" == "t" ]] \
+  || fail "RLS is not enabled on scheduled_tournament_registrations"
+pass "0 client-writable policies, 0 client write grants, RLS on"
+
+# ── 6. assert_security_posture() catches a planted violation ───────────────
+echo
+echo "── 4/4  assert_security_posture() ───────────────────────────────────"
+[[ "$(Q "select assert_security_posture()->>'hard_fail_count'")" == "0" ]] \
+  || fail "assert_security_posture() reports a hard failure on a clean schema"
+pass "clean schema -> hard_fail_count = 0"
+
+RUN -qc "alter table public.scheduled_tournament_matches disable row level security" >/dev/null
+PLANTED="$(Q "select assert_security_posture()")"
+RUN -qc "alter table public.scheduled_tournament_matches enable row level security" >/dev/null
+
+echo "$PLANTED" | grep -q '"hard_fail_count" *: *1' || fail "planted RLS-off violation not caught (got: $PLANTED)"
+echo "$PLANTED" | grep -q 'scheduled_tournament_matches' || fail "planted violation did not name the table"
+echo "$PLANTED" | grep -q 'rls_disabled' || fail "planted violation not classified rls_disabled"
+pass "planted 'RLS disabled' -> hard_fail_count = 1, names public.scheduled_tournament_matches"
+[[ "$(Q "select assert_security_posture()->>'hard_fail_count'")" == "0" ]] || fail "re-enable did not clear the violation"
+pass "re-enable -> hard_fail_count = 0"
+
+echo
+echo "════════════════════════════════════════════════════════════════════════"
+echo "  tournament-db-verify: ALL CHECKS PASSED"
+echo "════════════════════════════════════════════════════════════════════════"

--- a/scripts/tournament-db-verify/seed.sql
+++ b/scripts/tournament-db-verify/seed.sql
@@ -1,0 +1,51 @@
+-- Seed a full 8-player bracket for the two-session FOR UPDATE test.
+-- Runs against the throwaway DB only.
+
+\set ON_ERROR_STOP on
+
+insert into auth.users (id)
+select ('00000000-0000-4000-8000-00000000000' || g)::uuid
+from generate_series(1, 8) g;
+
+insert into public.scheduled_tournaments (id, scheduled_start, registration_open_at, registration_close_at, status)
+values (
+  '11111111-1111-4111-8111-111111111111',
+  now() - interval '5 min', now() - interval '35 min', now() - interval '7 min',
+  'registration_open'
+);
+
+insert into public.scheduled_tournament_registrations (tournament_id, user_id)
+select '11111111-1111-4111-8111-111111111111',
+       ('00000000-0000-4000-8000-00000000000' || g)::uuid
+from generate_series(1, 8) g;
+
+-- generate the bracket (QF1..4 waiting, SF1/2 + Final waiting, tournament -> in_progress)
+select public.generate_tournament_bracket(
+  '11111111-1111-4111-8111-111111111111',
+  jsonb_build_array(
+    jsonb_build_object('match_number', 1, 'player1_id', '00000000-0000-4000-8000-000000000001', 'player2_id', '00000000-0000-4000-8000-000000000008'),
+    jsonb_build_object('match_number', 2, 'player1_id', '00000000-0000-4000-8000-000000000004', 'player2_id', '00000000-0000-4000-8000-000000000005'),
+    jsonb_build_object('match_number', 3, 'player1_id', '00000000-0000-4000-8000-000000000003', 'player2_id', '00000000-0000-4000-8000-000000000006'),
+    jsonb_build_object('match_number', 4, 'player1_id', '00000000-0000-4000-8000-000000000002', 'player2_id', '00000000-0000-4000-8000-000000000007')
+  ),
+  jsonb_build_array(
+    jsonb_build_object('user_id', '00000000-0000-4000-8000-000000000001', 'seed', 1),
+    jsonb_build_object('user_id', '00000000-0000-4000-8000-000000000008', 'seed', 8),
+    jsonb_build_object('user_id', '00000000-0000-4000-8000-000000000004', 'seed', 4),
+    jsonb_build_object('user_id', '00000000-0000-4000-8000-000000000005', 'seed', 5),
+    jsonb_build_object('user_id', '00000000-0000-4000-8000-000000000003', 'seed', 3),
+    jsonb_build_object('user_id', '00000000-0000-4000-8000-000000000006', 'seed', 6),
+    jsonb_build_object('user_id', '00000000-0000-4000-8000-000000000002', 'seed', 2),
+    jsonb_build_object('user_id', '00000000-0000-4000-8000-000000000007', 'seed', 7)
+  ),
+  'db-verify'
+);
+
+-- drive QF1 (round 1, match 1) to in_progress so a game_over completion is valid
+select public.promote_tournament_match(id, 'ready', now(), now() + interval '2 min', 'QFONE', null, 'db-verify')
+from public.scheduled_tournament_matches
+where tournament_id = '11111111-1111-4111-8111-111111111111' and round = 1 and match_number = 1;
+
+select public.promote_tournament_match(id, 'in_progress', null, null, null, now(), 'db-verify')
+from public.scheduled_tournament_matches
+where tournament_id = '11111111-1111-4111-8111-111111111111' and round = 1 and match_number = 1;

--- a/scripts/tournament-db-verify/shim.sql
+++ b/scripts/tournament-db-verify/shim.sql
@@ -1,0 +1,39 @@
+-- Minimal Supabase stand-in for a throwaway local pg16 database.
+--
+-- The tournament migration chain references auth.users, auth.uid(), and the
+-- anon / authenticated / service_role roles. Supabase provisions these; a
+-- vanilla pg16 cluster does not. This is the smallest shim that lets the
+-- chain apply and exercises the RLS + FOR UPDATE behaviour we care about.
+-- It is NOT a faithful Supabase reproduction.
+
+create extension if not exists pgcrypto;
+
+-- Roles (no login — they only exist so GRANT / policy TO clauses resolve).
+do $$
+begin
+  if not exists (select 1 from pg_roles where rolname = 'anon') then create role anon nologin; end if;
+  if not exists (select 1 from pg_roles where rolname = 'authenticated') then create role authenticated nologin; end if;
+  if not exists (select 1 from pg_roles where rolname = 'service_role') then create role service_role nologin bypassrls; end if;
+end $$;
+
+grant usage on schema public to anon, authenticated, service_role;
+alter default privileges in schema public grant all on tables to service_role;
+
+-- auth schema + a stub users table (only `id` is referenced by FKs).
+create schema if not exists auth;
+create table if not exists auth.users (
+  id uuid primary key default gen_random_uuid(),
+  email text
+);
+grant usage on schema auth to anon, authenticated, service_role;
+
+-- auth.uid() — Supabase reads the JWT `sub` claim from a GUC. Here it reads a
+-- plain session GUC so the FOR UPDATE test can impersonate a user with
+--   set local request.jwt.claim.sub = '<uuid>';
+create or replace function auth.uid()
+returns uuid
+language sql
+stable
+as $$
+  select nullif(current_setting('request.jwt.claim.sub', true), '')::uuid;
+$$;

--- a/supabase/tests/rls_registrations_lockdown.sql
+++ b/supabase/tests/rls_registrations_lockdown.sql
@@ -1,0 +1,30 @@
+-- Runbook artifact — paste into the Supabase SQL editor against production to
+-- confirm the scheduled_tournament_registrations write lockdown (gap T-1,
+-- migration 2026-08-30_tournament_registration_rls_lockdown.sql) is actually
+-- applied. Each query must return ZERO rows / the expected value.
+--
+-- This is the manual counterpart to assert_security_posture() — kept because
+-- the T-1 lockdown was reviewed and merged but sat unapplied for weeks, and
+-- because there is no CI migration runner. Re-run after any migration that
+-- touches this table.
+
+-- 1. No client-writable policy survives (expect 0 rows).
+select policyname, cmd, roles
+  from pg_policies
+ where schemaname = 'public'
+   and tablename  = 'scheduled_tournament_registrations'
+   and cmd in ('INSERT', 'UPDATE', 'DELETE', 'ALL')
+   and roles && array['anon', 'authenticated', 'public']::name[];
+
+-- 2. No client INSERT/UPDATE/DELETE grant survives (expect 0 rows).
+select grantee, privilege_type
+  from information_schema.role_table_grants
+ where table_schema = 'public'
+   and table_name   = 'scheduled_tournament_registrations'
+   and grantee in ('anon', 'authenticated', 'public')
+   and privilege_type in ('INSERT', 'UPDATE', 'DELETE');
+
+-- 3. Row level security is enabled (expect one row: relrowsecurity = true).
+select relname, relrowsecurity
+  from pg_class
+ where oid = 'public.scheduled_tournament_registrations'::regclass;


### PR DESCRIPTION
The last piece of the tournament hardening (Step 5 / PR-G). **Not CI** — there is no Postgres service and no migration runner in this repo, and that gap is exactly why three reviewed lockdown migrations sat unapplied (T-1, the ghost/bot RLS tables, the `commit_glicko` RPC). `security-posture.yml` verifies the *consequences* against prod weekly; this script verifies the *mechanics* against a fresh DB.

## `scripts/tournament-db-verify.sh`

Spins its **own throwaway pg16** (`initdb` in a temp dir, `pg_ctl` on a random high port + private socket, `trap … EXIT` deletes it). **Aborts (exit 2)** before doing anything if `PGHOST` / `PGHOSTADDR` / `PGURL` / `PGURI` / `DATABASE_URL` / `SUPABASE_*_URL` is a URL or Supabase host, or if any arg looks like a remote target. No code path reads `.env` or any connection string — it cannot reach prod.

### What it checks (full run in the last review comment — all green)

1. **Greenfield apply** — `shim.sql` (`auth` schema, `auth.users`, `auth.uid()`, the `anon`/`authenticated`/`service_role` roles) + the curated 10-file tournament migration chain, in order. The `2026-08-30` RLS lockdown self-asserts as part of this.
2. **`SELECT … FOR UPDATE` serialization** — two `psql` sessions call `complete_tournament_match()` on the same match with **different winners**. Session B blocks on A's row lock (≥ 1s, measured), then takes the `applied:false` / `conflict:true` branch; the bracket then shows exactly one completion + one advancement, loser eliminated once. **This is the T-3 / T-4 regression guard** — double bracket advancement / wrong champion / un-eliminated loser. The JS in-memory port (PR-F) structurally cannot cover this; Node's event loop serializes it for free.
3. **RLS registrations lockdown** — the three diagnostics come back clean on the fresh schema.
4. **`assert_security_posture()` catches a planted violation** — `hard_fail_count` 0 clean → 1 after `disable row level security` (naming `public.scheduled_tournament_matches`, class `rls_disabled`) → 0 after re-enable. The runtime check the drift-detector's text-only unit test defers to here.

### Known limitation (not a blocker)

The `FOR UPDATE` check uses fixed sleeps (1.5s head start, 1.0s pass threshold, 3s hold). Fine for a local/manual script. If it ever flakes on a slow run, that is a timing-margin issue first — check that before treating it as a lock regression.

## Also added

- `supabase/tests/rls_registrations_lockdown.sql` — the same three RLS diagnostics as a paste-into-SQL-editor artifact for checking **prod**.
- `docs/ops/tournament-db-verify.md` — prereqs (`brew install postgresql@16`), the prod-safety boundary, what each check proves.

## Verification

- Runs green locally, **3× no flake** (session B blocks 1.48–1.51s consistently)
- Abort guards verified against `SUPABASE_DB_URL=postgres://…supabase.co`, a `postgresql://` arg, and a URL-shaped `PGHOST`
- `bash -n` clean; server suite still 201 files / 1159 tests; `tsc` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)