### PR TITLE
fix(puzzle-rush): correct leaderboard accent + gate/scope the Share button

### DIFF
--- a/client/src/puzzleRush/PuzzleRushLeaderboardScreen.tsx
+++ b/client/src/puzzleRush/PuzzleRushLeaderboardScreen.tsx
@@ -200,18 +200,22 @@ export function PuzzleRushLeaderboardScreen({
     [rows],
   );
 
+  // Only today's official run is shareable, and only what the player actually
+  // posted today — not their all-time best. `selfRow` under the Today filter is
+  // the caller's row on `data.daily`, so it exists iff they have an official
+  // run today.
   const shareText = useMemo(() => {
-    if (filter !== 'today' || !data?.personalBest) return '';
+    if (filter !== 'today' || !selfRow || !data) return '';
     const puzzleNumber = calculatePuzzleNumber(data.runDate);
-    const emojiBoxes = Array(data.personalBest.puzzlesSolved).fill('🟩').join('');
+    const emojiBoxes = Array(selfRow.puzzlesSolved).fill('🟩').join('');
     return [
       `Racehorse Puzzle Rush #${puzzleNumber}`,
       emojiBoxes,
       '',
-      `${data.personalBest.puzzlesSolved} solved`,
+      `${selfRow.puzzlesSolved} solved`,
       SITE_DOMAIN,
     ].filter(Boolean).join('\n');
-  }, [data, filter]);
+  }, [data, filter, selfRow]);
 
   const handleShareResult = useCallback(() => {
     if (!shareText) return;
@@ -259,7 +263,7 @@ export function PuzzleRushLeaderboardScreen({
                     <span aria-hidden>←</span>
                     Puzzle Rush
                   </button>
-                  {filter === 'today' && data?.personalBest ? (
+                  {shareText ? (
                     <button
                       type="button"
                       className="dfl-btn dfl-btn--accent"

--- a/client/src/puzzleRush/puzzleRush.css
+++ b/client/src/puzzleRush/puzzleRush.css
@@ -713,9 +713,16 @@
  * Rush is a blue mode — its hub, HUD and Start button all run on
  * --tier-standard — so the board takes the same accent rather than Fritz's
  * gold. Retinting the accent block is all it takes; every accented element on
- * the board reads from it.
+ * the board reads from it — the derived --dfl-accent-* vars re-resolve from
+ * --dfl-accent-rgb at their use site.
+ *
+ * Selector is .dfl-page.pr-board, not bare .pr-board: Fritz sets these on
+ * .dfl-page, an equal-specificity selector, so a bare .pr-board only wins on
+ * stylesheet order — and dailyFritzLeaderboardBoard.css is imported by three
+ * components, so bundle order is not ours to rely on. The extra class makes
+ * the win deterministic.
  */
-.pr-board {
+.dfl-page.pr-board {
   --dfl-accent: var(--tier-standard);
   --dfl-accent-rgb: 59, 130, 246;
   --dfl-accent-ink: var(--bg-obsidian);


### PR DESCRIPTION
Three defects on the Puzzle Rush leaderboard, all stemming from the board reusing Daily Fritz's `dfl-*` chrome (#63 / #105).

## 1. Board rendered gold instead of blue
`puzzleRush.css` retints the board blue via `.pr-board { --dfl-accent… }`, but Fritz sets those same custom properties on `.dfl-page` — an **equal-specificity** selector. The winner is decided by stylesheet order, and `dailyFritzLeaderboardBoard.css` is imported by three components, so the order isn't stable → Fritz's gold won.
**Fix:** scope the override to `.dfl-page.pr-board` so it wins deterministically. Overriding `--dfl-accent` + `--dfl-accent-rgb` is enough; the derived `--dfl-accent-border/-dim/-row/…` re-resolve from `-rgb` at their use site.

## 2. "Share Result" shown with no run today
The button was gated on `data.personalBest`, which `/api/puzzle-rush/leaderboard` returns as your **all-time** best run — so it appeared even with "No official runs today yet / Players 0".
**Fix:** gate on `selfRow` under the Today filter (your row on `data.daily`, present iff you have an official run today).

## 3. Share text was a fabricated / foreign-looking result
Built from the all-time PB: `Array(personalBest.puzzlesSolved).fill('🟩')` — all-green boxes and a solve count not earned today. Since #105 unified the card format, it's byte-for-byte the shape of the Daily Fritz card.
**Fix:** build the share text from today's actual row.

## Verification
- `tsc -b` clean
- 44 `src/puzzleRush` tests pass
- `npm run lint` exit 0 (warning budget 401, unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)