### PR TITLE
chore(guardrails): §8 — bundle-boundary checks need a fresh --dist build

### DIFF
--- a/ENGINEERING_GUARDRAILS.md
+++ b/ENGINEERING_GUARDRAILS.md
@@ -591,3 +591,67 @@ path, and every open challenge row is already unstartable) — but its routes ar
 **unmounted dead code on `main`** (`HARDENING_PLAN.md`, FC-DEAD-1), so INV-19
 and this detector are deliberately scoped to Daily Fritz; if the feature is
 revived, the tolerance path is part of that revival, not this guardrail.
+
+---
+
+## 8. Bundle-boundary checks must run against a fresh build, not the source graph
+
+**Rule:** the `BotMatchScreen` lazy-load boundary is verified two ways, and only
+one is authoritative. `checkBotMatchLazyBoundaries.mjs` **source-graph mode**
+walks static `import` statements from `BotMatchScreen.tsx` and flags a
+hard-coded list of known-heavy analyzer files; **`--dist` mode** scans the
+actual production chunks Rollup emitted. Source-graph mode *cannot see chunk
+assignment* — a module that is not itself on the forbidden list but is **shared
+between the bot path and the analyzer and gets hoisted by Rollup into the
+`analyzer-*` chunk** produces a static `BotMatchScreen → analyzer-*` edge that
+only `--dist` catches. So: any change that adds an import reachable from
+`BotMatchScreen` must be verified with `npm run build && npm run
+check:bot-match-lazy` (which passes `--dist`) — a bare
+`node scripts/checkBotMatchLazyBoundaries.mjs` or a stale `dist/` is not a
+check.
+
+**Closes:** the local-verification gap behind **PR #129** (mid-match move
+scrubber). `useMatchHistoryScrubber` imported `derivePostMoveReviewBoard` from
+`src/analyzer/reviewBoardState.ts` — a pure board projection `moveAnalyzer` also
+imports. Rollup hoisted the shared module into `analyzer-*`, giving
+`BotMatchScreen-*.js` a static `import … from "./analyzer-*.js"`. The bare
+source-graph script (run locally, no `--dist`) passed because `reviewBoardState`
+is not `moveAnalyzer`/`handSegmentation`/`consequenceChain`/`analysisTypes`. CI's
+`--dist` run caught it — but only on the *second* CI run, because the check runs
+after the e2e step in the Client Validation job and the first run's e2e failure
+stopped the job before it (the `ci-steps-hide-behind-earlier-failures` pattern).
+Fixed by moving the file to `src/modules/replay/reviewBoardState.ts` and pinning
+it to the `move-logger` chunk via `vite.config.ts` `manualChunks` — the same
+pattern already used for `botEngine` / `botHeuristics` / `moveLogger`, all
+play-path helpers `moveAnalyzer` imports.
+
+**Enforcement — BUILT:**
+- `.github/workflows/ci.yml` runs `npm run check:bot-match-lazy` (→
+  `checkBotMatchLazyBoundaries.mjs --dist`) as a **required** step in the Client
+  Validation job, *after* `npm run build --prefix client`. This has always been
+  the authoritative gate; a violation fails the merge.
+- **`--dist` now refuses a stale build.** `scanDistChunks` compares the newest
+  mtime under `src/` against the newest under `dist/assets/` and throws
+  `dist/ is older than src/ … Run npm run build first` rather than scanning an
+  out-of-date chunk set. This is what turns "run the check" into "run the check
+  meaningfully" — a stale `dist/` was previously a silent false-pass.
+- **Bare (source-graph) mode now prints a `⚠` banner** on every run stating that
+  it cannot see chunk assignment and will false-pass a hoisted shared module,
+  and that CI runs `--dist`.
+- **Negative test:** `checkBotMatchLazyBoundaries.test.ts` covers
+  `chunkHasForbiddenStaticImport` (static `analyzer-*` import flagged, lazy
+  `import()` / mapDeps metadata allowed) and `newestMtime` (0 for a missing
+  dir, positive for a real one — the stale-dist guard's primitive). Verified
+  against the repo: fresh build → pass; `touch src/bot/BotMatchScreen.tsx` →
+  stale-build throw.
+
+**Known limitation, stated plainly.** Source-graph mode's forbidden-file list
+(`moveAnalyzer|handSegmentation|consequenceChain|analysisTypes`) is still a
+hand-maintained approximation — it exists only as a fast local pre-filter and
+will keep drifting from reality. It is **not** trustworthy on its own and the
+banner now says so; the `--dist` build scan is the real check and the only one
+CI gates on. The stale-dist guard is mtime-based: a `git checkout` that resets
+all mtimes to the same instant, followed by a build, leaves `dist/` newer — the
+realistic CI and local sequence — but an unusual filesystem-clock or
+touch-everything scenario could theoretically defeat it. It is a guard against
+the common "forgot to rebuild" mistake, not a content hash.

--- a/client/scripts/checkBotMatchLazyBoundaries.mjs
+++ b/client/scripts/checkBotMatchLazyBoundaries.mjs
@@ -123,9 +123,34 @@ function scanSourceGraph() {
   return violations;
 }
 
+/** Newest mtime under a directory tree (ms), or 0 if the dir is missing. */
+export function newestMtime(dir) {
+  if (!fs.existsSync(dir)) return 0;
+  let newest = 0;
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    const mtime = entry.isDirectory()
+      ? newestMtime(full)
+      : fs.statSync(full).mtimeMs;
+    if (mtime > newest) newest = mtime;
+  }
+  return newest;
+}
+
 function scanDistChunks() {
   if (!fs.existsSync(DIST_ASSETS)) {
-    throw new Error('dist/assets not found — run npm run build before --dist');
+    throw new Error('dist/assets not found — run `npm run build` before --dist');
+  }
+
+  // A stale dist silently false-passes: the chunk scan is only meaningful
+  // against a build of the current source (this is exactly how PR #129's
+  // reviewBoardState chunk-hoisting slipped a local check — see
+  // ENGINEERING_GUARDRAILS.md §8).
+  if (newestMtime(SRC_ROOT) > newestMtime(DIST_ASSETS)) {
+    throw new Error(
+      'dist/ is older than src/ — the --dist chunk scan would check a stale build. ' +
+        'Run `npm run build` first.',
+    );
   }
 
   const violations = [];
@@ -161,6 +186,14 @@ function main() {
 
   if (checkDist) {
     violations.push(...scanDistChunks());
+  } else {
+    console.warn(
+      '⚠ source-graph mode only — this cannot see Rollup chunk assignment, so a ' +
+        'module shared with the analyzer that gets hoisted into the analyzer chunk ' +
+        'will FALSE-PASS here. CI runs `npm run check:bot-match-lazy` (which passes ' +
+        '--dist); run `npm run build && npm run check:bot-match-lazy` for the ' +
+        'authoritative check.',
+    );
   }
 
   if (violations.length === 0) {

--- a/client/scripts/checkBotMatchLazyBoundaries.test.ts
+++ b/client/scripts/checkBotMatchLazyBoundaries.test.ts
@@ -1,10 +1,15 @@
 import { describe, expect, it } from 'vitest';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import {
   chunkHasForbiddenStaticImport,
   isAnalyzerChunkRequest,
   isForbiddenRuntimeModule,
   isLessonV2ChunkRequest,
+  newestMtime,
 } from './checkBotMatchLazyBoundaries.mjs';
+
+const scriptsDir = path.dirname(fileURLToPath(import.meta.url));
 
 describe('checkBotMatchLazyBoundaries helpers', () => {
   it('detects forbidden runtime module paths', () => {
@@ -19,6 +24,11 @@ describe('checkBotMatchLazyBoundaries helpers', () => {
 
     const lazy = 'const d=(i,m,d=(m.f||(m.f=["assets/analyzer-BBq.js"])))=>i.map(i=>d[i]);import("./game-reviewer.js");';
     expect(chunkHasForbiddenStaticImport(lazy)).toEqual([]);
+  });
+
+  it('newestMtime: 0 for a missing dir, positive for a real one — the stale-dist guard', () => {
+    expect(newestMtime(path.join(scriptsDir, 'does-not-exist'))).toBe(0);
+    expect(newestMtime(scriptsDir)).toBeGreaterThan(0);
   });
 
   it('matches lesson-v2 and analyzer network URLs for dev and prod', () => {


### PR DESCRIPTION
Adds `ENGINEERING_GUARDRAILS.md` §8 and gives the `check:bot-match-lazy` script
the teeth the incident showed it was missing.

## Why

**PR #129** (mid-match scrubber): `useMatchHistoryScrubber` imported a board
projection that `moveAnalyzer` also imports; Rollup hoisted the shared module
into the `analyzer-*` chunk, giving `BotMatchScreen` a static analyzer import.
The bare `node scripts/checkBotMatchLazyBoundaries.mjs` (source-graph mode, run
locally) **false-passed** — it can't see chunk assignment. CI's `--dist` run
caught it, but only on the *second* run, because the check runs after the e2e
step and the first run's e2e failure stopped the job.

## Changes

- **`ENGINEERING_GUARDRAILS.md` §8** — states the rule (source-graph mode is a
  heuristic pre-filter; `--dist` against a fresh build is authoritative and is
  what CI gates on), cites PR #129, documents the known limitations plainly.
- **`checkBotMatchLazyBoundaries.mjs`:**
  - `--dist` now **throws on a stale build** — newest `src/` mtime > newest
    `dist/assets/` mtime → `dist/ is older than src/ … Run npm run build first`.
    A stale `dist/` was previously a silent false-pass.
  - Bare (source-graph) mode prints a `⚠` banner every run.
  - `newestMtime` exported; `checkBotMatchLazyBoundaries.test.ts` covers it.

## Verification (post-rebase onto current main)

`tsc -b`, client vitest **215/1617**, server vitest **218/1300**, lint **51/51
(0 errors)**, `lint:css`, `check:architecture` **20/20**, `check:deps`,
`check:multiplayer-arch`, `check:socket-registry`, `check:bot-match-lazy`
(`--dist`, fresh build) — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)