### PR TITLE
fix(friends): populated /friends list controls → 44px tap targets (#115)

### DIFF
--- a/client/src/friends/friendsScreen.css
+++ b/client/src/friends/friendsScreen.css
@@ -292,7 +292,14 @@
 /* ── Action buttons (inline in list rows) ── */
 .friends-page-action-btn {
   appearance: none;
-  padding: 4px 10px;
+  /* >=44px tap target (WCAG 2.5.5) — the label stays small; the hit area
+     doesn't. Matches the min-height treatment on .rh-nav-tab / .rh-back-button
+     / .rh-hub-filter. */
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 44px;
+  padding: 4px 12px;
   cursor: pointer;
   background: rgba(255, 255, 255, 0.04);
   border: 1px solid rgba(255, 255, 255, 0.08);
@@ -308,6 +315,11 @@
 
 .friends-page-action-btn:hover {
   filter: brightness(1.2);
+}
+
+.friends-page-action-btn:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.5);
+  outline-offset: 2px;
 }
 
 .friends-page-action-btn--invite {
@@ -625,6 +637,8 @@
     display: inline-flex !important;
     align-items: center;
     gap: 8px;
+    /* >=44px tap target — the divider border sits below the padded hit area. */
+    min-height: 44px;
     background: none;
     border: none;
     cursor: pointer;
@@ -634,7 +648,7 @@
     letter-spacing: 0.05em;
     text-transform: uppercase;
     color: var(--tier-standard, #3B82F6);
-    padding: 0 0 12px;
+    padding: 4px 0 12px;
     margin-bottom: 4px;
     border-bottom: 1px solid rgba(255, 255, 255, 0.06);
     width: 100%;


### PR DESCRIPTION
Closes #115.

The signed-in Friends list has sub-44px interactive controls (the mobile reachability gate misses them — it runs as a guest and only sees the signed-out gate; broader blind spot tracked in #116):

| Control | Before | After |
|---|---|---|
| Row **INVITE** / **REMOVE** (`.friends-page-action-btn`) | 51×**24** / 55×**24** | 55×**44** / 59×**44** |
| **← Back to Friends List** (`.friends-page-preview-back-btn`, single-pane) | full-width × **~30** | 660 × **44** |

- `min-height: 44px` + flex centering (matches the `.rh-nav-tab` / `.rh-back-button` / `.rh-hub-filter` treatment from #110). Labels stay small; only the hit area grows.
- Added `:focus-visible` outline to `.friends-page-action-btn` — REMOVE had no visible keyboard-focus indicator.

**Verified** on a real signed-in account at viewport 700: INVITE 55×44, REMOVE 59×44 (both focusable), back button 660×44. 68px rows accommodate the taller buttons; the two-pane→single-pane collapse behaviour (#112) is unchanged. `lint:css` + `vite build` green.

CSS-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)