### PR TITLE
feat(dev): server freshness gate — abort instead of testing stale code (#119)

### DIFF
--- a/client/e2e/globalSetup.ts
+++ b/client/e2e/globalSetup.ts
@@ -1,0 +1,32 @@
+import type { FullConfig } from '@playwright/test';
+// @ts-expect-error — build script module, not part of the app's TS program.
+import { checkServerFreshness, describeFreshness } from '../scripts/serverFreshness.mjs';
+
+/**
+ * Freshness gate — issue #119. Before any test runs, confirm the client dev
+ * server is serving the current working tree's config and not stale output
+ * (a server left running from before a postcss.config.js / vite.config.ts /
+ * dependency change silently serves e.g. unresolved `@media (--phone)`).
+ *
+ * The `mobile-reachability` project already guarantees this with its own
+ * `--strictPort` fresh server; this covers the `chromium` / `mobile-390`
+ * projects, which reuse whatever is on :5173 locally.
+ */
+export default async function globalSetup(config: FullConfig): Promise<void> {
+  const baseURL =
+    config.projects.find((p) => p.use.baseURL)?.use.baseURL ??
+    process.env.PLAYWRIGHT_BASE_URL ??
+    `http://localhost:${process.env.REACHABILITY ? 5233 : 5173}`;
+
+  const result = await checkServerFreshness(baseURL);
+
+  if (result.status === 'stale' || result.status === 'no-endpoint') {
+    throw new Error(
+      `\n\n${describeFreshness(result)}\n\n` +
+        `Aborting the whole run — testing against a stale server produces false results.\n`,
+    );
+  }
+  // fresh / unreachable → proceed (Playwright's own webServer wait already
+  // covers a genuinely-down server).
+  console.log(`[freshness] ${describeFreshness(result)}`);
+}

--- a/client/package.json
+++ b/client/package.json
@@ -35,6 +35,7 @@
     "check:multiplayer-cycles": "depcruise src/multiplayer --config .dependency-cruiser.multiplayer-cycles.json --output-type err",
     "check:socket-registry": "npx tsx scripts/validateSocketEventRegistry.ts",
     "check:architecture": "npx tsx scripts/checkArchitectureInvariants.ts",
+    "check:server-fresh": "node scripts/checkServerFresh.mjs",
     "check:bot-match-lazy": "node scripts/checkBotMatchLazyBoundaries.mjs --dist",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/client/playwright.config.ts
+++ b/client/playwright.config.ts
@@ -16,6 +16,9 @@ const PHONE = { width: 390, height: 844 } as const;
 
 export default defineConfig({
   testDir: './e2e',
+  // Aborts the run if the client dev server is serving stale config (issue
+  // #119) — see e2e/globalSetup.ts.
+  globalSetup: './e2e/globalSetup.ts',
   fullyParallel: false,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 1 : 0,

--- a/client/scripts/checkServerFresh.mjs
+++ b/client/scripts/checkServerFresh.mjs
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+/**
+ * `npm run check:server-fresh [url]` — asserts the dev server at `url`
+ * (default http://localhost:5173) is serving the current working tree's
+ * config, not stale code. See issue #119.
+ *
+ * Exit 0: fresh, or no server reachable (nothing to check).
+ * Exit 1: stale server, or a server with no /__server_fingerprint endpoint.
+ */
+import { checkServerFreshness, describeFreshness } from './serverFreshness.mjs';
+
+const baseUrl = process.argv[2] ?? process.env.PLAYWRIGHT_BASE_URL ?? 'http://localhost:5173';
+const result = await checkServerFreshness(baseUrl);
+const line = describeFreshness(result);
+
+if (result.status === 'fresh' || result.status === 'unreachable') {
+  console.log(`✓ ${line}`);
+  process.exit(0);
+}
+
+console.error(`\n✗ ${line}\n`);
+process.exit(1);

--- a/client/scripts/serverFreshness.mjs
+++ b/client/scripts/serverFreshness.mjs
@@ -1,0 +1,118 @@
+/**
+ * Dev-server freshness check — see docs/breakpoints.md "Server isolation" and
+ * issue #119.
+ *
+ * A Vite dev server bakes its plugin/config graph at startup and does NOT pick
+ * up changes to postcss.config.js / vite.config.ts / tailwind config / installed
+ * deps on HMR. A server left running from before such a change silently serves
+ * stale output — e.g. unresolved `@media (--phone)` — and every check run
+ * against it is a lie (this cost two false-green reachability matrices and one
+ * false-red friendsScreen result).
+ *
+ * This module computes a fingerprint of exactly those restart-requiring inputs.
+ * The Vite plugin (configFingerprintPlugin in vite.config.ts) computes it once
+ * at startup and serves it at GET /__server_fingerprint; callers recompute it
+ * from disk and compare. Mismatch ⇒ the running server predates a config change
+ * ⇒ restart it.
+ */
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const clientDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+/** Files whose contents, if changed, require a dev-server restart to take effect. */
+const RESTART_REQUIRING_FILES = [
+  'postcss.config.js',
+  'vite.config.ts',
+  'tailwind.config.js',
+];
+
+/**
+ * Content hash of the restart-requiring inputs. `package.json` contributes only
+ * its dependency maps (a version bump changes the resolved plugin graph; a
+ * script or metadata edit does not).
+ */
+export function computeConfigFingerprint(baseDir = clientDir) {
+  const hash = createHash('sha256');
+  for (const rel of RESTART_REQUIRING_FILES) {
+    hash.update(rel);
+    hash.update('\0');
+    try {
+      hash.update(readFileSync(path.join(baseDir, rel)));
+    } catch {
+      hash.update('<absent>');
+    }
+    hash.update('\0');
+  }
+  try {
+    const pkg = JSON.parse(readFileSync(path.join(baseDir, 'package.json'), 'utf8'));
+    hash.update(JSON.stringify({ d: pkg.dependencies ?? {}, dd: pkg.devDependencies ?? {} }));
+  } catch {
+    hash.update('<no package.json>');
+  }
+  return hash.digest('hex').slice(0, 16);
+}
+
+/** Current checkout identity — reported for context, never used as a pass/fail input. */
+export function readCheckoutIdentity(baseDir = clientDir) {
+  const git = (args) =>
+    execFileSync('git', args, { cwd: baseDir, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }).trim();
+  try {
+    return { branch: git(['rev-parse', '--abbrev-ref', 'HEAD']), sha: git(['rev-parse', '--short', 'HEAD']) };
+  } catch {
+    return { branch: 'unknown', sha: 'unknown' };
+  }
+}
+
+/** The full payload the Vite plugin serves and the checkers recompute. */
+export function localServerMeta(baseDir = clientDir) {
+  return { fingerprint: computeConfigFingerprint(baseDir), ...readCheckoutIdentity(baseDir) };
+}
+
+/**
+ * Fetch the running server's fingerprint and compare to the working tree.
+ * Returns { status: 'fresh' | 'stale' | 'unreachable' | 'no-endpoint', ... }.
+ */
+export async function checkServerFreshness(baseUrl, baseDir = clientDir) {
+  const local = localServerMeta(baseDir);
+  let server;
+  try {
+    const res = await fetch(new URL('/__server_fingerprint', baseUrl), { signal: AbortSignal.timeout(4000) });
+    if (res.status === 404) return { status: 'no-endpoint', baseUrl, local };
+    if (!res.ok) return { status: 'unreachable', baseUrl, local, detail: `HTTP ${res.status}` };
+    server = await res.json();
+  } catch (err) {
+    return { status: 'unreachable', baseUrl, local, detail: err?.message ?? String(err) };
+  }
+  const fresh = server.fingerprint === local.fingerprint;
+  return { status: fresh ? 'fresh' : 'stale', baseUrl, local, server };
+}
+
+/** One-line human summary for logs / abort messages. */
+export function describeFreshness(result) {
+  const { local, server } = result;
+  const at = (m) => (m ? `${m.branch} @ ${m.sha}` : '?');
+  switch (result.status) {
+    case 'fresh':
+      return `dev server at ${result.baseUrl} is fresh (${at(server)}, config ${local.fingerprint})`;
+    case 'no-endpoint':
+      return `dev server at ${result.baseUrl} has no /__server_fingerprint — it predates issue #119's plugin, or isn't a Vite dev server. Restart 'npm run dev'.`;
+    case 'unreachable':
+      return `no dev server reachable at ${result.baseUrl} (${result.detail}) — nothing to check`;
+    case 'stale':
+      return [
+        `STALE DEV SERVER at ${result.baseUrl}`,
+        `  server config fingerprint: ${server.fingerprint}   (${at(server)})`,
+        `  working tree fingerprint:  ${local.fingerprint}   (${at(local)})`,
+        server.branch !== local.branch || server.sha !== local.sha
+          ? `  → the server is running a DIFFERENT checkout (likely a stale worktree squatting the port).`
+          : `  → a restart-requiring config file changed since the server started.`,
+        `  Fix: kill that server and restart 'npm run dev' from ${local.branch} @ ${local.sha}.`,
+      ].join('\n');
+    default:
+      return `unknown freshness status: ${result.status}`;
+  }
+}

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -5,6 +5,8 @@ import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
 // @ts-expect-error — build script module, not part of the app's TS program.
 import { resolveAppVersion } from './scripts/appVersion.mjs';
+// @ts-expect-error — build script module, not part of the app's TS program.
+import { localServerMeta } from './scripts/serverFreshness.mjs';
 
 // Injects <link rel="preload" fetchpriority="high"> for hero images used as
 // CSS backgrounds on the home screen so Lighthouse discovers LCP resources
@@ -26,6 +28,24 @@ function preloadHeroImagePlugin(): Plugin {
       });
       if (!preloads.length) return html;
       return html.replace('</head>', `  ${preloads.join('\n  ')}\n  </head>`);
+    },
+  };
+}
+
+// Dev-only. Serves the restart-requiring-config fingerprint + checkout identity
+// (computed once at startup) so `check:server-fresh` and the Playwright
+// globalSetup can abort loudly instead of testing against a stale server.
+// See scripts/serverFreshness.mjs and issue #119.
+function configFingerprintPlugin(): Plugin {
+  return {
+    name: 'config-fingerprint',
+    apply: 'serve',
+    configureServer(server) {
+      const body = JSON.stringify(localServerMeta());
+      server.middlewares.use('/__server_fingerprint', (_req, res) => {
+        res.setHeader('content-type', 'application/json');
+        res.end(body);
+      });
     },
   };
 }
@@ -58,6 +78,7 @@ export default defineConfig({
       },
     }),
     preloadHeroImagePlugin(),
+    configFingerprintPlugin(),
   ],
   // Baked in rather than read from the environment at runtime: Vite only
   // exposes VITE_-prefixed variables, so Vercel's VERCEL_GIT_COMMIT_SHA could

--- a/docs/breakpoints.md
+++ b/docs/breakpoints.md
@@ -131,6 +131,16 @@ phone rules apply, and the matrix comes back green over a broken app. The first
 green matrix for this work was exactly that false pass; the `.rh-hub-filter`
 defect below only surfaced once the harness got its own fresh server.
 
+The rest of the Playwright surface (the `chromium` / `mobile-390` projects,
+which reuse whatever is on :5173 locally) and manual browser checks are covered
+by a **freshness gate** (issue #119): a dev-only Vite plugin serves a
+fingerprint of the restart-requiring config (`postcss.config.js`,
+`vite.config.ts`, `tailwind.config.js`, installed deps) plus the checkout's
+branch\@sha at `GET /__server_fingerprint`; `e2e/globalSetup.ts` and
+`npm run check:server-fresh` recompute it from the working tree and **abort
+loudly** — naming both the server's and the working tree's branch\@sha — if
+they differ.
+
 ### Status: green, 20 routes × 3 viewports (2026-09-07, verified on a
 ### freshly-started :5233 server — `lsof :5233` confirmed empty pre-run)
 


### PR DESCRIPTION
Closes #119.

## Problem
A Vite dev server bakes its plugin/config graph at startup and doesn't pick up `postcss.config.js` / `vite.config.ts` / dependency changes on HMR. A server left running from before such a change silently serves stale output (e.g. unresolved `@media (--phone)`). This phase: **2 false-green reachability matrices + 1 false-red friendsScreen result**, ~3–5 debugging rounds each.

## Mechanism
- **`scripts/serverFreshness.mjs`** — SHA-256 fingerprint of the restart-requiring inputs (`postcss.config.js`, `vite.config.ts`, `tailwind.config.js`, `package.json` dep maps) + the checkout's `branch @ sha`.
- **`configFingerprintPlugin`** in `vite.config.ts` (dev-only, `apply: 'serve'`) — computes it once at startup, serves `GET /__server_fingerprint`.
- **`e2e/globalSetup.ts`** (new, wired into `playwright.config.ts`) — recomputes from the working tree before any test; **hard-throws on mismatch** → Playwright aborts the whole run, exit 1, zero tests.
- **`npm run check:server-fresh [url]`** — same check standalone, for manual use.

## Wrong-worktree legibility
Both the abort and the CLI print **the server's and the working tree's `branch @ sha`**:
```
STALE DEV SERVER at http://localhost:5173
  server config fingerprint: bbb   (social-board-redesign @ 8a3706fb)
  working tree fingerprint:  aaa   (feat/server-freshness-check @ 280f0ae8)
  → the server is running a DIFFERENT checkout (likely a stale worktree squatting the port).
```
No more PID/`ps`-chain archaeology.

## Scope
- Runs **alongside** the reachability harness's `--strictPort` fresh server, not instead of it — that keeps its guarantee; this covers the `chromium` / `mobile-390` projects + manual checks that still reuse `:5173`.
- **Built-bundle SHA check deferred** — CI (`reuseExistingServer: false`) and Vercel builds can't go stale.

## Verified
fresh → proceeds with a log line; `postcss.config.js` edited after server start → `npx playwright test` exits 1, zero tests run; simulated worktree mismatch → the "DIFFERENT checkout" message; unreachable server → proceeds (exit 0). `tsc -b` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)