### PR TITLE
fix(social): bump .rh-sb-filter tap target to the 44px floor

### DIFF
--- a/client/src/social/socialBoard.css
+++ b/client/src/social/socialBoard.css
@@ -190,7 +190,15 @@
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  height: 30px;
+  /* 44px is the min tap-target height (same floor as the rest of the mobile
+     CSS — match-in-game.css / home-hub.css / rh-mobile-chrome.css all use
+     min-height: 44px for touch targets). The unpadded 30px height passed the
+     phone-portrait/tablet-portrait reachability breakpoints only because
+     WCAG 2.5.8's spacing exemption covered it there (enough gap between
+     filter chips); at phone-landscape the filters pack onto one row tightly
+     enough to lose that exemption, surfacing the real defect. Fixing the
+     height directly, not relying on the exemption to keep holding. */
+  min-height: 44px;
   padding: 0 12px;
   border: 1px solid var(--rh-sb-line);
   border-radius: var(--radius-control);


### PR DESCRIPTION
Closes issue #116's **M3** — the one finding from the authenticated mobile-reachability run. See `LAUNCH_READINESS_CHECKLIST.md`.

## What was found

Set up a dedicated QA account and ran `npm run e2e:reachability:authed` for real (60/60 executed, 0 skipped — see the M3 investigation report in-session for the account setup and raw per-route results). One failure: `/social` at phone-landscape (844×390) — two sub-44px tap targets.

```json
[
  { "kind": "tap", "label": "Wins",     "w": 52, "h": 30 },
  { "kind": "tap", "label": "Mentions", "w": 73, "h": 30 }
]
```

## Root cause

`.rh-sb-filter` (the `/social` feed's filter chips — Wins, Mentions, etc.) is `height: 30px` **unconditionally, at every breakpoint** — not a landscape-specific rule. It only failed the harness at phone-landscape: WCAG 2.5.8's spacing exemption (undersized targets are OK if every pair's centers are ≥24px apart) covered it at phone-portrait and tablet-portrait, where the chips have more room and don't pack as tightly. At phone-landscape's wider 844px row, the filters sit close enough together on one line to lose that exemption, surfacing the real underlying defect.

## Fix

`height: 30px` → `min-height: 44px`, matching the `min-height: 44px` convention already used for touch targets elsewhere in the mobile CSS (`match-in-game.css`, `home-hub.css`, `rh-mobile-chrome.css`). Fixing the actual size rather than leaving it dependent on the spacing exemption holding at the other two breakpoints.

`.rh-sb-filter` is scoped to this one file/component (`socialBoard.css` + `ActivityFeedPanel.tsx`) — confirmed no other breakpoint or screen reuses the class, so there's no other call site to check for a knock-on effect.

## Verification

`npm run e2e:reachability:authed` — **60/60 pass** (was 59/60; phone-portrait and tablet-portrait unaffected, still pass — no regression).

Full bar: client typecheck / lint (51/51) / lint:hooks / lint:css / vitest (215 files / 1617 tests) / `check:deps` / `check:multiplayer-arch` / `check:socket-registry` / `check:architecture` (20/20 CERTIFIED) / `check:bot-match-lazy` (fresh `--dist` build); server build + vitest (220 files / 1310 tests). All green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pog14A6F9zVfVtECAg8Y7Q