### PR TITLE
test(e2e): authenticated mobile-reachability pass — Phase 1, local-only (#116)

### DIFF
--- a/client/.gitignore
+++ b/client/.gitignore
@@ -24,5 +24,6 @@ dist-ssr
 *.sw?
 .vercel
 .env*.local
-# Reachability harness output: 63 diagnostic screenshots + matrix, regenerated each run
+# Reachability harness output: diagnostic screenshots + matrix, regenerated each run
 e2e/screenshots/mobile-reachability/
+e2e/screenshots/mobile-reachability-authed/

--- a/client/e2e/mobile-reachability.spec.ts
+++ b/client/e2e/mobile-reachability.spec.ts
@@ -26,12 +26,47 @@ import { fileURLToPath } from 'node:url';
  * no assertion. The red/green matrix is written to
  * e2e/screenshots/mobile-reachability/matrix.json after a full run.
  *
- * Auth-gated routes (stats/friends/social/settings/...) render their signed-out
- * gate as a guest; the gate itself must still pass both contracts.
+ * Two passes:
+ *  - default (guest): auth-gated routes (stats/friends/social/settings/...)
+ *    render their signed-out gate; the gate itself must still pass. Blocking.
+ *  - REACHABILITY_AUTHED=1 (npm run e2e:reachability:authed): reuses the
+ *    .auth/daily-fritz-qa.json fixture so those routes render real content.
+ *    Local-only, informational, auto-skips without a current fixture. See
+ *    issue #116.
  */
 
 const e2eDir = path.dirname(fileURLToPath(import.meta.url));
-const outDir = path.join(e2eDir, 'screenshots', 'mobile-reachability');
+const AUTHED = !!process.env.REACHABILITY_AUTHED;
+const authStatePath = path.resolve(process.cwd(), '.auth/daily-fritz-qa.json');
+const outDir = path.join(
+  e2eDir,
+  'screenshots',
+  AUTHED ? 'mobile-reachability-authed' : 'mobile-reachability',
+);
+
+/** The `sb-<ref>-auth-token` localStorage entry from the QA fixture, if current. */
+function readAuthTokenFromFixture(filePath: string): { name: string; value: string } | null {
+  if (!fs.existsSync(filePath)) return null;
+  try {
+    const state = JSON.parse(fs.readFileSync(filePath, 'utf8')) as {
+      origins?: Array<{ localStorage?: Array<{ name?: string; value?: string }> }>;
+    };
+    for (const origin of state.origins ?? []) {
+      for (const entry of origin.localStorage ?? []) {
+        if (!entry.name?.startsWith('sb-') || !entry.name.endsWith('-auth-token') || !entry.value) {
+          continue;
+        }
+        const session = JSON.parse(entry.value) as { expires_at?: unknown };
+        if (typeof session.expires_at === 'number' && session.expires_at > Date.now() / 1000 + 60) {
+          return { name: entry.name, value: entry.value };
+        }
+      }
+    }
+  } catch {
+    /* fall through */
+  }
+  return null;
+}
 
 const MIN_TAP = 44;
 const MIN_SPACING = 24;
@@ -82,8 +117,24 @@ type Cell = { route: string; bp: string; pass: boolean; violations: Violation[] 
 const jsonlPath = path.join(outDir, 'cells.jsonl');
 
 test.beforeEach(async ({ page }) => {
-  // Past the welcome gate, with a stable guest identity so identity-derived UI
-  // renders instead of a first-run prompt.
+  if (AUTHED) {
+    // Reuse the QA fixture's Supabase session, injected for whatever origin the
+    // reachability server runs on (storageState is per-origin; addInitScript is
+    // not). Auto-skip if there's no current fixture — run `npm run
+    // qa:capture-auth` to make one.
+    const token = readAuthTokenFromFixture(authStatePath);
+    test.skip(
+      !token,
+      'authed reachability needs a current .auth/daily-fritz-qa.json (npm run qa:capture-auth)',
+    );
+    await page.addInitScript((entry) => {
+      window.localStorage.setItem('hasSeenWelcome', '1');
+      window.localStorage.setItem(entry!.name, entry!.value);
+    }, token);
+    return;
+  }
+  // Guest pass: past the welcome gate, with a stable guest identity so
+  // identity-derived UI renders instead of a first-run prompt.
   await page.addInitScript(() => {
     window.localStorage.setItem('hasSeenWelcome', '1');
     window.localStorage.setItem('racehorse_guest_identity_v1', 'guest_e2e_reach_stable');
@@ -256,6 +307,9 @@ for (const bp of BREAKPOINTS) {
 }
 
 test.afterAll(async () => {
+  // Nothing to assemble if every test skipped (e.g. the authed pass with no
+  // .auth fixture) — cells.jsonl was never created.
+  if (!fs.existsSync(jsonlPath)) return;
   fs.mkdirSync(outDir, { recursive: true });
   // Assemble from the JSONL, keeping the last cell written per route|bp.
   const byKey = new Map<string, Cell>();

--- a/client/package.json
+++ b/client/package.json
@@ -44,6 +44,8 @@
     "preview": "vite preview",
     "e2e": "playwright test",
     "e2e:reachability": "REACHABILITY=1 playwright test --project=mobile-reachability",
+    "e2e:reachability:authed": "REACHABILITY_AUTHED=1 playwright test --project=mobile-reachability-authed",
+    "seed:reachability-qa": "node scripts/seedReachabilityQaData.mjs",
     "e2e:ui": "playwright test --ui",
     "e2e:headed": "playwright test --headed",
     "size-check": "node scripts/check-bundle-size.mjs"

--- a/client/playwright.config.ts
+++ b/client/playwright.config.ts
@@ -9,7 +9,7 @@ const repoRoot = path.resolve(clientDir, '..');
 // running from before a postcss.config.js / breakpoint change — silently serves
 // unresolved `@media (--phone)` etc. and makes the whole matrix a lie. Isolating
 // the port + forcing a rebuild is the fix.
-const REACHABILITY = !!process.env.REACHABILITY;
+const REACHABILITY = !!process.env.REACHABILITY || !!process.env.REACHABILITY_AUTHED;
 const CLIENT_PORT = REACHABILITY ? 5233 : 5173;
 const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? `http://localhost:${CLIENT_PORT}`;
 const PHONE = { width: 390, height: 844 } as const;
@@ -60,7 +60,7 @@ export default defineConfig({
     // 21 routes × 3 viewports). Sets its own viewport per test. Opt-in via
     // REACHABILITY=1 (npm run e2e:reachability) so it stays out of the blocking
     // `e2e` gate until its matrix is green. See docs/breakpoints.md.
-    ...(process.env.REACHABILITY
+    ...(process.env.REACHABILITY && !process.env.REACHABILITY_AUTHED
       ? [
           {
             name: 'mobile-reachability',
@@ -68,6 +68,20 @@ export default defineConfig({
             use: { ...devices['Desktop Chrome'] },
             // Each test settles, then measures twice 500ms apart; live-socket
             // routes can burn the full settle cap. 90s keeps well clear.
+            timeout: 90_000,
+          },
+        ]
+      : []),
+    // Authenticated reachability pass (issue #116) — same matrix, signed in via
+    // the .auth/daily-fritz-qa.json fixture so /friends, /stats, /settings etc.
+    // render real content. Local-only, informational; auto-skips without a
+    // fixture. `npm run e2e:reachability:authed`.
+    ...(process.env.REACHABILITY_AUTHED
+      ? [
+          {
+            name: 'mobile-reachability-authed',
+            testMatch: /mobile-reachability\.spec\.ts/,
+            use: { ...devices['Desktop Chrome'] },
             timeout: 90_000,
           },
         ]

--- a/client/scripts/seedReachabilityQaData.mjs
+++ b/client/scripts/seedReachabilityQaData.mjs
@@ -1,0 +1,140 @@
+/**
+ * One-time seed for the authenticated mobile-reachability pass (issue #116).
+ *
+ * The reachability harness's authed pass (`npm run e2e:reachability:authed`)
+ * signs in as the approved QA account so `/friends`, `/stats`, `/settings` etc.
+ * render real content instead of the signed-out gate. `/stats` and `/settings`
+ * only need a signed-in session; `/friends` needs actual friend rows. This
+ * script gives the QA account three accepted friendships, idempotently.
+ *
+ * It creates three clearly-marked, unroutable throwaway friend accounts
+ * (`*@qa.invalid`, RFC 6761 reserved) + their `profiles` rows, then inserts
+ * `friends` rows with status `accepted` using the service key (which bypasses
+ * the RLS policy that stops a client inserting anything but `pending`).
+ *
+ *   Requires (env, or client/.env + server/.env):
+ *     SUPABASE_URL, SUPABASE_SERVICE_KEY   (server/.env)
+ *     DAILY_FRITZ_QA_USER_ID               (the approved QA account, uuid)
+ *
+ *   Usage:
+ *     DAILY_FRITZ_QA_USER_ID=<uuid> node client/scripts/seedReachabilityQaData.mjs [--dry-run]
+ *
+ * This writes to production. It only ADDS marked test rows; it never deletes or
+ * modifies anything else. Run it once; re-runs are no-ops.
+ */
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const DRY_RUN = process.argv.includes('--dry-run');
+
+const FRIENDS = [
+  { email: 'reachability-qa-friend-1@qa.invalid', username: 'reach_qa_friend_1' },
+  { email: 'reachability-qa-friend-2@qa.invalid', username: 'reach_qa_friend_2' },
+  { email: 'reachability-qa-friend-3@qa.invalid', username: 'reach_qa_friend_3' },
+];
+
+function loadEnvFile(relPath) {
+  try {
+    const raw = readFileSync(resolve(__dirname, relPath), 'utf8');
+    const env = {};
+    for (const line of raw.split('\n')) {
+      const t = line.trim();
+      if (!t || t.startsWith('#')) continue;
+      const eq = t.indexOf('=');
+      if (eq > 0) env[t.slice(0, eq)] = t.slice(eq + 1);
+    }
+    return env;
+  } catch {
+    return {};
+  }
+}
+
+const fileEnv = { ...loadEnvFile('../.env'), ...loadEnvFile('../../server/.env') };
+const cfg = {
+  url: process.env.SUPABASE_URL ?? fileEnv.SUPABASE_URL,
+  serviceKey: process.env.SUPABASE_SERVICE_KEY ?? fileEnv.SUPABASE_SERVICE_KEY,
+  qaUserId: process.env.DAILY_FRITZ_QA_USER_ID?.trim(),
+};
+
+for (const [k, v] of Object.entries(cfg)) {
+  if (!v) {
+    console.error(`Missing ${k === 'qaUserId' ? 'DAILY_FRITZ_QA_USER_ID' : k.toUpperCase()}.`);
+    process.exit(1);
+  }
+}
+
+const svc = {
+  apikey: cfg.serviceKey,
+  Authorization: `Bearer ${cfg.serviceKey}`,
+  'Content-Type': 'application/json',
+};
+
+async function api(path, init = {}) {
+  const res = await fetch(new URL(path, cfg.url), { ...init, headers: { ...svc, ...init.headers } });
+  const text = await res.text();
+  if (!res.ok) throw new Error(`${init.method ?? 'GET'} ${path} → ${res.status}: ${text.slice(0, 300)}`);
+  return text ? JSON.parse(text) : null;
+}
+
+/** Find an auth user by email (admin API), or create it (confirmed). Returns its id. */
+async function ensureFriendUser({ email, username }) {
+  const found = await api(`/auth/v1/admin/users?email=${encodeURIComponent(email)}`);
+  const existing = (found?.users ?? found)?.find?.((u) => u.email === email) ?? null;
+  if (existing) return existing.id;
+  if (DRY_RUN) {
+    console.log(`  [dry-run] would create auth user ${email}`);
+    return null;
+  }
+  const created = await api('/auth/v1/admin/users', {
+    method: 'POST',
+    body: JSON.stringify({
+      email,
+      password: crypto.randomUUID() + crypto.randomUUID(),
+      email_confirm: true,
+      user_metadata: { username, seeded_by: 'seedReachabilityQaData' },
+    }),
+  });
+  return created.id;
+}
+
+async function ensureProfile(id, username) {
+  const rows = await api(`/rest/v1/profiles?id=eq.${id}&select=id`);
+  if (rows?.length) return;
+  if (DRY_RUN) return void console.log(`  [dry-run] would insert profile ${username}`);
+  await api('/rest/v1/profiles', {
+    method: 'POST',
+    headers: { Prefer: 'resolution=ignore-duplicates' },
+    body: JSON.stringify({ id, username }),
+  });
+}
+
+async function ensureFriendship(friendId) {
+  const rows = await api(
+    `/rest/v1/friends?select=id,status&or=(and(user_id.eq.${cfg.qaUserId},friend_user_id.eq.${friendId}),and(user_id.eq.${friendId},friend_user_id.eq.${cfg.qaUserId}))`,
+  );
+  if (rows?.some((r) => r.status === 'accepted')) return 'already-accepted';
+  if (DRY_RUN) {
+    console.log(`  [dry-run] would insert friends row (accepted) qa↔${friendId}`);
+    return 'would-create';
+  }
+  await api('/rest/v1/friends', {
+    method: 'POST',
+    headers: { Prefer: 'resolution=merge-duplicates' },
+    body: JSON.stringify({ user_id: cfg.qaUserId, friend_user_id: friendId, status: 'accepted' }),
+  });
+  return 'created';
+}
+
+console.log(
+  `${DRY_RUN ? '[dry-run] ' : ''}Seeding 3 accepted friendships for QA user ${cfg.qaUserId} @ ${cfg.url}`,
+);
+for (const friend of FRIENDS) {
+  console.log(`- ${friend.username}`);
+  const id = await ensureFriendUser(friend);
+  if (!id) continue;
+  await ensureProfile(id, friend.username);
+  console.log(`  friendship: ${await ensureFriendship(id)}`);
+}
+console.log('Done. Run `npm run qa:capture-auth` if the QA session fixture is stale, then `npm run e2e:reachability:authed`.');

--- a/docs/breakpoints.md
+++ b/docs/breakpoints.md
@@ -123,6 +123,16 @@ matrix is green and any regression fails the Client Validation job. Writes
 `e2e/screenshots/mobile-reachability/` (gitignored); CI uploads the matrix as
 an artifact.
 
+The guest pass measures auth-gated routes (`/friends`, `/stats`, `/settings`,
+…) at their **signed-out gate** — the populated screen behind it is not
+covered (issue #116). An **authenticated pass** —
+`npm run e2e:reachability:authed` — reuses the `.auth/daily-fritz-qa.json`
+fixture so those routes render real content. It is **local-only and
+informational** for now: it auto-skips without a current fixture
+(`npm run qa:capture-auth` to make one), and `client/scripts/seedReachabilityQaData.mjs`
+gives the QA account the friend rows `/friends` needs. Not wired into CI — that
+is a later call once it's proven stable (issue #116 options B/C).
+
 **Server isolation (load-bearing):** the harness runs on port **5233** with
 `reuseExistingServer: false` and `vite --strictPort`, so every run builds a
 fresh dev server. A stale server on :5173 — one left running from before a


### PR DESCRIPTION
Phase 1 of #116 (hybrid). **Local-only, informational — no CI changes.**

## Why
The guest reachability gate only sees the *signed-out gate* for `/friends`, `/stats`, `/settings`, `/social` — the populated screen is unverified. That's how the 24px `/friends` row buttons (#115) got past it.

## What's here
| Piece | |
|---|---|
| `npm run e2e:reachability:authed` | Same 20-route × 3-viewport matrix, signed in. Reuses `.auth/daily-fritz-qa.json` by injecting its Supabase session via `addInitScript` (per-origin, so it works on the `:5233` fresh server — `storageState` wouldn't). |
| Auto-skip | No current fixture → all 60 skip cleanly (`npm run qa:capture-auth` to make one). `afterAll` no longer throws on an all-skipped run. |
| `scripts/seedReachabilityQaData.mjs` | Idempotent. Adds 3 accepted friendships (+ marked `*@qa.invalid` throwaway friend accounts and `profiles` rows) to the QA account via the service key. **Writes to prod; only adds marked rows, never deletes.** Run once by a human with `DAILY_FRITZ_QA_USER_ID` — **not executed in this PR.** |
| Output isolation | Separate `mobile-reachability-authed/` dir (gitignored) so the two matrices don't clobber. |
| `docs/breakpoints.md` | Documents the authed pass + that it's not in CI yet. |

## Grep check (as scoped)
`daily-fritz-v2.spec.ts` and `spectator-mode.spec.ts` — the two existing authed specs — assert **nothing** about the QA account's friends / rating / stats / settings. Seeding is safe. `/stats` and `/settings` don't even need seeding (a signed-in session populates the page shell); only `/friends` needs data.

## Verified
- Authed pass: **60 skipped, exit 0** (clean auto-skip — the checked-in fixture is expired).
- Guest gate (blocking): **60/60, 20 routes green** — parameterisation didn't regress it.
- `tsc -b`, `lint:css` clean.

Phase 2 (a non-blocking CI job) is a separate call — #116 options B/C.

🤖 Generated with [Claude Code](https://claude.com/claude-code)