### PR TITLE
feat(scrubber): mid-match move-history scrubber — solo scope (PvF / Ghost / Daily Fritz)

### DIFF
--- a/client/e2e/mid-match-scrubber.spec.ts
+++ b/client/e2e/mid-match-scrubber.spec.ts
@@ -1,0 +1,71 @@
+import { test, expect, type Page } from '@playwright/test';
+
+/**
+ * Mid-match move-history scrubber (solo scope: Play vs Fritz).
+ *
+ * Verifies the scrubber appears once a move is logged, steps into history
+ * view-only, returns to live, and that its `< / >` controls meet the 44px
+ * mobile tap-target minimum (docs/mid-match-move-scrubber-plan.md item 7).
+ */
+
+test.describe.configure({ timeout: 60_000 });
+
+async function startFritzMatch(page: Page) {
+  await page.goto('/');
+  await page.getByLabel('Game modes').getByRole('button', { name: 'Single Player', exact: true }).click();
+  await page.getByText('Play vs Fritz', { exact: false }).first().click();
+  await expect(page.getByText('Start Match', { exact: false }).first()).toBeVisible({ timeout: 15_000 });
+  await page.getByText('Start Match', { exact: false }).first().click();
+
+  const handArea = page.locator('.wl-hand-area:visible, .hand-area:not(.pre-game-draw-hand-dock)');
+  const pickable = page.locator('.pre-game-draw-board__tile-slot.is-pickable').first();
+
+  // Draw phase: pick face-down tiles until the hand is dealt.
+  for (let i = 0; i < 12; i += 1) {
+    if (await handArea.first().isVisible().catch(() => false)) break;
+    if (await pickable.isVisible().catch(() => false)) {
+      await pickable.click().catch(() => {});
+    }
+    await page.waitForTimeout(1_000);
+  }
+  await expect(handArea.first()).toBeVisible({ timeout: 20_000 });
+}
+
+/** Drive one move so the log is non-empty regardless of who opens. */
+async function ensureFirstMoveLogged(page: Page) {
+  const dock = page.locator('[data-ui="scrubber-dock"]');
+  // Fritz opens automatically ~half the time; give it a moment.
+  if (await dock.isVisible({ timeout: 6_000 }).catch(() => false)) return;
+
+  // Otherwise it is the player's opening move: place the one legal tile.
+  const tile = page.locator('.hand-area .domino-tile').first();
+  await tile.click({ force: true });
+  const zone = page.locator('.placement-zone.active').first();
+  await zone.click({ force: true });
+  await expect(dock).toBeVisible({ timeout: 15_000 });
+}
+
+test('scrubber steps through history view-only and returns to live', async ({ page }) => {
+  await startFritzMatch(page);
+  await ensureFirstMoveLogged(page);
+
+  const dock = page.locator('[data-ui="scrubber-dock"]');
+  await expect(dock).toBeVisible();
+  await expect(dock.getByText('Live')).toBeVisible();
+
+  const prev = dock.getByLabel('Previous move');
+  const box = await prev.boundingBox();
+  expect(box, 'previous-move control has a measurable box').not.toBeNull();
+  expect(box!.width).toBeGreaterThanOrEqual(44);
+  expect(box!.height).toBeGreaterThanOrEqual(44);
+
+  await prev.click();
+  await expect(dock.getByText(/Move \d+ \/ \d+/)).toBeVisible();
+
+  // Hand is view-only while parked in history: every hand tile is disabled.
+  await expect(page.locator('.hand-area .domino-tile:not(.disabled)')).toHaveCount(0);
+  await expect(page.locator('.hand-area .domino-tile.disabled').first()).toBeVisible();
+
+  await dock.getByRole('button', { name: /Back to live/ }).click();
+  await expect(dock.getByText('Live')).toBeVisible();
+});

--- a/client/e2e/mid-match-scrubber.spec.ts
+++ b/client/e2e/mid-match-scrubber.spec.ts
@@ -8,7 +8,7 @@ import { test, expect, type Page } from '@playwright/test';
  * mobile tap-target minimum (docs/mid-match-move-scrubber-plan.md item 7).
  */
 
-test.describe.configure({ timeout: 60_000 });
+test.describe.configure({ timeout: 90_000 });
 
 async function startFritzMatch(page: Page) {
   await page.goto('/');
@@ -31,18 +31,36 @@ async function startFritzMatch(page: Page) {
   await expect(handArea.first()).toBeVisible({ timeout: 20_000 });
 }
 
-/** Drive one move so the log is non-empty regardless of who opens. */
+/**
+ * Get one move into the log so the scrubber appears — resilient to who opens.
+ * Fritz opens automatically ~half the time; the other half it is the player's
+ * turn, and a placement zone only exists once a hand tile is selected. Poll
+ * both paths rather than assuming one (CI is slower than local, so a fixed
+ * "give Fritz N seconds then force the player move" race is not safe).
+ */
 async function ensureFirstMoveLogged(page: Page) {
   const dock = page.locator('[data-ui="scrubber-dock"]');
-  // Fritz opens automatically ~half the time; give it a moment.
-  if (await dock.isVisible({ timeout: 6_000 }).catch(() => false)) return;
-
-  // Otherwise it is the player's opening move: place the one legal tile.
-  const tile = page.locator('.hand-area .domino-tile').first();
-  await tile.click({ force: true });
+  // A playable hand tile's accessible name is exactly "Domino N-N"; an
+  // unplayable one is "Domino N-N, not playable" — the `$` anchor excludes it.
+  const playable = page
+    .getByRole('group', { name: 'Your hand' })
+    .getByRole('button', { name: /^Domino \d-\d$/ });
   const zone = page.locator('.placement-zone.active').first();
-  await zone.click({ force: true });
-  await expect(dock).toBeVisible({ timeout: 15_000 });
+
+  const deadline = Date.now() + 45_000;
+  while (Date.now() < deadline) {
+    if (await dock.isVisible().catch(() => false)) return;
+    // Our turn? Select a playable tile, drop it on the first legal zone.
+    if (await playable.first().isVisible().catch(() => false)) {
+      await playable.first().click({ force: true }).catch(() => {});
+      if (await zone.isVisible({ timeout: 3_000 }).catch(() => false)) {
+        await zone.click({ force: true }).catch(() => {});
+        await page.waitForTimeout(1_000);
+      }
+    }
+    await page.waitForTimeout(1_500);
+  }
+  await expect(dock).toBeVisible({ timeout: 5_000 });
 }
 
 test('scrubber steps through history view-only and returns to live', async ({ page }) => {

--- a/client/src/analyzer/moveAnalyzer.ts
+++ b/client/src/analyzer/moveAnalyzer.ts
@@ -14,7 +14,7 @@ import type {
 } from './analysisTypes';
 import { buildConsequenceChainsForHand } from './consequenceChain';
 import { buildHandVerdict, segmentMoveLogByHand } from './handSegmentation';
-import { derivePostMoveReviewBoard } from './reviewBoardState';
+import { derivePostMoveReviewBoard } from '../modules/replay/reviewBoardState.ts';
 
 export type { AnalyzeMoveLogOptions, ConsequenceChain, HandAnalysis, OracleMode } from './analysisTypes';
 

--- a/client/src/bot/BotMatchScreenView.tsx
+++ b/client/src/bot/BotMatchScreenView.tsx
@@ -27,6 +27,7 @@ export function BotMatchScreenView({
   layout,
   hud,
   board,
+  historyScrubber,
   hand,
   coach,
   overlays,
@@ -130,6 +131,10 @@ export function BotMatchScreenView({
       getDebugSnapshot={debug.getDebugSnapshot}
       dailyFritzSubmitSucceededRef={debug.dailyFritzSubmitSucceededRef}
       boardRef={board.boardRef}
+      displayBoard={board.displayBoard}
+      viewingHistory={board.viewingHistory}
+      historyScrubberEnabled={historyScrubber.enabled}
+      historyScrubber={historyScrubber.state}
       lessonBoardPlacementMoves={board.lessonBoardPlacementMoves}
       activePlacementMoves={board.activePlacementMoves}
       selectedTile={board.selectedTile}

--- a/client/src/bot/botMatchScreenViewTypes.ts
+++ b/client/src/bot/botMatchScreenViewTypes.ts
@@ -3,6 +3,7 @@ export type {
   BotMatchLayoutViewModel,
   MatchHudViewModel,
   BoardViewModel,
+  MatchHistoryScrubberViewModel,
   HandViewModel,
   CoachViewModel,
   ModalOverlayViewModel,

--- a/client/src/bot/useBotMatchScreenController.ts
+++ b/client/src/bot/useBotMatchScreenController.ts
@@ -14,7 +14,7 @@ import { useGhostRuntime } from '../modules/ghost/useGhostRuntime.ts';
 import { useDailyFritzRuntime } from '../modules/daily/useDailyFritzRuntime.ts';
 import { useReviewRuntime } from '../modules/review/useReviewRuntime.ts';
 import { useFritzRatingDisplay } from '../modules/fritz/useFritzRatingDisplay.ts';
-import { useReplayRecorder } from '../modules/replay/index.ts';
+import { useReplayRecorder, useMatchHistoryScrubber } from '../modules/replay/index.ts';
 import { useLocalRunSession } from '../modules/bot-turn/index.ts';
 
 export function useBotMatchScreenController(props: BotMatchScreenProps): BotMatchScreenViewProps {
@@ -54,6 +54,8 @@ export function useBotMatchScreenController(props: BotMatchScreenProps): BotMatc
   );
 
   const localRun = useLocalRunSession(refs.setDrawSequenceActiveBoth);
+
+  const historyScrubber = useMatchHistoryScrubber(replay.moveLog);
 
   const authoring = useAuthoringCapture({
     isAuthoringMode: guidedBoot.isAuthoringMode,
@@ -159,5 +161,6 @@ export function useBotMatchScreenController(props: BotMatchScreenProps): BotMatc
     turns,
     rating,
     navigation,
+    historyScrubber,
   });
 }

--- a/client/src/bot/view-model/assembleBotMatchViewModel.ts
+++ b/client/src/bot/view-model/assembleBotMatchViewModel.ts
@@ -17,6 +17,7 @@ export function assembleBotMatchViewModel(args: CreateBotMatchViewModelArgs): Bo
     turns,
     rating,
     navigation,
+    historyScrubber,
   } = args;
 
   const {
@@ -129,9 +130,25 @@ export function assembleBotMatchViewModel(args: CreateBotMatchViewModelArgs): Bo
     fritzPresentation: turns.fritzPresentation ?? null,
   };
 
+  // The scrubber is a solo-play affordance only: no guided lesson, authoring,
+  // journey trial, lesson layout, pre-game draw, or finished game.
+  const historyScrubberEnabled =
+    !isGuidedMode &&
+    !isAuthoringMode &&
+    !isAuthoringV2Mode &&
+    !isGuidedV2Mode &&
+    !isJourneyTrial &&
+    !turns.isLessonLayoutMode &&
+    !preGameDrawActive &&
+    !match.gameOver;
+  const viewingHistory = historyScrubberEnabled && historyScrubber.viewingHistory;
+  const displayBoard = viewingHistory ? historyScrubber.historyBoard : match.board;
+
   const board = {
     boardRef: refs.boardRef,
     boneyardRef: refs.boneyardRef,
+    displayBoard,
+    viewingHistory,
     ghostBoardPulse: ghost.ghostBoardPulse,
     openEnds: presentation.openEnds,
     openEndsSum: presentation.openEndsSum,
@@ -324,6 +341,10 @@ export function assembleBotMatchViewModel(args: CreateBotMatchViewModelArgs): Bo
     layout,
     hud,
     board,
+    historyScrubber: {
+      enabled: historyScrubberEnabled,
+      state: historyScrubber,
+    },
     hand,
     coach,
     overlays,

--- a/client/src/bot/view-model/assembleBotMatchViewModel.ts
+++ b/client/src/bot/view-model/assembleBotMatchViewModel.ts
@@ -1,5 +1,6 @@
 import type { CreateBotMatchViewModelArgs } from './createBotMatchViewModelArgs.ts';
 import { buildHandRevealTileReveals } from './buildHandRevealTileReveals.ts';
+import { resolveHistoryScrubberView } from './resolveHistoryScrubberView.ts';
 import type { BotMatchScreenViewModel } from './botMatchViewModelTypes.ts';
 
 export function assembleBotMatchViewModel(args: CreateBotMatchViewModelArgs): BotMatchScreenViewModel {
@@ -130,19 +131,22 @@ export function assembleBotMatchViewModel(args: CreateBotMatchViewModelArgs): Bo
     fritzPresentation: turns.fritzPresentation ?? null,
   };
 
-  // The scrubber is a solo-play affordance only: no guided lesson, authoring,
-  // journey trial, lesson layout, pre-game draw, or finished game.
-  const historyScrubberEnabled =
-    !isGuidedMode &&
-    !isAuthoringMode &&
-    !isAuthoringV2Mode &&
-    !isGuidedV2Mode &&
-    !isJourneyTrial &&
-    !turns.isLessonLayoutMode &&
-    !preGameDrawActive &&
-    !match.gameOver;
-  const viewingHistory = historyScrubberEnabled && historyScrubber.viewingHistory;
-  const displayBoard = viewingHistory ? historyScrubber.historyBoard : match.board;
+  const {
+    enabled: historyScrubberEnabled,
+    viewingHistory,
+    displayBoard,
+  } = resolveHistoryScrubberView({
+    scrubber: historyScrubber,
+    liveBoard: match.board,
+    isGuidedMode,
+    isAuthoringMode,
+    isAuthoringV2Mode,
+    isGuidedV2Mode,
+    isJourneyTrial,
+    isLessonLayoutMode: turns.isLessonLayoutMode,
+    preGameDrawActive,
+    gameOver: match.gameOver,
+  });
 
   const board = {
     boardRef: refs.boardRef,
@@ -171,10 +175,11 @@ export function assembleBotMatchViewModel(args: CreateBotMatchViewModelArgs): Bo
     handAreaRef: refs.handAreaRef,
     handTileSize: presentation.handTileSize,
     lessonHandRowCount: presentation.lessonHandRowCount,
-    selectedTile,
+    selectedTile: viewingHistory ? null : selectedTile,
     setSelectedTile,
     setSelectedController,
-    handActive: presentation.handActive,
+    // Parked on a past move: the hand is view-only until "back to live".
+    handActive: presentation.handActive && !viewingHistory,
     botTurn: presentation.botTurn,
     drawSequenceActive: turns.drawSequenceActive,
     drawPulseIndex: turns.drawPulseIndex,

--- a/client/src/bot/view-model/botMatchViewModelTypes.ts
+++ b/client/src/bot/view-model/botMatchViewModelTypes.ts
@@ -7,7 +7,8 @@ import type { PivotalTurnSelection } from '../../training/pivotalReview/pivotalT
 import type { DailyFritzStartResponse } from '../../dailyFritz/api';
 import type { DailyFritzSetOverlayViewModel } from '../../dailyFritz/setOverlayViewModel';
 import type { GhostCompletionResult } from '../../ghost/api';
-import type { AppMode, Move, PlacementPosition, Tile } from '../../types';
+import type { AppMode, BoardState, Move, PlacementPosition, Tile } from '../../types';
+import type { MatchHistoryScrubberState } from '../../modules/replay/index.ts';
 import type { DailyFritzLeaderboardRow } from '../../dailyFritz/api';
 import type { GuidedMatchFinalDebrief } from '../../learn/guidedMatch/guidedMatchFinalDebrief';
 import type { HandOverTileReveal } from '../../components/handOver/handOverCopy';
@@ -129,6 +130,10 @@ export type MatchHudViewModel = {
 export type BoardViewModel = {
   boardRef: RefObject<BoardHandle | null>;
   boneyardRef: RefObject<HTMLDivElement | null>;
+  /** Board to render: the live board, or a projected historical board while scrubbing. */
+  displayBoard: BoardState | null;
+  /** True while the player is parked on a past move — board interaction is suppressed. */
+  viewingHistory: boolean;
   ghostBoardPulse: boolean;
   openEnds: number[];
   openEndsSum: number;
@@ -324,12 +329,19 @@ export type DebugViewModel = {
   lastBotChoice: BotChoice | null;
 };
 
+export type MatchHistoryScrubberViewModel = {
+  /** Whether the scrubber applies to this match mode (solo PvF / Ghost / Daily Fritz, in play). */
+  enabled: boolean;
+  state: MatchHistoryScrubberState;
+};
+
 export type BotMatchScreenViewModel = {
   match: BotMatchState;
   navigation: BotMatchNavigationViewModel;
   layout: BotMatchLayoutViewModel;
   hud: MatchHudViewModel;
   board: BoardViewModel;
+  historyScrubber: MatchHistoryScrubberViewModel;
   hand: HandViewModel;
   coach: CoachViewModel;
   overlays: OverlayViewModel;

--- a/client/src/bot/view-model/createBotMatchViewModelArgs.ts
+++ b/client/src/bot/view-model/createBotMatchViewModelArgs.ts
@@ -11,6 +11,7 @@ import type { UseFritzRatingDisplayResult } from '../../modules/fritz/useFritzRa
 import type { UseMatchNavigationResult } from '../../modules/match/hooks/useMatchNavigation.ts';
 import type { useAuthoringCapture } from '../../modules/guided/useAuthoringCapture.ts';
 import type { useMatchUiChrome } from '../useMatchUiChrome.ts';
+import type { MatchHistoryScrubberState } from '../../modules/replay/index.ts';
 
 type UseAuthoringCaptureResult = ReturnType<typeof useAuthoringCapture>;
 type UseMatchUiChromeResult = ReturnType<typeof useMatchUiChrome>;
@@ -29,4 +30,5 @@ export type CreateBotMatchViewModelArgs = {
   turns: UseMatchTurnStackResult;
   rating: UseFritzRatingDisplayResult;
   navigation: UseMatchNavigationResult;
+  historyScrubber: MatchHistoryScrubberState;
 };

--- a/client/src/bot/view-model/resolveHistoryScrubberView.test.ts
+++ b/client/src/bot/view-model/resolveHistoryScrubberView.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+import type { BoardState } from '../../types.ts';
+import type { MatchHistoryScrubberState } from '../../modules/replay/index.ts';
+import { resolveHistoryScrubberView } from './resolveHistoryScrubberView.ts';
+
+const liveBoard = { leftEnd: 3, rightEnd: 4 } as unknown as BoardState;
+const historyBoard = { leftEnd: 1, rightEnd: 2 } as unknown as BoardState;
+
+function scrubber(over: Partial<MatchHistoryScrubberState> = {}): MatchHistoryScrubberState {
+  return {
+    viewingHistory: false,
+    viewingIndex: null,
+    historyBoard: null,
+    position: 0,
+    total: 0,
+    viewedHandNumber: null,
+    movesBehindLive: 0,
+    canStepBack: false,
+    canStepForward: false,
+    stepBack: () => {},
+    stepForward: () => {},
+    jumpTo: () => {},
+    backToLive: () => {},
+    ...over,
+  };
+}
+
+function input(over: Partial<Parameters<typeof resolveHistoryScrubberView>[0]> = {}) {
+  return {
+    scrubber: scrubber(),
+    liveBoard,
+    isGuidedMode: false,
+    isAuthoringMode: false,
+    isAuthoringV2Mode: false,
+    isGuidedV2Mode: false,
+    isJourneyTrial: false,
+    isLessonLayoutMode: false,
+    preGameDrawActive: false,
+    gameOver: false,
+    ...over,
+  };
+}
+
+describe('resolveHistoryScrubberView', () => {
+  it('is enabled for a plain solo match in play', () => {
+    const view = resolveHistoryScrubberView(input());
+    expect(view.enabled).toBe(true);
+    expect(view.viewingHistory).toBe(false);
+    expect(view.displayBoard).toBe(liveBoard);
+  });
+
+  it.each([
+    'isGuidedMode',
+    'isAuthoringMode',
+    'isAuthoringV2Mode',
+    'isGuidedV2Mode',
+    'isJourneyTrial',
+    'isLessonLayoutMode',
+    'preGameDrawActive',
+    'gameOver',
+  ] as const)('is disabled when %s', (flag) => {
+    const view = resolveHistoryScrubberView(input({ [flag]: true }));
+    expect(view.enabled).toBe(false);
+    expect(view.viewingHistory).toBe(false);
+    expect(view.displayBoard).toBe(liveBoard);
+  });
+
+  it('swaps to the historical board while viewing when enabled', () => {
+    const view = resolveHistoryScrubberView(
+      input({ scrubber: scrubber({ viewingHistory: true, historyBoard, viewingIndex: 2 }) }),
+    );
+    expect(view.viewingHistory).toBe(true);
+    expect(view.displayBoard).toBe(historyBoard);
+  });
+
+  it('ignores the cursor when the scrubber is disabled (guided lesson mid-scroll)', () => {
+    const view = resolveHistoryScrubberView(
+      input({
+        isGuidedMode: true,
+        scrubber: scrubber({ viewingHistory: true, historyBoard, viewingIndex: 2 }),
+      }),
+    );
+    expect(view.viewingHistory).toBe(false);
+    expect(view.displayBoard).toBe(liveBoard);
+  });
+});

--- a/client/src/bot/view-model/resolveHistoryScrubberView.ts
+++ b/client/src/bot/view-model/resolveHistoryScrubberView.ts
@@ -1,0 +1,52 @@
+import type { MatchHistoryScrubberState } from '../../modules/replay/index.ts';
+import type { BoardState } from '../../types.ts';
+
+export interface HistoryScrubberViewInput {
+  scrubber: MatchHistoryScrubberState;
+  liveBoard: BoardState | null;
+  isGuidedMode: boolean;
+  isAuthoringMode: boolean;
+  isAuthoringV2Mode: boolean;
+  isGuidedV2Mode: boolean;
+  isJourneyTrial: boolean;
+  isLessonLayoutMode: boolean;
+  preGameDrawActive: boolean;
+  gameOver: boolean;
+}
+
+export interface HistoryScrubberView {
+  /** Whether the scrubber applies at all: solo PvF / Ghost / Daily Fritz, in play. */
+  enabled: boolean;
+  /** Enabled AND the cursor is parked on a past move. */
+  viewingHistory: boolean;
+  /** Board to render — the projected historical board while viewing, else the live board. */
+  displayBoard: BoardState | null;
+}
+
+/**
+ * Pure decision for the mid-match history scrubber on the bot match surface.
+ * The scrubber is a solo-play affordance only — never during a guided lesson,
+ * authoring, a journey trial, the lesson layout, the pre-game draw, or after
+ * the game is over.
+ */
+export function resolveHistoryScrubberView(
+  input: HistoryScrubberViewInput,
+): HistoryScrubberView {
+  const enabled =
+    !input.isGuidedMode &&
+    !input.isAuthoringMode &&
+    !input.isAuthoringV2Mode &&
+    !input.isGuidedV2Mode &&
+    !input.isJourneyTrial &&
+    !input.isLessonLayoutMode &&
+    !input.preGameDrawActive &&
+    !input.gameOver;
+
+  const viewingHistory = enabled && input.scrubber.viewingHistory;
+
+  return {
+    enabled,
+    viewingHistory,
+    displayBoard: viewingHistory ? input.scrubber.historyBoard : input.liveBoard,
+  };
+}

--- a/client/src/bot/view/board/BotMatchBoardStage.tsx
+++ b/client/src/bot/view/board/BotMatchBoardStage.tsx
@@ -7,7 +7,9 @@ import {
 import type { BoardHandle } from '../../../components';
 import { ErrorBoundary } from '../../../components/ErrorBoundary.tsx';
 import { PreGameTileDrawBoard } from '../../../match/preGameDraw/PreGameTileDrawBoard.tsx';
-import type { Move, PlacementPosition, Tile } from '../../../types.ts';
+import type { BoardState, Move, PlacementPosition, Tile } from '../../../types.ts';
+import { MatchHistoryScrubber } from '../../../modules/replay/index.ts';
+import type { MatchHistoryScrubberState } from '../../../modules/replay/index.ts';
 import type { AuthoredStep } from '../../../learn/guidedAuthoring.ts';
 import type { FrozenLesson } from '../../../learn/guidedAuthoring.ts';
 import type { GuidedMatchCaptureStatus } from '../../../learn/guidedMatch/guidedMatchCapture.ts';
@@ -57,6 +59,10 @@ export type BotMatchBoardStageProps = {
   getDebugSnapshot: () => HandLifecycleDebugSnapshot;
   dailyFritzSubmitSucceededRef: RefObject<boolean>;
   boardRef: RefObject<BoardHandle | null>;
+  displayBoard: BoardState | null;
+  viewingHistory: boolean;
+  historyScrubberEnabled: boolean;
+  historyScrubber: MatchHistoryScrubberState;
   lessonBoardPlacementMoves: Move[];
   activePlacementMoves: Move[];
   selectedTile: Tile | null;
@@ -70,6 +76,8 @@ export type BotMatchBoardStageProps = {
   onRequestLeave: () => void;
 };
 
+function noop() {}
+
 export function BotMatchBoardStage(props: BotMatchBoardStageProps) {
   const {
     preGameDrawActive,
@@ -81,6 +89,10 @@ export function BotMatchBoardStage(props: BotMatchBoardStageProps) {
     boneyardRef,
     boneyardDisplayCount = null,
     boardRef,
+    displayBoard,
+    viewingHistory,
+    historyScrubberEnabled,
+    historyScrubber,
     lessonBoardPlacementMoves,
     activePlacementMoves,
     selectedTile,
@@ -127,6 +139,11 @@ export function BotMatchBoardStage(props: BotMatchBoardStageProps) {
           <BoneyardCountPill ref={boneyardRef} count={boneyardDisplayCount ?? match.boneyard.length} />
         </div>
       )}
+      {historyScrubberEnabled && (
+        <div className="rh-scrubber-dock" data-ui="scrubber-dock">
+          <MatchHistoryScrubber scrubber={historyScrubber} />
+        </div>
+      )}
       <BotMatchGhostBoardOverlays
         isGhostMode={props.isGhostMode}
         ghostAgreementType={props.ghostAgreementType}
@@ -167,17 +184,24 @@ export function BotMatchBoardStage(props: BotMatchBoardStageProps) {
         <Board
           ref={boardRef}
           showZoomTray={isLessonLayoutMode}
-          board={match.board}
-          legalMoves={isLessonLayoutMode ? lessonBoardPlacementMoves : activePlacementMoves}
-          selectedTile={selectedTile}
+          board={viewingHistory ? displayBoard : match.board}
+          legalMoves={
+            viewingHistory
+              ? []
+              : isLessonLayoutMode
+                ? lessonBoardPlacementMoves
+                : activePlacementMoves
+          }
+          selectedTile={viewingHistory ? null : selectedTile}
           handNumber={match.handNumber}
           handOver={match.handOver}
           gameOver={match.gameOver}
-          lastPlayedTile={lastPlayedTile}
-          onPositionClick={onPositionClick}
+          lastPlayedTile={viewingHistory ? null : lastPlayedTile}
+          onPositionClick={viewingHistory ? noop : onPositionClick}
           tileSize={84}
           profileDailyFritz={enableDailyFritzProfiling}
-          fitMode="default"
+          fitMode={viewingHistory ? 'guided' : 'default'}
+          containFullBoard={viewingHistory}
         />
       </ErrorBoundary>
       {!isLessonLayoutMode && (

--- a/client/src/bot/view/board/BotMatchBoardStage.tsx
+++ b/client/src/bot/view/board/BotMatchBoardStage.tsx
@@ -117,7 +117,7 @@ export function BotMatchBoardStage(props: BotMatchBoardStageProps) {
 
   return (
     <>
-      {scoreToast && <BotMatchScoreToastOverlay scoreToast={scoreToast} />}
+      {scoreToast && !viewingHistory && <BotMatchScoreToastOverlay scoreToast={scoreToast} />}
       <BotMatchBoardDebugOverlays
         enableGuidedMatchCandidateCapture={props.enableGuidedMatchCandidateCapture}
         isJourneyTrial={props.isJourneyTrial}
@@ -145,7 +145,7 @@ export function BotMatchBoardStage(props: BotMatchBoardStageProps) {
         </div>
       )}
       <BotMatchGhostBoardOverlays
-        isGhostMode={props.isGhostMode}
+        isGhostMode={props.isGhostMode && !viewingHistory}
         ghostAgreementType={props.ghostAgreementType}
         ghostPlayedTile={props.ghostPlayedTile}
       />

--- a/client/src/modules/replay/MatchHistoryScrubber.css
+++ b/client/src/modules/replay/MatchHistoryScrubber.css
@@ -1,3 +1,14 @@
+.rh-scrubber-dock {
+  display: flex;
+  justify-content: center;
+  margin-top: 6px;
+  pointer-events: none;
+}
+
+.rh-scrubber-dock .rh-scrubber {
+  pointer-events: auto;
+}
+
 .rh-scrubber {
   display: flex;
   align-items: center;

--- a/client/src/modules/replay/MatchHistoryScrubber.css
+++ b/client/src/modules/replay/MatchHistoryScrubber.css
@@ -1,0 +1,65 @@
+.rh-scrubber {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 6px 10px;
+  border-radius: var(--radius-control);
+  background: rgba(10, 16, 28, 0.6);
+  backdrop-filter: blur(16px);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  font-family: var(--font-body);
+  user-select: none;
+}
+
+.rh-scrubber--viewing {
+  border-color: rgba(59, 130, 246, 0.45);
+}
+
+.rh-scrubber-step.rh-btn {
+  min-width: 44px;
+  min-height: 44px;
+  padding: 0;
+  font-family: var(--font-display);
+  font-size: 20px;
+  line-height: 1;
+}
+
+.rh-scrubber-label {
+  min-width: 118px;
+  text-align: center;
+  font-family: var(--font-display);
+  font-size: 14px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.95);
+  font-variant-numeric: tabular-nums;
+}
+
+.rh-scrubber:not(.rh-scrubber--viewing) .rh-scrubber-label {
+  color: var(--tier-standard);
+}
+
+.rh-scrubber-live.rh-btn {
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.rh-scrubber-live-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 5px;
+  border-radius: var(--radius-pill);
+  background: var(--tier-standard);
+  color: var(--bg-obsidian);
+  font-family: var(--font-display);
+  font-size: 12px;
+  font-weight: 800;
+  font-variant-numeric: tabular-nums;
+}

--- a/client/src/modules/replay/MatchHistoryScrubber.test.tsx
+++ b/client/src/modules/replay/MatchHistoryScrubber.test.tsx
@@ -1,0 +1,82 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { MatchHistoryScrubber } from './MatchHistoryScrubber.tsx';
+import type { MatchHistoryScrubberState } from './hooks/useMatchHistoryScrubber.ts';
+
+function state(over: Partial<MatchHistoryScrubberState> = {}): MatchHistoryScrubberState {
+  return {
+    viewingHistory: false,
+    viewingIndex: null,
+    historyBoard: null,
+    position: 6,
+    total: 6,
+    viewedHandNumber: null,
+    movesBehindLive: 0,
+    canStepBack: true,
+    canStepForward: false,
+    stepBack: vi.fn(),
+    stepForward: vi.fn(),
+    jumpTo: vi.fn(),
+    backToLive: vi.fn(),
+    ...over,
+  };
+}
+
+describe('MatchHistoryScrubber', () => {
+  it('renders nothing with an empty log', () => {
+    const { container } = render(<MatchHistoryScrubber scrubber={state({ total: 0 })} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('shows Live and disables next when at live', () => {
+    render(<MatchHistoryScrubber scrubber={state()} />);
+    expect(screen.getByText('Live')).toBeTruthy();
+    expect(screen.getByLabelText('Next move').hasAttribute('disabled')).toBe(true);
+    expect(screen.queryByText('Back to live')).toBeNull();
+  });
+
+  it('shows move position + hand and a back-to-live control when viewing history', () => {
+    render(
+      <MatchHistoryScrubber
+        scrubber={state({
+          viewingHistory: true,
+          viewingIndex: 2,
+          position: 3,
+          total: 6,
+          viewedHandNumber: 2,
+          canStepForward: true,
+          movesBehindLive: 3,
+        })}
+      />,
+    );
+    expect(screen.getByText(/Move 3 \/ 6/)).toBeTruthy();
+    expect(screen.getByText(/Hand 2/)).toBeTruthy();
+    expect(screen.getByText('3')).toBeTruthy(); // the new-moves badge
+    expect(screen.getByLabelText('Back to live, 3 new moves')).toBeTruthy();
+  });
+
+  it('wires the step and back-to-live callbacks', () => {
+    const s = state({ viewingHistory: true, canStepForward: true });
+    render(<MatchHistoryScrubber scrubber={s} />);
+    fireEvent.click(screen.getByLabelText('Previous move'));
+    fireEvent.click(screen.getByLabelText('Next move'));
+    fireEvent.click(screen.getByRole('button', { name: /Back to live/ }));
+    expect(s.stepBack).toHaveBeenCalledTimes(1);
+    expect(s.stepForward).toHaveBeenCalledTimes(1);
+    expect(s.backToLive).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables previous at the first move', () => {
+    render(<MatchHistoryScrubber scrubber={state({ viewingHistory: true, canStepBack: false })} />);
+    expect(screen.getByLabelText('Previous move').hasAttribute('disabled')).toBe(true);
+  });
+
+  it('singularises the new-move count', () => {
+    render(
+      <MatchHistoryScrubber
+        scrubber={state({ viewingHistory: true, movesBehindLive: 1 })}
+      />,
+    );
+    expect(screen.getByLabelText('Back to live, 1 new move')).toBeTruthy();
+  });
+});

--- a/client/src/modules/replay/MatchHistoryScrubber.tsx
+++ b/client/src/modules/replay/MatchHistoryScrubber.tsx
@@ -1,0 +1,85 @@
+import { Button } from '../../components/primitives/Button.tsx';
+import type { MatchHistoryScrubberState } from './hooks/useMatchHistoryScrubber.ts';
+import './MatchHistoryScrubber.css';
+
+export interface MatchHistoryScrubberProps {
+  scrubber: MatchHistoryScrubberState;
+}
+
+/**
+ * View-only control strip for stepping through the current match's move history.
+ * Presentational: all cursor logic lives in `useMatchHistoryScrubber`. The board
+ * itself is swapped by the match view model, not rendered here.
+ */
+export function MatchHistoryScrubber({ scrubber }: MatchHistoryScrubberProps) {
+  const {
+    viewingHistory,
+    position,
+    total,
+    viewedHandNumber,
+    movesBehindLive,
+    canStepBack,
+    canStepForward,
+    stepBack,
+    stepForward,
+    backToLive,
+  } = scrubber;
+
+  if (total === 0) return null;
+
+  return (
+    <div
+      className={`rh-scrubber${viewingHistory ? ' rh-scrubber--viewing' : ''}`}
+      data-ui="match-history-scrubber"
+    >
+      <Button
+        variant="ghost"
+        className="rh-scrubber-step"
+        onClick={stepBack}
+        disabled={!canStepBack}
+        aria-label="Previous move"
+      >
+        <span aria-hidden="true">‹</span>
+      </Button>
+
+      <span className="rh-scrubber-label" aria-live="polite">
+        {viewingHistory ? (
+          <>
+            Move {position} / {total}
+            {viewedHandNumber != null ? ` · Hand ${viewedHandNumber}` : ''}
+          </>
+        ) : (
+          'Live'
+        )}
+      </span>
+
+      <Button
+        variant="ghost"
+        className="rh-scrubber-step"
+        onClick={stepForward}
+        disabled={!canStepForward}
+        aria-label="Next move"
+      >
+        <span aria-hidden="true">›</span>
+      </Button>
+
+      {viewingHistory ? (
+        <Button
+          variant="secondary"
+          className="rh-scrubber-live"
+          onClick={backToLive}
+          aria-label={
+            movesBehindLive > 0
+              ? `Back to live, ${movesBehindLive} new ${movesBehindLive === 1 ? 'move' : 'moves'}`
+              : 'Back to live'
+          }
+        >
+          Back to live
+          {movesBehindLive > 0 ? (
+            <span className="rh-scrubber-live-count">{movesBehindLive}</span>
+          ) : null}
+        </Button>
+      ) : null}
+    </div>
+  );
+}

--- a/client/src/modules/replay/hooks/useMatchHistoryScrubber.test.ts
+++ b/client/src/modules/replay/hooks/useMatchHistoryScrubber.test.ts
@@ -1,0 +1,154 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import type { MoveEntry } from '../../../game/moveLogger.ts';
+import { useMatchHistoryScrubber } from './useMatchHistoryScrubber.ts';
+
+function entry(moveNumber: number, handNumber: number): MoveEntry {
+  return {
+    moveNumber,
+    handNumber,
+    player: moveNumber % 2 === 1 ? 'you' : 'opponent',
+    action: 'place',
+    tile: [moveNumber % 7, (moveNumber + 1) % 7],
+    position: 'left',
+    boardEnds: [0, 0],
+    handBefore: [],
+    validMoves: [],
+    pipDelta: 0,
+    pointsScored: 0,
+    boardState: [],
+    boardRenderState: null,
+    handSnapshot: [],
+    engineBestMove: null,
+  };
+}
+
+function log(count: number, handNumber = 1): MoveEntry[] {
+  return Array.from({ length: count }, (_, i) => entry(i + 1, handNumber));
+}
+
+describe('useMatchHistoryScrubber', () => {
+  it('starts live (not viewing history)', () => {
+    const { result } = renderHook(() => useMatchHistoryScrubber(log(4)));
+    expect(result.current.viewingHistory).toBe(false);
+    expect(result.current.viewingIndex).toBeNull();
+    expect(result.current.movesBehindLive).toBe(0);
+    expect(result.current.canStepForward).toBe(false);
+    expect(result.current.canStepBack).toBe(true);
+  });
+
+  it('is inert with an empty log', () => {
+    const { result } = renderHook(() => useMatchHistoryScrubber([]));
+    expect(result.current.canStepBack).toBe(false);
+    act(() => result.current.stepBack());
+    expect(result.current.viewingIndex).toBeNull();
+  });
+
+  it('stepBack from live lands on the last logged move', () => {
+    const { result } = renderHook(() => useMatchHistoryScrubber(log(4)));
+    act(() => result.current.stepBack());
+    expect(result.current.viewingHistory).toBe(true);
+    expect(result.current.viewingIndex).toBe(3);
+    expect(result.current.position).toBe(4);
+    expect(result.current.total).toBe(4);
+  });
+
+  it('steps backward and forward through the log', () => {
+    const { result } = renderHook(() => useMatchHistoryScrubber(log(4)));
+    act(() => result.current.stepBack());
+    act(() => result.current.stepBack());
+    expect(result.current.viewingIndex).toBe(2);
+    act(() => result.current.stepForward());
+    expect(result.current.viewingIndex).toBe(3);
+  });
+
+  it('stepForward past the last logged move returns to live', () => {
+    const { result } = renderHook(() => useMatchHistoryScrubber(log(4)));
+    act(() => result.current.stepBack());
+    expect(result.current.viewingIndex).toBe(3);
+    act(() => result.current.stepForward());
+    expect(result.current.viewingIndex).toBeNull();
+    expect(result.current.viewingHistory).toBe(false);
+  });
+
+  it('does not step before the first move', () => {
+    const { result } = renderHook(() => useMatchHistoryScrubber(log(3)));
+    act(() => result.current.jumpTo(0));
+    expect(result.current.canStepBack).toBe(false);
+    act(() => result.current.stepBack());
+    expect(result.current.viewingIndex).toBe(0);
+  });
+
+  it('jumpTo clamps to the valid range', () => {
+    const { result } = renderHook(() => useMatchHistoryScrubber(log(3)));
+    act(() => result.current.jumpTo(99));
+    expect(result.current.viewingIndex).toBe(2);
+    act(() => result.current.jumpTo(-5));
+    expect(result.current.viewingIndex).toBe(0);
+  });
+
+  it('backToLive clears the cursor', () => {
+    const { result } = renderHook(() => useMatchHistoryScrubber(log(4)));
+    act(() => result.current.jumpTo(1));
+    act(() => result.current.backToLive());
+    expect(result.current.viewingIndex).toBeNull();
+  });
+
+  it('reports how many moves are behind live and does not auto-snap when new moves land', () => {
+    const { result, rerender } = renderHook(
+      ({ entries }) => useMatchHistoryScrubber(entries),
+      { initialProps: { entries: log(4) } },
+    );
+    act(() => result.current.jumpTo(1));
+    expect(result.current.movesBehindLive).toBe(2);
+    rerender({ entries: log(6) });
+    // still parked on the same move
+    expect(result.current.viewingIndex).toBe(1);
+    expect(result.current.movesBehindLive).toBe(4);
+    expect(result.current.total).toBe(6);
+  });
+
+  it('drops back to live when the log is reset (rematch / new game)', () => {
+    const { result, rerender } = renderHook(
+      ({ entries }) => useMatchHistoryScrubber(entries),
+      { initialProps: { entries: log(5) } },
+    );
+    act(() => result.current.jumpTo(3));
+    expect(result.current.viewingIndex).toBe(3);
+    rerender({ entries: [] });
+    expect(result.current.viewingIndex).toBeNull();
+    expect(result.current.viewingHistory).toBe(false);
+  });
+
+  it('clamps the cursor when the log shrinks below it', () => {
+    const { result, rerender } = renderHook(
+      ({ entries }) => useMatchHistoryScrubber(entries),
+      { initialProps: { entries: log(8) } },
+    );
+    act(() => result.current.jumpTo(6));
+    rerender({ entries: log(3) });
+    expect(result.current.viewingIndex).toBeNull();
+  });
+
+  it('exposes the viewed entry hand number for hand-boundary labelling', () => {
+    const entries = [...log(3, 1), entry(4, 2), entry(5, 2)];
+    const { result } = renderHook(() => useMatchHistoryScrubber(entries));
+    act(() => result.current.jumpTo(4));
+    expect(result.current.viewedHandNumber).toBe(2);
+    act(() => result.current.jumpTo(1));
+    expect(result.current.viewedHandNumber).toBe(1);
+  });
+
+  it('derives a post-move board from the viewed entry and null when live', () => {
+    const entries = log(3);
+    const { result } = renderHook(() => useMatchHistoryScrubber(entries));
+    expect(result.current.historyBoard).toBeNull();
+    act(() => result.current.jumpTo(1));
+    // Projected from the viewed MoveEntry (not from live state): the entry is a
+    // 'place' action, so derivePostMoveReviewBoard returns its post-action board.
+    expect(result.current.historyBoard).not.toBeNull();
+    expect(result.current.viewingIndex).toBe(1);
+    act(() => result.current.backToLive());
+    expect(result.current.historyBoard).toBeNull();
+  });
+});

--- a/client/src/modules/replay/hooks/useMatchHistoryScrubber.ts
+++ b/client/src/modules/replay/hooks/useMatchHistoryScrubber.ts
@@ -1,5 +1,5 @@
 import { useCallback, useMemo, useState } from 'react';
-import { derivePostMoveReviewBoard } from '../../../analyzer/reviewBoardState.ts';
+import { derivePostMoveReviewBoard } from '../reviewBoardState.ts';
 import type { MoveEntry } from '../../../game/moveLogger.ts';
 import type { BoardState } from '../../../types.ts';
 

--- a/client/src/modules/replay/hooks/useMatchHistoryScrubber.ts
+++ b/client/src/modules/replay/hooks/useMatchHistoryScrubber.ts
@@ -1,0 +1,102 @@
+import { useCallback, useMemo, useState } from 'react';
+import { derivePostMoveReviewBoard } from '../../../analyzer/reviewBoardState.ts';
+import type { MoveEntry } from '../../../game/moveLogger.ts';
+import type { BoardState } from '../../../types.ts';
+
+export interface MatchHistoryScrubberState {
+  /** True while the player is parked on a past move rather than the live board. */
+  viewingHistory: boolean;
+  /** Index into moveLog being viewed, or null when live. */
+  viewingIndex: number | null;
+  /**
+   * Board projection for the viewed move (post-action), or null when live —
+   * the consumer renders the live board on null.
+   */
+  historyBoard: BoardState | null;
+  /** 1-based position of the viewed move; equals `total` when live. */
+  position: number;
+  total: number;
+  /** `handNumber` of the viewed entry, or null when live. */
+  viewedHandNumber: number | null;
+  /** Moves that have landed ahead of the viewed one — the "back to live" pill count. */
+  movesBehindLive: number;
+  canStepBack: boolean;
+  canStepForward: boolean;
+  stepBack: () => void;
+  stepForward: () => void;
+  jumpTo: (index: number) => void;
+  backToLive: () => void;
+}
+
+/**
+ * Owns the view-only history cursor for a live match's move log. It never
+ * touches game state: `historyBoard` is a pure projection of a logged
+ * `MoveEntry`, and every consumer treats a null cursor as "show live".
+ *
+ * New moves landing while the player views history do NOT snap them away
+ * (`movesBehindLive` drives a "back to live" pill instead). A log reset
+ * (rematch / new game) or a log that shrinks below the cursor forces live.
+ */
+export function useMatchHistoryScrubber(
+  moveLog: readonly MoveEntry[],
+): MatchHistoryScrubberState {
+  const total = moveLog.length;
+  const [viewingIndex, setViewingIndex] = useState<number | null>(null);
+
+  // Adjust-state-on-prop-change: the log was reset or trimmed under the cursor.
+  if (viewingIndex !== null && viewingIndex >= total) {
+    setViewingIndex(null);
+  }
+
+  const effectiveIndex =
+    viewingIndex !== null && viewingIndex < total ? viewingIndex : null;
+
+  const stepBack = useCallback(() => {
+    setViewingIndex((prev) => {
+      if (prev === null || prev >= total) return total > 0 ? total - 1 : null;
+      return Math.max(0, prev - 1);
+    });
+  }, [total]);
+
+  const stepForward = useCallback(() => {
+    setViewingIndex((prev) => {
+      if (prev === null || prev >= total) return null;
+      return prev + 1 >= total ? null : prev + 1;
+    });
+  }, [total]);
+
+  const jumpTo = useCallback(
+    (index: number) => {
+      if (total === 0) return;
+      setViewingIndex(Math.max(0, Math.min(total - 1, Math.trunc(index))));
+    },
+    [total],
+  );
+
+  const backToLive = useCallback(() => setViewingIndex(null), []);
+
+  const historyBoard = useMemo(
+    () =>
+      effectiveIndex === null
+        ? null
+        : derivePostMoveReviewBoard(moveLog[effectiveIndex]),
+    [moveLog, effectiveIndex],
+  );
+
+  return {
+    viewingHistory: effectiveIndex !== null,
+    viewingIndex: effectiveIndex,
+    historyBoard,
+    position: effectiveIndex === null ? total : effectiveIndex + 1,
+    total,
+    viewedHandNumber:
+      effectiveIndex === null ? null : moveLog[effectiveIndex].handNumber ?? null,
+    movesBehindLive: effectiveIndex === null ? 0 : total - 1 - effectiveIndex,
+    canStepBack: effectiveIndex === null ? total > 0 : effectiveIndex > 0,
+    canStepForward: effectiveIndex !== null,
+    stepBack,
+    stepForward,
+    jumpTo,
+    backToLive,
+  };
+}

--- a/client/src/modules/replay/index.ts
+++ b/client/src/modules/replay/index.ts
@@ -1,3 +1,5 @@
 export { ReplayRecorder } from './ReplayRecorder.ts';
 export type { ReplayMoveInput } from './ReplayRecorder.ts';
 export { useReplayRecorder } from './hooks/useReplayRecorder.ts';
+export { useMatchHistoryScrubber } from './hooks/useMatchHistoryScrubber.ts';
+export type { MatchHistoryScrubberState } from './hooks/useMatchHistoryScrubber.ts';

--- a/client/src/modules/replay/index.ts
+++ b/client/src/modules/replay/index.ts
@@ -3,3 +3,5 @@ export type { ReplayMoveInput } from './ReplayRecorder.ts';
 export { useReplayRecorder } from './hooks/useReplayRecorder.ts';
 export { useMatchHistoryScrubber } from './hooks/useMatchHistoryScrubber.ts';
 export type { MatchHistoryScrubberState } from './hooks/useMatchHistoryScrubber.ts';
+export { MatchHistoryScrubber } from './MatchHistoryScrubber.tsx';
+export type { MatchHistoryScrubberProps } from './MatchHistoryScrubber.tsx';

--- a/client/src/modules/replay/reviewBoardState.ts
+++ b/client/src/modules/replay/reviewBoardState.ts
@@ -1,7 +1,7 @@
 import { simulatePlacement } from '@racehorse/game-core';
-import type { BoardState, Tile } from '../types.ts';
-import type { MoveEntry } from '../game/moveLogger.ts';
-import { normalizeBoardRenderState } from '../game/moveLogger.ts';
+import type { BoardState, Tile } from '../../types.ts';
+import type { MoveEntry } from '../../game/moveLogger.ts';
+import { normalizeBoardRenderState } from '../../game/moveLogger.ts';
 
 /**
  * Move logs intentionally retain the pre-action board for evaluation. Game Review,

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -132,6 +132,10 @@ export default defineConfig({
           if (id.includes('/src/modules/fritz/fritzConfig')) return 'fritz-config';
           // Move log helpers used during play — isolate from analyzer so bot match does not fetch analysis code.
           if (id.includes('/src/game/moveLogger')) return 'move-logger';
+          // Post-move board projection: shared by play (mid-match scrubber) and
+          // analysis (moveAnalyzer replay oracle). Keep it with move-logger so the
+          // standard bot path never statically pulls the analyzer chunk.
+          if (id.includes('/src/modules/replay/reviewBoardState')) return 'move-logger';
           // Review UI is lazy-loaded — keep Board/DominoTile out of the analysis engine chunk.
           if (id.includes('/src/analyzer/GameReviewer')) return 'game-reviewer';
           if (id.includes('/src/analyzer/reviewSidebarCopy')) return 'game-reviewer';

--- a/docs/mid-match-move-scrubber-plan.md
+++ b/docs/mid-match-move-scrubber-plan.md
@@ -1,10 +1,43 @@
 # Mid-Match Move History Scrubber — Plan
 
 Date: 2026-09-08
-Status: **Investigated, not started.** Ready to pick up.
+Status: **Solo scope built** on `feat/mid-match-scrubber-solo` (2026-09-08, not
+pushed). PvF / Ghost / Daily Fritz only — multiplayer / tournament and the
+reconnect-backfill decision are deliberately out of this pass. See
+"Solo build — what shipped" below.
 Related: `docs/game-review-chess-parity-implementation-plan.md` (post-game
 review oracle — a separate, much larger effort; this feature shares none of
 its analysis machinery).
+
+---
+
+## Solo build — what shipped (`feat/mid-match-scrubber-solo`)
+
+5 commits, each scoped to a plan item, `tsc -b` / full client vitest 215-files-
+1616 / server vitest 218-1300 / lint 51-of-51 (0 errors) / lint:css /
+check:architecture 20-of-20 / check:deps / check:multiplayer-arch /
+check:socket-registry / check:bot-match-lazy all green.
+
+| Plan item | Commit | Notes |
+| :--- | :--- | :--- |
+| Lean scrubber (state) | `useMatchHistoryScrubber` hook | view-only cursor over `replay.moveLog`; `historyBoard` = `derivePostMoveReviewBoard(entry)` (reusable piece 1). No auto-snap on new moves; log-reset / shrink forces live. 13 tests. |
+| Lean scrubber (UI) | `MatchHistoryScrubber` control strip | `‹ / ›` + `Move N / M · Hand H` + `Back to live` w/ new-move badge. `rh-scrubber` scoped CSS, Button primitive, 44px targets. **Deviation:** the strip does *not* render its own `<Board>` (plan piece 2/3) — the existing bot board is swapped instead (see below). 6 tests. |
+| `viewingIndex` → swap display board | `wire history scrubber into solo BotMatchScreen` | **Plan inaccuracy corrected:** the plan assumed a `boardForDisplay` seam already existed in `bot/createBotMatchViewModel.ts`. It did not — the bot board renders `board={match.board}` directly in `BotMatchBoardStage`. This commit introduces the seam: `assembleBotMatchViewModel` computes `displayBoard` and threads it + `viewingHistory` through the `board` VM to `BotMatchBoardStage`, which renders `<Board>` off `displayBoard` with `containFullBoard` while scrubbing. Still within the ~1d estimate. |
+| Lock interaction while viewing | `lock hand + board overlays while viewing history` | hand tray forced `handActive=false` (all tiles disabled), selected tile cleared, ghost overlays + score toast suppressed. **The solo surface has no manual draw/pass buttons** (draw is engine-automatic via `usePlayerNoMoveEffect`) — that half of the plan item is multiplayer-only. Gate logic extracted to pure `resolveHistoryScrubberView` (11 tests). |
+| Back-to-live on new move | (folded into the hook) | no auto-snap; `movesBehindLive` drives the pill count. |
+| Hand-boundary handling | (folded into hook + UI) | `viewedHandNumber` from `MoveEntry.handNumber`; label shows `· Hand H`. Cross-boundary board changes are per-entry projections — already correct. |
+| Edge cases | — | optimistic-rollback = MP-only, skipped. Hand-over overlay occludes the dock and the log persists across hands, so walking back into a finished hand works once the modal is dismissed — no extra handling needed. |
+| Tests + 44px reachability | `e2e — solo scrubber steps history + 44px tap targets` | Playwright spec in the default `e2e` gate: drives a PvF first move, asserts dock appears, `‹` measures ≥44×44, step-back shows `Move N / M`, hand disabled, `Back to live` restores `Live`. |
+
+**Gating:** the scrubber is enabled only when NOT guided / authoring / journey /
+lesson-layout / pre-game-draw / game-over — i.e. genuine solo play in the three
+in-scope modes.
+
+**No hidden multiplayer coupling** was found in the solo surfaces:
+`BotMatchScreen` (PvF / Ghost / Daily Fritz) is fully separate from
+`multiplayer/`; `ReplayRecorder` already logs both players; the projection +
+`<Board>` are pure client. The only surprise was the missing display-board seam
+(above), which was in-estimate to add.
 
 ---
 


### PR DESCRIPTION
Implements the solo scope of `docs/mid-match-move-scrubber-plan.md` — a
chess.com-style, view-only move-history scrubber usable **during** a live solo
match. Multiplayer / tournament and the reconnect-backfill decision are
deliberately out of this pass.

## What's here (6 commits, scoped per plan item)

| Commit | Item |
| :--- | :--- |
| `useMatchHistoryScrubber` hook | view-only cursor over `replay.moveLog`; `historyBoard` = `derivePostMoveReviewBoard(entry)` (plan reusable piece 1). No auto-snap on new moves (`movesBehindLive` drives a pill); log reset / shrink forces live. 13 tests. |
| `MatchHistoryScrubber` control strip | `‹ / ›`, `Move N / M · Hand H`, `Back to live` + new-move badge. Scoped `rh-scrubber` CSS, `Button` primitive, 44px tap targets. 6 tests. |
| Wire into `BotMatchScreen` | via the view model, gated to solo play only. **Introduces the board-display seam** the bot side lacked — the plan assumed `bot/createBotMatchViewModel.ts` already had a `boardForDisplay`; it did not (renders `board={match.board}` directly). `assembleBotMatchViewModel` now computes `displayBoard` + `viewingHistory` and threads them to `BotMatchBoardStage`, which renders `<Board>` off `displayBoard` with `containFullBoard` while scrubbing. |
| Lock interaction while viewing | hand tray forced view-only (all tiles disabled), selected tile cleared, ghost overlays + score toast suppressed. The solo surface has no manual draw/pass buttons (draw is engine-automatic), so nothing else to disable. Gate logic → pure `resolveHistoryScrubberView`, 11 tests. |
| e2e | Playwright spec in the default `e2e` gate: drives a PvF first move, asserts dock appears, `‹` measures ≥ 44×44, step-back shows `Move N / M`, hand disabled, `Back to live` restores `Live`. **First run outside local — watching CI.** |
| docs | plan status + the `boardForDisplay`-seam correction. |

## Notes

- Rebased onto `main` post-D-CQ-5 (#124). The two files D-CQ-5 also touched
  (`assembleBotMatchViewModel.ts`, `botMatchViewModelTypes.ts`) 3-way-merged
  cleanly — edits were in disjoint regions.
- **No hidden multiplayer coupling** in the solo surfaces: `BotMatchScreen` is
  fully separate from `multiplayer/`; `ReplayRecorder` already logs both
  players; the projection + `<Board>` are pure client.

## Verification (post-rebase)

`tsc -b` · client vitest **215 / 1616** · server vitest **218 / 1300** · lint
**51/51 (0 errors)** · `lint:css` · `check:architecture` **20/20** ·
`check:deps` · `check:multiplayer-arch` · `check:socket-registry` ·
`check:bot-match-lazy` — all green. Scrubber e2e green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)