### PR TITLE
Social feed: leaderboard board treatment

### DIFF
--- a/client/src/social/ActivityFeedPanel.board.test.tsx
+++ b/client/src/social/ActivityFeedPanel.board.test.tsx
@@ -1,0 +1,70 @@
+// @vitest-environment jsdom
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { FeedItem } from './socialApi';
+
+const fetchActivityFeed = vi.fn();
+vi.mock('./socialApi', async (importActual) => ({
+  ...(await importActual<typeof import('./socialApi')>()),
+  fetchActivityFeed: () => fetchActivityFeed(),
+}));
+
+const { default: ActivityFeedPanel } = await import('./ActivityFeedPanel');
+
+function item(overrides: Partial<FeedItem> = {}): FeedItem {
+  return {
+    id: 'f1',
+    user_id: 'u1',
+    username: 'marcus_r',
+    type: 'win',
+    metadata: { score: 30, opponent_score: 24, mode: 'multiplayer' },
+    created_at: new Date(Date.now() - 14 * 60_000).toISOString(),
+    ...overrides,
+  };
+}
+
+const user = { id: 'me', email: 'oliver@example.com' } as never;
+
+describe('ActivityFeedPanel — board table', () => {
+  beforeEach(() => fetchActivityFeed.mockReset());
+
+  it('renders the five-column board table with a signed score margin', async () => {
+    fetchActivityFeed.mockResolvedValue({ feed: [item()], error: null });
+    render(
+      <ActivityFeedPanel user={user} filter="all" onViewProfile={vi.fn()} />,
+    );
+
+    const table = await screen.findByRole('region', { name: /activity feed/i });
+    expect(table).toHaveClass('rh-sb-table');
+    expect(table.querySelector('.rh-sb-thead')).not.toBeNull();
+    await waitFor(() => expect(screen.getByText('30–24')).toBeInTheDocument());
+    expect(screen.getByText('+6')).toHaveClass('rh-sb-score__margin');
+  });
+
+  it('marks the signed-in player’s own row', async () => {
+    fetchActivityFeed.mockResolvedValue({
+      feed: [item({ username: 'oliver' }), item({ id: 'f2', username: 'tessa_ng' })],
+      error: null,
+    });
+    render(
+      <ActivityFeedPanel
+        user={user}
+        filter="all"
+        selfUsername="oliver"
+        onViewProfile={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => expect(screen.getByText('oliver')).toBeInTheDocument());
+    const selfRow = screen.getByText('oliver').closest('.rh-sb-row');
+    expect(selfRow).toHaveClass('rh-sb-row--self');
+    expect(screen.getByText('tessa_ng').closest('.rh-sb-row')).not.toHaveClass('rh-sb-row--self');
+    expect(screen.getByText('You')).toHaveClass('rh-sb-you');
+  });
+
+  it('shows the empty state inside the board frame when the feed is empty', async () => {
+    fetchActivityFeed.mockResolvedValue({ feed: [], error: null });
+    render(<ActivityFeedPanel user={user} filter="all" onViewProfile={vi.fn()} />);
+    expect(await screen.findByText(/Play a match or follow rivals/i)).toBeInTheDocument();
+  });
+});

--- a/client/src/social/ActivityFeedPanel.board.test.tsx
+++ b/client/src/social/ActivityFeedPanel.board.test.tsx
@@ -43,14 +43,17 @@ describe('ActivityFeedPanel — board table', () => {
 
   it('marks the signed-in player’s own row', async () => {
     fetchActivityFeed.mockResolvedValue({
-      feed: [item({ username: 'oliver' }), item({ id: 'f2', username: 'tessa_ng' })],
+      feed: [
+        item({ username: 'oliver', user_id: 'me' }),
+        item({ id: 'f2', username: 'tessa_ng', user_id: 'other' }),
+      ],
       error: null,
     });
     render(
       <ActivityFeedPanel
         user={user}
         filter="all"
-        selfUsername="oliver"
+        selfUserId="me"
         onViewProfile={vi.fn()}
       />,
     );

--- a/client/src/social/ActivityFeedPanel.tsx
+++ b/client/src/social/ActivityFeedPanel.tsx
@@ -125,9 +125,9 @@ interface ActivityFeedPanelProps {
   user: User | null;
   filter: ActivityFeedFilterTab;
   friendUsernames?: Set<string>;
-  /** Lower/exact handle of the signed-in player — the row that matches
-   *  gets the gold left bar. Best-effort; absent just means no self row. */
-  selfUsername?: string;
+  /** Supabase id of the signed-in player — the row whose `user_id`
+   *  matches gets the gold left bar. */
+  selfUserId?: string;
   onViewProfile: (username: string) => void;
   emptyAction?: React.ReactNode;
   onFeedChange?: (feed: FeedItem[]) => void;
@@ -187,12 +187,11 @@ export default function ActivityFeedPanel({
   user,
   filter,
   friendUsernames = new Set(),
-  selfUsername,
+  selfUserId,
   onViewProfile,
   emptyAction,
   onFeedChange,
 }: ActivityFeedPanelProps) {
-  const selfHandle = selfUsername?.toLowerCase() ?? null;
   const [feed, setFeed] = useState<FeedItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -285,7 +284,7 @@ export default function ActivityFeedPanel({
       {visibleItems.map((item) => {
         const vm = buildFeedRowViewModel(item);
         const row = boardRow(item, vm);
-        const isSelf = selfHandle != null && item.username.toLowerCase() === selfHandle;
+        const isSelf = selfUserId != null && item.user_id === selfUserId;
         const outcomeClass =
           row.outcome === 'win' ? ' is-win' : row.outcome === 'loss' ? ' is-loss' : '';
         return (

--- a/client/src/social/ActivityFeedPanel.tsx
+++ b/client/src/social/ActivityFeedPanel.tsx
@@ -3,7 +3,6 @@ import type { User } from '@supabase/supabase-js';
 import { fetchActivityFeed, type FeedItem } from './socialApi';
 import {
   buildFeedRowViewModel,
-  type FeedIconKind,
   type FeedRowViewModel,
 } from './activityFeedRowModel';
 import './activityFeed.css';
@@ -11,13 +10,13 @@ import './socialBoard.css';
 
 export type ActivityFeedFilterTab = 'all' | 'friends' | 'wins' | 'streaks' | 'tournaments' | 'mentions';
 
-const FILTER_TABS: { id: ActivityFeedFilterTab; label: string; icon: FeedIconKind | 'friends' | 'mention' }[] = [
-  { id: 'all', label: 'All Activity', icon: 'medal' },
-  { id: 'friends', label: 'Friends', icon: 'friends' },
-  { id: 'wins', label: 'Wins', icon: 'trophy' },
-  { id: 'streaks', label: 'Streaks', icon: 'flame' },
-  { id: 'tournaments', label: 'Tournaments', icon: 'crown' },
-  { id: 'mentions', label: 'Mentions', icon: 'mention' },
+const FILTER_TABS: { id: ActivityFeedFilterTab; label: string }[] = [
+  { id: 'all', label: 'All Activity' },
+  { id: 'friends', label: 'Friends' },
+  { id: 'wins', label: 'Wins' },
+  { id: 'streaks', label: 'Streaks' },
+  { id: 'tournaments', label: 'Tournaments' },
+  { id: 'mentions', label: 'Mentions' },
 ];
 
 function initials(username: string): string {
@@ -34,49 +33,6 @@ function avatarHue(username: string): number {
   return Math.abs(hash) % 360;
 }
 
-function FilterTabIcon({ kind }: { kind: (typeof FILTER_TABS)[number]['icon'] }) {
-  const common = { width: 14, height: 14, viewBox: '0 0 24 24', fill: 'none', 'aria-hidden': true as const };
-  switch (kind) {
-    case 'friends':
-      return (
-        <svg {...common}>
-          <path d="M16 11c1.66 0 3-1.34 3-3S17.66 5 16 5s-3 1.34-3 3 1.34 3 3 3ZM8 11c1.66 0 3-1.34 3-3S9.66 5 8 5 5 6.34 5 8s1.34 3 3 3Zm0 2c-2.33 0-7 1.17-7 3.5V19h14v-2.5C15 14.17 10.33 13 8 13Zm8 0c-.29 0-.62.02-.97.06 1.16.84 1.97 1.97 1.97 3.44V19h6v-2.5c0-2.33-4.67-3.5-7-3.5Z" fill="currentColor" />
-        </svg>
-      );
-    case 'trophy':
-      return (
-        <svg {...common}>
-          <path d="M8 4h8v2a4 4 0 0 0 4 4h1v2a5 5 0 0 1-5 5h-1v3H9v-3H8a5 5 0 0 1-5-5V10h1a4 4 0 0 0 4-4V4Z" stroke="currentColor" strokeWidth="1.6" />
-        </svg>
-      );
-    case 'flame':
-      return (
-        <svg {...common}>
-          <path d="M12 3s-4 4.5-4 8a4 4 0 0 0 8 0c0-2-1.5-3.5-2-4.5.5 1 1.5 2.5 1.5 4a2.5 2.5 0 0 1-5 0c0-2.5 2-5.5 2-5.5Z" stroke="currentColor" strokeWidth="1.6" strokeLinejoin="round" />
-        </svg>
-      );
-    case 'crown':
-      return (
-        <svg {...common}>
-          <path d="M5 18h14l-1.2-9-3.3 3.5L12 6 9.5 12.5 6.2 9 5 18Z" stroke="currentColor" strokeWidth="1.6" strokeLinejoin="round" />
-        </svg>
-      );
-    case 'mention':
-      return (
-        <svg {...common}>
-          <path d="M12 18a6 6 0 1 0 0-12 6 6 0 0 0 0 12Zm0-8v4m0 4h.01" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
-        </svg>
-      );
-    case 'medal':
-    default:
-      return (
-        <svg {...common}>
-          <circle cx="12" cy="12" r="8" stroke="currentColor" strokeWidth="1.6" />
-          <path d="M8 12h8M12 8v8" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" />
-        </svg>
-      );
-  }
-}
 
 type BoardOutcome = 'win' | 'loss' | 'neutral';
 
@@ -158,9 +114,6 @@ export function ActivityFeedFilterTabs({ filter, onFilterChange }: ActivityFeedF
           className="rh-sb-filter"
           onClick={() => onFilterChange(tab.id)}
         >
-          <span className="rh-sb-filter__icon" aria-hidden="true">
-            <FilterTabIcon kind={tab.icon} />
-          </span>
           {tab.label}
         </button>
       ))}
@@ -355,7 +308,6 @@ export default function ActivityFeedPanel({
                   <span className="rh-sb-who__handle">{item.username}</span>
                   {isSelf ? <span className="rh-sb-you">You</span> : null}
                 </span>
-                <span className="rh-sb-who__meta">{row.modeLabel}</span>
               </span>
             </span>
 
@@ -373,7 +325,7 @@ export default function ActivityFeedPanel({
 
             <span className="rh-sb-score">
               {vm.scoreLine ? (
-                <span className="rh-sb-score__line">{vm.scoreLine.replace(' - ', '–')}</span>
+                <span className="rh-sb-score__line">{vm.scoreLine.replace(/\s*[-–]\s*/, '–')}</span>
               ) : null}
               {row.margin ? (
                 <span

--- a/client/src/social/ActivityFeedPanel.tsx
+++ b/client/src/social/ActivityFeedPanel.tsx
@@ -1,12 +1,13 @@
-import { useCallback, useEffect, useMemo, useState, type CSSProperties } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import type { User } from '@supabase/supabase-js';
 import { fetchActivityFeed, type FeedItem } from './socialApi';
 import {
   buildFeedRowViewModel,
-  type FeedBadgeTone,
   type FeedIconKind,
+  type FeedRowViewModel,
 } from './activityFeedRowModel';
 import './activityFeed.css';
+import './socialBoard.css';
 
 export type ActivityFeedFilterTab = 'all' | 'friends' | 'wins' | 'streaks' | 'tournaments' | 'mentions';
 
@@ -77,59 +78,67 @@ function FilterTabIcon({ kind }: { kind: (typeof FILTER_TABS)[number]['icon'] })
   }
 }
 
-function FeedCategoryIcon({ kind }: { kind: FeedIconKind }) {
-  const cls = `rh-af-rich-cat rh-af-rich-cat--${kind}`;
-  const common = { width: 16, height: 16, viewBox: '0 0 24 24', fill: 'none', 'aria-hidden': true as const };
-  switch (kind) {
-    case 'trophy':
-      return (
-        <span className={cls}>
-          <svg {...common}><path d="M8 4h8v2a4 4 0 0 0 4 4h1v2a5 5 0 0 1-5 5h-1v3H9v-3H8a5 5 0 0 1-5-5V10h1a4 4 0 0 0 4-4V4Z" stroke="currentColor" strokeWidth="1.6" /></svg>
-        </span>
-      );
-    case 'puzzle':
-      return (
-        <span className={cls}>
-          <svg {...common}><path d="M8 8h3V5H8v3Zm5 0h3V5h-3v3ZM8 16h3v3H8v-3Zm5 0h3v3h-3v-3Z" fill="currentColor" /></svg>
-        </span>
-      );
-    case 'flame':
-      return (
-        <span className={cls}>
-          <svg {...common}><path d="M12 3s-4 4.5-4 8a4 4 0 0 0 8 0c0-2-1.5-3.5-2-4.5.5 1 1.5 2.5 1.5 4a2.5 2.5 0 0 1-5 0c0-2.5 2-5.5 2-5.5Z" stroke="currentColor" strokeWidth="1.6" /></svg>
-        </span>
-      );
-    case 'medal':
-    case 'crown':
-      return (
-        <span className={cls}>
-          <svg {...common}><path d="M5 18h14l-1.2-9-3.3 3.5L12 6 9.5 12.5 6.2 9 5 18Z" stroke="currentColor" strokeWidth="1.6" /></svg>
-        </span>
-      );
-    case 'swords':
-      return (
-        <span className={cls}>
-          <svg {...common}><path d="m4 20 8-8m4-4 4-4m0 8 4 4M14 6l4-4m-6 14-4 4" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" /></svg>
-        </span>
-      );
-    case 'robot':
-      return (
-        <span className={cls}>
-          <svg {...common}><rect x="6" y="8" width="12" height="10" rx="2" stroke="currentColor" strokeWidth="1.6" /><circle cx="10" cy="13" r="1" fill="currentColor" /><circle cx="14" cy="13" r="1" fill="currentColor" /><path d="M12 4v4" stroke="currentColor" strokeWidth="1.6" /></svg>
-        </span>
-      );
-    case 'mention':
-    default:
-      return (
-        <span className={cls}>
-          <svg {...common}><path d="M16 12a4 4 0 1 1-8 0 4 4 0 0 1 8 0Zm-4 4v4" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" /></svg>
-        </span>
-      );
-  }
-}
+type BoardOutcome = 'win' | 'loss' | 'neutral';
 
-function badgeClass(tone: FeedBadgeTone): string {
-  return `rh-af-rich-badge rh-af-rich-badge--${tone}`;
+const BOARD_MODE_LABEL: Record<FeedItem['type'], string> = {
+  win: 'Match',
+  loss: 'Match',
+  streak: 'Streak',
+  tournament: 'Tournament',
+  puzzle: 'Puzzle Rush',
+  daily_fritz: 'Daily Fritz',
+};
+
+/** Everything the board's five-column row needs, derived from the shared
+ *  view model plus the raw item — outcome tone, a signed margin, a plain
+ *  mode label. No new data fetch; same metadata the feed already carries. */
+function boardRow(item: FeedItem, vm: FeedRowViewModel): {
+  modeLabel: string;
+  outcome: BoardOutcome;
+  margin: string | undefined;
+  badge: { label: string; kind: 'skunk' | 'win' | 'loss' | 'neutral' } | undefined;
+} {
+  const meta = item.metadata;
+  const won =
+    item.type === 'win' ||
+    meta.won === true ||
+    meta.result === 'win' ||
+    (item.type === 'tournament' && String(meta.placement ?? '').toLowerCase().includes('1st'));
+  const lost = item.type === 'loss' || meta.won === false || meta.result === 'loss';
+  const outcome: BoardOutcome = won ? 'win' : lost ? 'loss' : 'neutral';
+
+  let margin: string | undefined;
+  const a = Number(meta.score ?? meta.player_score);
+  const b = Number(meta.opponent_score ?? meta.fritz_score);
+  if (Number.isFinite(a) && Number.isFinite(b)) {
+    const diff = a - b;
+    margin = `${diff > 0 ? '+' : diff < 0 ? '−' : ''}${Math.abs(diff)}`;
+  } else if (vm.ratingDelta) {
+    margin = vm.ratingDelta;
+  } else if (vm.pointsLine) {
+    margin = vm.pointsLine;
+  }
+
+  let badge: { label: string; kind: 'skunk' | 'win' | 'loss' | 'neutral' } | undefined;
+  const src = vm.badge ?? vm.modeBadge;
+  if (src) {
+    const kind =
+      src.tone === 'skunk' || (src.tone === 'gold' && /skunk/i.test(src.label))
+        ? 'skunk'
+        : outcome === 'win'
+          ? 'win'
+          : outcome === 'loss'
+            ? 'loss'
+            : 'neutral';
+    badge = { label: src.label, kind };
+  }
+
+  return {
+    modeLabel: vm.modeBadge?.label ?? BOARD_MODE_LABEL[item.type],
+    outcome,
+    margin,
+    badge,
+  };
 }
 
 interface ActivityFeedFilterTabsProps {
@@ -139,17 +148,17 @@ interface ActivityFeedFilterTabsProps {
 
 export function ActivityFeedFilterTabs({ filter, onFilterChange }: ActivityFeedFilterTabsProps) {
   return (
-    <nav className="rh-af-filters social-tabs-row" role="tablist" aria-label="Activity filters">
+    <nav className="rh-sb-filters" role="tablist" aria-label="Activity filters">
       {FILTER_TABS.map((tab) => (
         <button
           key={tab.id}
           type="button"
           role="tab"
           aria-selected={filter === tab.id}
-          className={`rh-af-filter social-filter-tab${filter === tab.id ? ' rh-af-filter--active active' : ''}`}
+          className="rh-sb-filter"
           onClick={() => onFilterChange(tab.id)}
         >
-          <span className="rh-af-filter-icon">
+          <span className="rh-sb-filter__icon" aria-hidden="true">
             <FilterTabIcon kind={tab.icon} />
           </span>
           {tab.label}
@@ -163,6 +172,9 @@ interface ActivityFeedPanelProps {
   user: User | null;
   filter: ActivityFeedFilterTab;
   friendUsernames?: Set<string>;
+  /** Lower/exact handle of the signed-in player — the row that matches
+   *  gets the gold left bar. Best-effort; absent just means no self row. */
+  selfUsername?: string;
   onViewProfile: (username: string) => void;
   emptyAction?: React.ReactNode;
   onFeedChange?: (feed: FeedItem[]) => void;
@@ -222,10 +234,12 @@ export default function ActivityFeedPanel({
   user,
   filter,
   friendUsernames = new Set(),
+  selfUsername,
   onViewProfile,
   emptyAction,
   onFeedChange,
 }: ActivityFeedPanelProps) {
+  const selfHandle = selfUsername?.toLowerCase() ?? null;
   const [feed, setFeed] = useState<FeedItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -258,110 +272,142 @@ export default function ActivityFeedPanel({
   const visibleItems = useMemo(() => filtered.slice(0, visibleCount), [filtered, visibleCount]);
   const canLoadMore = visibleCount < filtered.length;
 
-  return (
-    <div className="rh-af-panel social-feed-panel">
-      <div className="rh-af-feed-card rh-social-card">
-        <div className="rh-af-feed social-feed-scroll">
-          {loading && (
-            <div className="rh-af-status rh-af-status--loading" aria-live="polite">
-              <span className="rh-af-status-kicker">Loading</span>
-              <strong>Building your social feed…</strong>
-              <p>Recent wins, rival updates, and tournament results will appear here.</p>
-            </div>
-          )}
-          {!loading && error && (
-            <div className="rh-af-status rh-af-status--error" role="alert">
-              <span className="rh-af-status-kicker">Feed unavailable</span>
-              <strong>{error}</strong>
-              <button type="button" className="rh-af-status-btn" onClick={() => void load()}>
-                Retry
-              </button>
-            </div>
-          )}
-          {!loading && !error && filtered.length === 0 && (
-            <div className="rh-af-empty">
-              <span className="rh-af-status-kicker">No activity yet</span>
-              <strong>
-                {filter === 'mentions'
-                  ? 'Mentions will show up here when rivals tag you.'
-                  : 'Play a match or follow rivals to start your feed.'}
-              </strong>
-              <p>
-                {filter === 'mentions'
-                  ? 'Follow active players to turn this into a real conversation.'
-                  : 'Wins, streaks, Daily Fritz runs, and tournament results will land here first.'}
-              </p>
-              {emptyAction}
-            </div>
-          )}
-          {!loading && !error && visibleItems.map((item) => {
-            const vm = buildFeedRowViewModel(item);
-            const hue = avatarHue(item.username);
-            return (
-              <article key={item.id} className="rh-af-rich-row" data-feed-type={item.type}>
-                <button
-                  type="button"
-                  className="rh-af-rich-avatar"
-                  style={{ ['--rh-af-avatar-hue' as string]: String(hue) } as CSSProperties}
-                  onClick={() => onViewProfile(item.username)}
-                  aria-label={`View ${item.username}'s profile`}
-                >
-                  {initials(item.username)}
-                </button>
-                <FeedCategoryIcon kind={vm.icon} />
-                <div className="rh-af-rich-main">
-                  <p className="rh-af-rich-line">
-                    <button type="button" className="rh-af-rich-user" onClick={() => onViewProfile(item.username)}>
-                      {item.username}
-                    </button>
-                    <span className="rh-af-rich-action">{vm.action}</span>
-                  </p>
-                  <div className="rh-af-rich-meta">
-                    {vm.modeBadge ? (
-                      <span className={badgeClass(vm.modeBadge.tone)}>{vm.modeBadge.label}</span>
-                    ) : null}
-                    <p className="rh-af-rich-secondary">{vm.secondary}</p>
-                  </div>
-                </div>
-                <div className="rh-af-rich-stats">
-                  {vm.scoreLine ? <span className="rh-af-rich-score">{vm.scoreLine}</span> : null}
-                  {vm.pointsLine ? <span className="rh-af-rich-points">{vm.pointsLine}</span> : null}
-                  {vm.ratingDelta ? <span className="rh-af-rich-delta">{vm.ratingDelta}</span> : null}
-                  {vm.streakCount ? (
-                    <span className="rh-af-rich-streaks" aria-label={`${vm.streakCount} win streak`}>
-                      {Array.from({ length: vm.streakCount }, (_, i) => (
-                        <span key={i} className="rh-af-rich-streak-dot" aria-hidden="true">✓</span>
-                      ))}
-                    </span>
-                  ) : null}
-                  {vm.badge ? (
-                    <span className={badgeClass(vm.badge.tone)}>{vm.badge.label}</span>
-                  ) : null}
-                  {vm.showViewButton ? (
-                    <button type="button" className="rh-af-rich-view-btn">View</button>
-                  ) : null}
-                </div>
-                <div className="rh-af-rich-end">
-                  <time dateTime={item.created_at}>{timeAgo(item.created_at)}</time>
-                  <span className="rh-af-rich-chevron" aria-hidden="true">›</span>
-                </div>
-              </article>
-            );
-          })}
-          {!loading && !error && canLoadMore ? (
-            <div className="rh-af-load-more-wrap">
-              <button
-                type="button"
-                className="rh-af-load-more"
-                onClick={() => setVisibleCount((count) => count + 10)}
-              >
-                Load Older Activity
-                <span className="rh-af-load-more-chevron" aria-hidden="true">⌄</span>
-              </button>
-            </div>
-          ) : null}
+  if (loading) {
+    return (
+      <section className="rh-sb-table" aria-label="Activity feed">
+        <div className="rh-sb-feed-state" aria-live="polite">
+          <span className="rh-sb-feed-state__kicker">Loading</span>
+          <strong>Building your social feed…</strong>
+          <p>Recent wins, rival updates, and tournament results will appear here.</p>
         </div>
+      </section>
+    );
+  }
+
+  if (error) {
+    return (
+      <section className="rh-sb-table" aria-label="Activity feed">
+        <div className="rh-sb-feed-state" role="alert">
+          <span className="rh-sb-feed-state__kicker">Feed unavailable</span>
+          <strong>{error}</strong>
+          <p>
+            <button type="button" className="rh-sb-btn" onClick={() => void load()}>Retry</button>
+          </p>
+        </div>
+      </section>
+    );
+  }
+
+  if (filtered.length === 0) {
+    return (
+      <section className="rh-sb-table" aria-label="Activity feed">
+        <div className="rh-sb-feed-state">
+          <span className="rh-sb-feed-state__kicker">No activity yet</span>
+          <strong>
+            {filter === 'mentions'
+              ? 'Mentions will show up here when rivals tag you.'
+              : 'Play a match or follow rivals to start your feed.'}
+          </strong>
+          <p>
+            {filter === 'mentions'
+              ? 'Follow active players to turn this into a real conversation.'
+              : 'Wins, streaks, Daily Fritz runs, and tournament results will land here first.'}
+          </p>
+          {emptyAction}
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section className="rh-sb-table" aria-label="Activity feed">
+      <div className="rh-sb-thead rh-sb-row-grid" aria-hidden="true">
+        <span>Who</span>
+        <span>What happened</span>
+        <span>Score</span>
+        <span>Mode</span>
+        <span className="rh-sb-thead__when">When</span>
       </div>
-    </div>
+
+      {visibleItems.map((item) => {
+        const vm = buildFeedRowViewModel(item);
+        const row = boardRow(item, vm);
+        const isSelf = selfHandle != null && item.username.toLowerCase() === selfHandle;
+        const outcomeClass =
+          row.outcome === 'win' ? ' is-win' : row.outcome === 'loss' ? ' is-loss' : '';
+        return (
+          <button
+            type="button"
+            key={item.id}
+            className={`rh-sb-row rh-sb-row-grid${isSelf ? ' rh-sb-row--self' : ''}`}
+            onClick={() => onViewProfile(item.username)}
+          >
+            <span className="rh-sb-who">
+              <span
+                className="rh-sb-avatar"
+                aria-hidden="true"
+                style={{ '--rh-sb-avatar-hue': String(avatarHue(item.username)) } as React.CSSProperties}
+              >
+                {initials(item.username)}
+              </span>
+              <span className="rh-sb-who__copy">
+                <span className="rh-sb-who__name">
+                  <span className="rh-sb-who__handle">{item.username}</span>
+                  {isSelf ? <span className="rh-sb-you">You</span> : null}
+                </span>
+                <span className="rh-sb-who__meta">{row.modeLabel}</span>
+              </span>
+            </span>
+
+            <span className="rh-sb-what">
+              {vm.action}
+              {row.badge ? (
+                <span className={`rh-sb-badge rh-sb-badge--${row.badge.kind}`}>{row.badge.label}</span>
+              ) : null}
+              {vm.secondary ? (
+                <span className={`rh-sb-what__sub${row.badge?.kind === 'skunk' ? ' is-accent' : outcomeClass}`}>
+                  {vm.secondary}
+                </span>
+              ) : null}
+            </span>
+
+            <span className="rh-sb-score">
+              {vm.scoreLine ? (
+                <span className="rh-sb-score__line">{vm.scoreLine.replace(' - ', '–')}</span>
+              ) : null}
+              {row.margin ? (
+                <span
+                  className={`rh-sb-score__margin${
+                    row.badge?.kind === 'skunk' ? ' is-accent' : outcomeClass
+                  }`}
+                >
+                  {row.margin}
+                </span>
+              ) : null}
+            </span>
+
+            <span>
+              <span className="rh-sb-mode">{row.modeLabel}</span>
+            </span>
+
+            <span className="rh-sb-when">
+              <time dateTime={item.created_at}>{timeAgo(item.created_at).replace(' ago', '')}</time>
+            </span>
+          </button>
+        );
+      })}
+
+      {canLoadMore ? (
+        <div className="rh-sb-tfoot">
+          <button
+            type="button"
+            className="rh-sb-btn"
+            onClick={() => setVisibleCount((count) => count + 10)}
+          >
+            Load earlier activity
+          </button>
+        </div>
+      ) : null}
+    </section>
   );
 }

--- a/client/src/social/ActivityFeedScreen.tsx
+++ b/client/src/social/ActivityFeedScreen.tsx
@@ -6,7 +6,7 @@ import {
   PlayerInitialsAvatar,
   SideRailCard,
 } from '../components/hub';
-import SocialPageHero from './SocialPageHero';
+import SocialPageHero, { type SocialHeroStat } from './SocialPageHero';
 import { secondsUntilNextPacificMidnight } from '../dailyFritz/format';
 import type { OutboundChallenge, SendFriendChallengeResult } from '../multiplayer/friendChallenge';
 import { useFriendChallenge } from '../multiplayer/useFriendChallenge';
@@ -26,6 +26,7 @@ import ActivityFeedPanel, {
 import { fetchGlobalLeaderboard } from './socialApi';
 import './hub/hubShared.css';
 import './activityFeedScreen.css';
+import './socialBoard.css';
 
 interface ActivityFeedScreenProps {
   user: User | null;
@@ -292,32 +293,37 @@ export default function ActivityFeedScreen({
       .slice(0, 3);
   }, [friends, onlineFriends]);
 
-  const socialHeroStats = useMemo(
+  const socialHeroStats = useMemo<SocialHeroStat[]>(
     () => [
       {
         label: 'Online',
         value: String(displayOnlineCount),
-        note: displayOnlineCount > 0 ? 'friends live now' : 'quiet right now',
+        qualifier: displayOnlineCount > 0 ? 'live now' : 'quiet',
       },
       {
         label: 'Rivals',
         value: String(friends.length),
-        note: friends.length > 0 ? 'players in your circle' : 'add players to follow',
+        qualifier: friends.length > 0 ? 'in your circle' : 'none yet',
       },
       {
-        label: 'Recent Activity',
+        label: 'Activity',
         value: String(feedItems.length),
-        note: feedItems.length > 0 ? 'updates in your feed' : 'no updates yet',
+        qualifier: 'this week',
       },
       {
-        label: 'Top Streak',
+        label: 'Top streak',
         value: weeklyHighlights.topStreak?.value != null ? String(weeklyHighlights.topStreak.value) : '—',
-        note: weeklyHighlights.topStreak?.username ?? 'waiting on this week',
+        qualifier: weeklyHighlights.topStreak?.username ?? undefined,
         accent: true,
       },
     ],
     [displayOnlineCount, feedItems.length, friends.length, weeklyHighlights.topStreak],
   );
+
+  const selfUsername =
+    (user?.user_metadata?.username as string | undefined) ??
+    user?.email?.split('@')[0] ??
+    undefined;
 
   const noopToast = useMemo(() => (_message: string) => undefined, []);
   const {
@@ -368,7 +374,7 @@ export default function ActivityFeedScreen({
     <HubViewportPage
       currentMode="feed"
       activeColor="var(--tier-elite)"
-      className="rh-sf-page rh-sf-screen"
+      className="rh-sf-page rh-sf-screen rh-sb-page"
       onNavigate={(mode) => {
         if (mode === 'home') {
           onClose();
@@ -383,41 +389,45 @@ export default function ActivityFeedScreen({
         <div className="rh-hub-grid rh-sf-layout-grid social-layout-grid">
           <main className="rh-hub-main rh-sf-main-column social-main-column">
             <SocialPageHero
+              eyebrow="Community"
               title="Social"
-              subtitle="Follow rivals, track wins, and see what’s happening across Racehorse."
-              meta={user ? (
+              tagline="Every result your circle posts, in the order it happened."
+              actions={(
                 <>
-                  {socialHeroStats.map((stat) => (
-                    <article
-                      key={stat.label}
-                      className={`social-hero__stat${stat.accent ? ' social-hero__stat--accent' : ''}`}
-                    >
-                      <span className="social-hero__stat-label">{stat.label}</span>
-                      <strong className="social-hero__stat-value">{stat.value}</strong>
-                      <span className="social-hero__stat-note">{stat.note}</span>
-                    </article>
-                  ))}
+                  <button type="button" className="rh-sb-btn" onClick={onClose}>
+                    <span aria-hidden="true">←</span> Home
+                  </button>
+                  {onNavigateToFriends ? (
+                    <button type="button" className="rh-sb-btn rh-sb-btn--accent" onClick={onNavigateToFriends}>
+                      Find Players
+                    </button>
+                  ) : null}
                 </>
-              ) : undefined}
+              )}
+              stats={user ? socialHeroStats : undefined}
               filters={user ? (
                 <ActivityFeedFilterTabs filter={feedFilter} onFilterChange={setFeedFilter} />
               ) : undefined}
             />
 
                 {!user ? (
-                  <section className="rh-sf-signin social-feed-panel">
-                    <p>Sign in to see activity from your friends and rivals.</p>
+                  <section className="rh-sb-table">
+                    <div className="rh-sb-feed-state">
+                      <span className="rh-sb-feed-state__kicker">Signed out</span>
+                      <strong>Sign in to see activity from your friends and rivals.</strong>
+                    </div>
                   </section>
                 ) : (
                 <ActivityFeedPanel
                   user={user}
                   filter={feedFilter}
                   friendUsernames={friendUsernames}
+                  selfUsername={selfUsername}
                   onViewProfile={onViewProfile}
                   onFeedChange={setFeedItems}
                   emptyAction={
                     onNavigateToFriends ? (
-                      <button className="rh-sf-widget-link" type="button" onClick={onNavigateToFriends}>
+                      <button className="rh-sb-btn" type="button" onClick={onNavigateToFriends}>
                         Add Friends
                       </button>
                     ) : undefined

--- a/client/src/social/ActivityFeedScreen.tsx
+++ b/client/src/social/ActivityFeedScreen.tsx
@@ -320,10 +320,6 @@ export default function ActivityFeedScreen({
     [displayOnlineCount, feedItems.length, friends.length, weeklyHighlights.topStreak],
   );
 
-  const selfUsername =
-    (user?.user_metadata?.username as string | undefined) ??
-    user?.email?.split('@')[0] ??
-    undefined;
 
   const noopToast = useMemo(() => (_message: string) => undefined, []);
   const {
@@ -422,7 +418,7 @@ export default function ActivityFeedScreen({
                   user={user}
                   filter={feedFilter}
                   friendUsernames={friendUsernames}
-                  selfUsername={selfUsername}
+                  selfUserId={user.id}
                   onViewProfile={onViewProfile}
                   onFeedChange={setFeedItems}
                   emptyAction={

--- a/client/src/social/SocialPageHero.tsx
+++ b/client/src/social/SocialPageHero.tsx
@@ -1,27 +1,63 @@
 import type { ReactNode } from 'react';
-import './socialPageHero.css';
+
+export interface SocialHeroStat {
+  label: string;
+  value: string;
+  qualifier?: string;
+  accent?: boolean;
+}
 
 interface SocialPageHeroProps {
+  eyebrow: string;
   title: string;
-  subtitle: string;
-  meta?: ReactNode;
+  tagline: string;
+  actions?: ReactNode;
+  stats?: SocialHeroStat[];
   filters?: ReactNode;
 }
 
+/**
+ * The Social masthead in the leaderboard "board" treatment: display
+ * headline with a gold terminal dot on a faint grid-paper ground, and a
+ * single connected stat strip fused to its bottom edge.
+ */
 export default function SocialPageHero({
+  eyebrow,
   title,
-  subtitle,
-  meta,
+  tagline,
+  actions,
+  stats,
   filters,
 }: SocialPageHeroProps) {
   return (
-    <header className="social-hero">
-      <div className="social-hero__head">
-        <h1 className="social-hero__title">{title}</h1>
-        <p className="social-hero__subtitle">{subtitle}</p>
-      </div>
-      {meta ? <div className="social-hero__meta">{meta}</div> : null}
-      {filters ? <div className="social-hero__filters">{filters}</div> : null}
-    </header>
+    <>
+      <header className="rh-sb-masthead">
+        <div>
+          <span className="rh-sb-eyebrow">{eyebrow}</span>
+          <h1 className="rh-sb-title">
+            {title}
+            <span className="rh-sb-title__dot" aria-hidden="true">.</span>
+          </h1>
+          <p className="rh-sb-tagline">{tagline}</p>
+        </div>
+        {actions ? <div className="rh-sb-masthead__actions">{actions}</div> : null}
+      </header>
+
+      {stats && stats.length > 0 ? (
+        <div className="rh-sb-meta" aria-label="Social status">
+          {stats.map((stat) => (
+            <div className="rh-sb-meta__cell" key={stat.label}>
+              <span className="rh-sb-meta__label">{stat.label}</span>
+              <span className={`rh-sb-meta__value${stat.accent ? ' is-accent' : ''}`}>
+                {stat.value}
+                {stat.qualifier ? <span className="rh-sb-meta__qual"> {stat.qualifier}</span> : null}
+              </span>
+            </div>
+          ))}
+        </div>
+      ) : null}
+
+      {filters ?? null}
+    </>
   );
 }

--- a/client/src/social/SocialPageHero.tsx
+++ b/client/src/social/SocialPageHero.tsx
@@ -31,31 +31,33 @@ export default function SocialPageHero({
 }: SocialPageHeroProps) {
   return (
     <>
-      <header className="rh-sb-masthead">
-        <div>
-          <span className="rh-sb-eyebrow">{eyebrow}</span>
-          <h1 className="rh-sb-title">
-            {title}
-            <span className="rh-sb-title__dot" aria-hidden="true">.</span>
-          </h1>
-          <p className="rh-sb-tagline">{tagline}</p>
-        </div>
-        {actions ? <div className="rh-sb-masthead__actions">{actions}</div> : null}
-      </header>
+      <div className="rh-sb-masthead-wrap">
+        <header className="rh-sb-masthead">
+          <div>
+            <span className="rh-sb-eyebrow">{eyebrow}</span>
+            <h1 className="rh-sb-title">
+              {title}
+              <span className="rh-sb-title__dot" aria-hidden="true">.</span>
+            </h1>
+            <p className="rh-sb-tagline">{tagline}</p>
+          </div>
+          {actions ? <div className="rh-sb-masthead__actions">{actions}</div> : null}
+        </header>
 
-      {stats && stats.length > 0 ? (
-        <div className="rh-sb-meta" aria-label="Social status">
-          {stats.map((stat) => (
-            <div className="rh-sb-meta__cell" key={stat.label}>
-              <span className="rh-sb-meta__label">{stat.label}</span>
-              <span className={`rh-sb-meta__value${stat.accent ? ' is-accent' : ''}`}>
-                {stat.value}
-                {stat.qualifier ? <span className="rh-sb-meta__qual"> {stat.qualifier}</span> : null}
-              </span>
-            </div>
-          ))}
-        </div>
-      ) : null}
+        {stats && stats.length > 0 ? (
+          <div className="rh-sb-meta" aria-label="Social status">
+            {stats.map((stat) => (
+              <div className="rh-sb-meta__cell" key={stat.label}>
+                <span className="rh-sb-meta__label">{stat.label}</span>
+                <span className={`rh-sb-meta__value${stat.accent ? ' is-accent' : ''}`}>
+                  {stat.value}
+                  {stat.qualifier ? <span className="rh-sb-meta__qual"> {stat.qualifier}</span> : null}
+                </span>
+              </div>
+            ))}
+          </div>
+        ) : null}
+      </div>
 
       {filters ?? null}
     </>

--- a/client/src/social/socialBoard.css
+++ b/client/src/social/socialBoard.css
@@ -1,0 +1,475 @@
+/* ------------------------------------------------------------------
+   Social Board — the leaderboard "board" treatment applied to Social.
+   Same feed, same rail panels, same filters — only the visual system
+   moves: square records, hairline dividers, one connected stat strip,
+   a display masthead, and gold reserved for signal (your row, #1, a
+   skunk, the primary CTA).
+
+   Tokens only (client/src/styles/tokens.css). The --rh-sb-* custom
+   properties below are scoped to .rh-sb-page (not a :root block) and
+   map straight onto the documented palette in client/CLAUDE.md §3.
+   ------------------------------------------------------------------ */
+
+.rh-sb-page {
+  --rh-sb-line: rgba(255, 255, 255, 0.08);
+  --rh-sb-line-soft: rgba(255, 255, 255, 0.05);
+  --rh-sb-line-strong: rgba(255, 255, 255, 0.14);
+  --rh-sb-ink: rgba(255, 255, 255, 0.95);
+  --rh-sb-subtle: rgba(255, 255, 255, 0.72);
+  --rh-sb-muted: rgba(255, 255, 255, 0.6);
+  --rh-sb-label: rgba(255, 255, 255, 0.42);
+  --rh-sb-dim: rgba(255, 255, 255, 0.35);
+  --rh-sb-surface: rgba(10, 16, 28, 0.6);
+  --rh-sb-grid: rgba(255, 255, 255, 0.02);
+
+  --rh-sb-accent: var(--tier-elite);
+  --rh-sb-accent-border: rgba(231, 182, 74, 0.42);
+  --rh-sb-accent-dim: rgba(231, 182, 74, 0.14);
+  --rh-sb-accent-row: rgba(231, 182, 74, 0.05);
+  --rh-sb-accent-row-hover: rgba(231, 182, 74, 0.07);
+
+  --rh-sb-win: var(--tier-rookie);
+  --rh-sb-loss: #ff4d6d;
+
+  --rh-sb-ease: cubic-bezier(0.2, 0, 0, 1);
+}
+
+/* The board wants a lean, connected shell — drop the hub's rounded
+   glass main column so the table can butt against the masthead. */
+.rh-sb-page .rh-sf-main-column,
+.rh-sb-page .social-main-column {
+  gap: 14px;
+}
+
+/* ------------------------------------------------------------ masthead */
+
+.rh-sb-masthead {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 24px;
+  padding: 26px 26px 22px;
+  border: 1px solid var(--rh-sb-line);
+  border-radius: var(--radius-record) var(--radius-record) 0 0;
+  background-color: rgba(255, 255, 255, 0.012);
+  background-image:
+    linear-gradient(var(--rh-sb-grid) 1px, transparent 1px),
+    linear-gradient(90deg, var(--rh-sb-grid) 1px, transparent 1px);
+  background-size: 44px 44px, 44px 44px;
+}
+
+.rh-sb-eyebrow {
+  display: block;
+  margin: 0 0 6px;
+  font-family: var(--font-display);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--rh-sb-label);
+}
+
+.rh-sb-title {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: clamp(40px, 5vw, 60px);
+  font-weight: 700;
+  line-height: 0.92;
+  letter-spacing: -0.01em;
+  color: var(--rh-sb-ink);
+  text-wrap: balance;
+}
+
+.rh-sb-title__dot { color: var(--rh-sb-accent); }
+
+.rh-sb-tagline {
+  margin: 10px 0 0;
+  max-width: 52ch;
+  font-size: 13px;
+  line-height: 1.45;
+  color: var(--rh-sb-muted);
+}
+
+.rh-sb-masthead__actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-shrink: 0;
+}
+
+.rh-sb-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  height: 34px;
+  padding: 0 14px;
+  border: 1px solid var(--rh-sb-line);
+  border-radius: var(--radius-control);
+  background: var(--rh-sb-surface);
+  color: var(--rh-sb-muted);
+  font-family: var(--font-body);
+  font-size: 12px;
+  font-weight: 600;
+  white-space: nowrap;
+  cursor: pointer;
+  transition:
+    color 120ms var(--rh-sb-ease),
+    border-color 120ms var(--rh-sb-ease),
+    transform 120ms var(--rh-sb-ease);
+}
+
+.rh-sb-btn:hover { color: var(--rh-sb-ink); border-color: var(--rh-sb-line-strong); transform: translateY(-1px); }
+.rh-sb-btn:active { transform: scale(0.97); }
+.rh-sb-btn:focus-visible { outline: 2px solid var(--rh-sb-accent); outline-offset: 2px; }
+
+.rh-sb-btn--accent {
+  border-color: var(--rh-sb-accent);
+  background: var(--rh-sb-accent);
+  color: #1a1200;
+  font-weight: 700;
+}
+
+.rh-sb-btn--accent:hover { color: #1a1200; border-color: var(--rh-sb-accent); filter: brightness(1.07); }
+
+/* -------------------------------------------------------- stat strip */
+
+.rh-sb-meta {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  border: 1px solid var(--rh-sb-line);
+  border-top: 0;
+  border-radius: 0 0 var(--radius-record) var(--radius-record);
+  background: var(--rh-sb-surface);
+}
+
+.rh-sb-meta__cell {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  min-height: 34px;
+  padding: 7px 18px;
+  border-left: 1px solid var(--rh-sb-line-soft);
+  min-width: 0;
+}
+
+.rh-sb-meta__cell:first-child { border-left: 0; }
+
+.rh-sb-meta__label {
+  flex-shrink: 0;
+  font-family: var(--font-display);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--rh-sb-label);
+}
+
+.rh-sb-meta__value {
+  font-family: var(--font-display);
+  font-size: 14px;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+  color: var(--rh-sb-ink);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.rh-sb-meta__value.is-accent { color: var(--rh-sb-accent); }
+.rh-sb-meta__qual { font-family: var(--font-body); font-size: 11px; font-weight: 500; color: var(--rh-sb-dim); }
+
+/* ----------------------------------------------------------- filters */
+
+.rh-sb-filters { display: flex; flex-wrap: wrap; gap: 6px; }
+
+.rh-sb-filter {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 30px;
+  padding: 0 12px;
+  border: 1px solid var(--rh-sb-line);
+  border-radius: var(--radius-control);
+  background: var(--rh-sb-surface);
+  color: var(--rh-sb-muted);
+  font-family: var(--font-body);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  transition:
+    color 120ms var(--rh-sb-ease),
+    border-color 120ms var(--rh-sb-ease),
+    background 120ms var(--rh-sb-ease);
+}
+
+.rh-sb-filter:hover { border-color: var(--rh-sb-accent-border); color: var(--rh-sb-subtle); }
+.rh-sb-filter:focus-visible { outline: 2px solid var(--rh-sb-accent); outline-offset: 2px; }
+
+.rh-sb-filter[aria-selected="true"] {
+  border-color: var(--rh-sb-accent-border);
+  background: var(--rh-sb-accent-dim);
+  color: var(--rh-sb-accent);
+}
+
+.rh-sb-filter__icon { display: inline-flex; width: 13px; height: 13px; }
+.rh-sb-filter__icon svg { width: 100%; height: 100%; }
+
+/* ------------------------------------------------------------- table */
+
+.rh-sb-table {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--rh-sb-line);
+  border-radius: var(--radius-record);
+  background: var(--rh-sb-surface);
+  overflow: hidden;
+}
+
+/* Five columns, like the leaderboard. The score column stops "what
+   happened" from absorbing every spare pixel and stranding the mode
+   tag against the right edge. */
+.rh-sb-row-grid {
+  display: grid;
+  grid-template-columns: 210px minmax(0, 1fr) 104px 128px 76px;
+  align-items: center;
+  gap: 12px;
+  padding: 0 20px;
+}
+
+.rh-sb-thead {
+  min-height: 34px;
+  border-bottom: 1px solid var(--rh-sb-line);
+  background: rgba(255, 255, 255, 0.014);
+  font-family: var(--font-display);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--rh-sb-label);
+}
+
+.rh-sb-thead__when { text-align: right; }
+
+.rh-sb-row {
+  position: relative;
+  width: 100%;
+  min-height: 60px;
+  padding-top: 9px;
+  padding-bottom: 9px;
+  border: 0;
+  border-bottom: 1px solid var(--rh-sb-line-soft);
+  background: transparent;
+  text-align: left;
+  cursor: pointer;
+  transition: background 120ms var(--rh-sb-ease);
+}
+
+.rh-sb-row:last-child { border-bottom: 0; }
+.rh-sb-row:hover { background: rgba(255, 255, 255, 0.02); }
+.rh-sb-row:focus-visible { outline: 2px solid var(--rh-sb-accent); outline-offset: -2px; }
+.rh-sb-row--self { background: var(--rh-sb-accent-row); }
+.rh-sb-row--self:hover { background: var(--rh-sb-accent-row-hover); }
+
+.rh-sb-row--self::before {
+  content: "";
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 3px;
+  background: var(--rh-sb-accent);
+}
+
+.rh-sb-who { display: flex; align-items: center; gap: 11px; min-width: 0; }
+
+.rh-sb-avatar {
+  display: grid;
+  place-items: center;
+  width: 28px;
+  height: 28px;
+  flex-shrink: 0;
+  border-radius: var(--radius-record);
+  background: hsl(var(--rh-sb-avatar-hue, 220) 34% 26%);
+  font-family: var(--font-display);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  color: rgba(255, 255, 255, 0.92);
+  text-transform: uppercase;
+}
+
+.rh-sb-who__copy { min-width: 0; }
+
+.rh-sb-who__name {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--rh-sb-ink);
+}
+
+.rh-sb-who__handle { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
+.rh-sb-you {
+  flex-shrink: 0;
+  padding: 1px 5px;
+  border: 1px solid var(--rh-sb-accent-border);
+  border-radius: var(--radius-record);
+  background: var(--rh-sb-accent-dim);
+  color: var(--rh-sb-accent);
+  font-family: var(--font-display);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+}
+
+.rh-sb-who__meta { margin-top: 2px; font-size: 11px; color: var(--rh-sb-dim); }
+
+.rh-sb-what { min-width: 0; font-size: 13px; color: var(--rh-sb-subtle); }
+.rh-sb-what strong { color: var(--rh-sb-ink); font-weight: 600; }
+.rh-sb-what__sub { margin-top: 2px; font-size: 11.5px; color: var(--rh-sb-muted); }
+.rh-sb-what__sub.is-win { color: var(--rh-sb-win); }
+.rh-sb-what__sub.is-loss { color: var(--rh-sb-loss); }
+.rh-sb-what__sub.is-accent { color: var(--rh-sb-accent); }
+
+/* Outcome badge. Gold is reserved: only a skunk earns it. */
+.rh-sb-badge {
+  display: inline-flex;
+  align-items: center;
+  height: 17px;
+  margin-left: 7px;
+  padding: 0 5px;
+  border: 1px solid var(--rh-sb-line);
+  border-radius: var(--radius-record);
+  font-family: var(--font-display);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--rh-sb-muted);
+  vertical-align: 1px;
+}
+
+.rh-sb-badge--skunk { border-color: var(--rh-sb-accent-border); background: var(--rh-sb-accent-dim); color: var(--rh-sb-accent); }
+.rh-sb-badge--win { border-color: rgba(74, 222, 128, 0.4); color: var(--rh-sb-win); }
+.rh-sb-badge--loss { border-color: rgba(255, 77, 109, 0.36); color: var(--rh-sb-loss); }
+
+.rh-sb-score { font-variant-numeric: tabular-nums; }
+
+.rh-sb-score__line {
+  font-family: var(--font-display);
+  font-size: 21px;
+  font-weight: 700;
+  line-height: 1.05;
+  color: var(--rh-sb-ink);
+}
+
+.rh-sb-score__margin { font-size: 11.5px; font-weight: 600; color: var(--rh-sb-muted); }
+.rh-sb-score__margin.is-win { color: var(--rh-sb-win); }
+.rh-sb-score__margin.is-loss { color: var(--rh-sb-loss); }
+.rh-sb-score__margin.is-accent { color: var(--rh-sb-accent); }
+
+/* Mode is a neutral hairline tag, never gold. */
+.rh-sb-mode {
+  display: inline-flex;
+  align-items: center;
+  height: 20px;
+  padding: 0 7px;
+  border: 1px solid var(--rh-sb-line);
+  border-radius: var(--radius-record);
+  font-family: var(--font-display);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--rh-sb-muted);
+  white-space: nowrap;
+}
+
+.rh-sb-when {
+  text-align: right;
+  font-size: 12px;
+  color: var(--rh-sb-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.rh-sb-tfoot {
+  display: flex;
+  justify-content: center;
+  padding: 12px;
+  border-top: 1px solid var(--rh-sb-line);
+}
+
+.rh-sb-feed-state {
+  padding: 40px 24px;
+  text-align: center;
+}
+
+.rh-sb-feed-state__kicker {
+  display: block;
+  margin-bottom: 8px;
+  font-family: var(--font-display);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--rh-sb-label);
+}
+
+.rh-sb-feed-state strong { display: block; font-size: 15px; color: var(--rh-sb-ink); }
+.rh-sb-feed-state p { margin: 8px 0 0; font-size: 12.5px; color: var(--rh-sb-muted); }
+
+/* -------------------------------------------------------------- rail */
+
+.rh-sb-page .rh-sf-right-rail,
+.rh-sb-page .social-right-rail {
+  gap: 14px;
+}
+
+.rh-sb-page .rh-sf-widget,
+.rh-sb-page .rh-hub-rail-card,
+.rh-sb-page .social-right-card,
+.rh-sb-page .rh-social-card {
+  border-radius: var(--radius-record);
+  border: 1px solid var(--rh-sb-line);
+  background: var(--rh-sb-surface);
+  box-shadow: none;
+}
+
+.rh-sb-page .rh-sf-widget-title,
+.rh-sb-page .rh-hub-rail-title {
+  font-family: var(--font-display);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--rh-sb-label);
+}
+
+/* ---------------------------------------------------------- responsive */
+
+@media (max-width: 900px) {
+  .rh-sb-masthead { flex-direction: column; gap: 16px; padding: 20px 18px 18px; }
+  .rh-sb-masthead__actions { width: 100%; }
+  .rh-sb-btn { flex: 1; justify-content: center; }
+  .rh-sb-meta { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .rh-sb-meta__cell:nth-child(3) { border-left: 0; }
+  .rh-sb-meta__cell:nth-child(-n+2) { border-bottom: 1px solid var(--rh-sb-line-soft); }
+}
+
+/* The five-column grid needs a horizontal scroll on a phone — same
+   constraint the leaderboard board has. */
+@media (max-width: 620px) {
+  .rh-sb-table { overflow-x: auto; }
+  .rh-sb-thead,
+  .rh-sb-row { min-width: 560px; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .rh-sb-btn,
+  .rh-sb-row,
+  .rh-sb-filter { transition: none; }
+  .rh-sb-btn:hover,
+  .rh-sb-btn:active { transform: none; }
+}

--- a/client/src/social/socialBoard.css
+++ b/client/src/social/socialBoard.css
@@ -41,6 +41,9 @@
   gap: 14px;
 }
 
+/* Masthead + stat strip are one connected unit — no gap between them. */
+.rh-sb-masthead-wrap { display: flex; flex-direction: column; }
+
 /* ------------------------------------------------------------ masthead */
 
 .rh-sb-masthead {
@@ -213,9 +216,6 @@
   color: var(--rh-sb-accent);
 }
 
-.rh-sb-filter__icon { display: inline-flex; width: 13px; height: 13px; }
-.rh-sb-filter__icon svg { width: 100%; height: 100%; }
-
 /* ------------------------------------------------------------- table */
 
 .rh-sb-table {
@@ -289,7 +289,7 @@
   height: 28px;
   flex-shrink: 0;
   border-radius: var(--radius-record);
-  background: hsl(var(--rh-sb-avatar-hue, 220) 34% 26%);
+  background: hsl(var(--rh-sb-avatar-hue, 220) 40% 34%);
   font-family: var(--font-display);
   font-size: 11px;
   font-weight: 700;
@@ -304,6 +304,7 @@
   display: flex;
   align-items: center;
   gap: 7px;
+  min-width: 0;
   font-size: 13px;
   font-weight: 700;
   color: var(--rh-sb-ink);
@@ -324,11 +325,9 @@
   letter-spacing: 0.12em;
 }
 
-.rh-sb-who__meta { margin-top: 2px; font-size: 11px; color: var(--rh-sb-dim); }
-
-.rh-sb-what { min-width: 0; font-size: 13px; color: var(--rh-sb-subtle); }
+.rh-sb-what { min-width: 0; font-size: 13px; line-height: 1.35; color: var(--rh-sb-subtle); }
 .rh-sb-what strong { color: var(--rh-sb-ink); font-weight: 600; }
-.rh-sb-what__sub { margin-top: 2px; font-size: 11.5px; color: var(--rh-sb-muted); }
+.rh-sb-what__sub { display: block; margin-top: 3px; font-size: 11.5px; color: var(--rh-sb-muted); }
 .rh-sb-what__sub.is-win { color: var(--rh-sb-win); }
 .rh-sb-what__sub.is-loss { color: var(--rh-sb-loss); }
 .rh-sb-what__sub.is-accent { color: var(--rh-sb-accent); }
@@ -355,13 +354,19 @@
 .rh-sb-badge--win { border-color: rgba(74, 222, 128, 0.4); color: var(--rh-sb-win); }
 .rh-sb-badge--loss { border-color: rgba(255, 77, 109, 0.36); color: var(--rh-sb-loss); }
 
-.rh-sb-score { font-variant-numeric: tabular-nums; }
+.rh-sb-score {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  font-variant-numeric: tabular-nums;
+}
 
 .rh-sb-score__line {
   font-family: var(--font-display);
-  font-size: 21px;
+  font-size: 20px;
   font-weight: 700;
   line-height: 1.05;
+  letter-spacing: 0.01em;
   color: var(--rh-sb-ink);
 }
 
@@ -429,6 +434,7 @@
 
 .rh-sb-page .rh-sf-widget,
 .rh-sb-page .rh-hub-rail-card,
+.rh-sb-page .rh-hub-panel,
 .rh-sb-page .social-right-card,
 .rh-sb-page .rh-social-card {
   border-radius: var(--radius-record);
@@ -438,13 +444,25 @@
 }
 
 .rh-sb-page .rh-sf-widget-title,
-.rh-sb-page .rh-hub-rail-title {
+.rh-sb-page .rh-hub-rail-title,
+.rh-sb-page .rh-hub-rail-card-title,
+.rh-sb-page .rh-sf-widget-title--solo {
   font-family: var(--font-display);
   font-size: 11px;
   font-weight: 700;
   letter-spacing: 0.15em;
   text-transform: uppercase;
   color: var(--rh-sb-label);
+}
+
+/* Square the inner sub-panels the widgets draw (highlight tiles, ranked
+   rows) so nothing rounded survives inside a record. */
+.rh-sb-page .rh-sf-highlights-grid > article,
+.rh-sb-page .rh-sf-ranked-row,
+.rh-sb-page .rh-sf-online-chip,
+.rh-sb-page .rh-sf-rival-card,
+.rh-sb-page .rh-sf-tournament {
+  border-radius: var(--radius-record);
 }
 
 /* ---------------------------------------------------------- responsive */

--- a/client/src/social/socialBoard.css
+++ b/client/src/social/socialBoard.css
@@ -263,6 +263,7 @@
   background: transparent;
   text-align: left;
   cursor: pointer;
+  overflow: hidden;
   transition: background 120ms var(--rh-sb-ease);
 }
 


### PR DESCRIPTION
Rebuilds `/social` on the Daily Fritz leaderboard's "board" visual system, per the mockup we'd had sitting as an artifact since Aug 30 but never shipped. **Pure visual reskin — every data source, panel, filter, and the feed contents are unchanged.**

## What moves

| Element | Before | After |
|---|---|---|
| Masthead | Flat "Social" + 4 boxed stat tiles | Barlow Condensed display headline (gold dot) + tagline + Home / Find Players, on grid-paper ground |
| Stats | 4 separate boxes with note lines | One 34px strip fused to the masthead, hairline-split, notes → dim qualifiers |
| Filters | Pills | Square hairline tabs |
| Feed | Rounded per-item cards | One bordered table — Who · What happened · Score · Mode · When; your row gets a 3px gold left bar |
| Rail | Rounded glass cards | Square records (scoped overrides) |
| Gold | On every mode tag | Signal only — your row, skunk badge, Find Players CTA. Win-green / loss-red carry outcome; signed margin derived from existing metadata. |

Deferred from the mockup: the "Your Standing" rail card (needs a weekly-standing shape not cheaply available yet).

## Files

`socialBoard.css` (new, `rh-sb-*`, tokens only, `--radius-record` for the table, no `!important`), `SocialPageHero.tsx` (props reshaped — sole consumer is `ActivityFeedScreen`), `ActivityFeedPanel.tsx` (rows → table), `ActivityFeedScreen.tsx` (masthead wiring), `ActivityFeedPanel.board.test.tsx` (new).

Retired the dead `FeedCategoryIcon` / `badgeClass` and the `rh-af-rich-*` row markup; their orphaned rules in `activityFeed.css` are left for a follow-up.

## Verification

`tsc -b` · client `vitest` 211 files / 1580 tests · server `vitest` 218 / 1300 · `lint` (377, net-zero) · `lint:css` · `check:architecture` 20/20 · behaviour tests 39 files · production build + prerender — all green. Built in an isolated worktree; no overlap with the hooks-correctness branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JSNbHAMoP1ap8CNpxEBxmC