### PR TITLE
fix(social): bump .rh-sf-widget-link tap target to the 44px floor

### DIFF
--- a/client/src/social/activityFeedScreen.css
+++ b/client/src/social/activityFeedScreen.css
@@ -727,7 +727,16 @@
 .rh-sf-widget-link {
   display: inline-flex;
   width: 100%;
-  min-height: 42px;
+  /* 44px min tap-target floor — was 2px short. Same convention as
+     socialBoard.css's .rh-sb-filter fix: touched CSS in the same grid
+     (.rh-sf-layout-grid, which collapses to a single stacked column below
+     1080px, covering all three reachability breakpoints) can shift this
+     element's position enough to gain or lose the WCAG 2.5.8 spacing
+     exemption that was masking the undersized target — confirmed by
+     measurement, .rh-sb-filter's own 30->44px bump shifted this element
+     28px down the page. Fixing the size directly, not relying on
+     neighboring layout to keep the exemption holding. */
+  min-height: 44px;
   align-items: center;
   justify-content: center;
   gap: 6px;


### PR DESCRIPTION
Second finding from issue #116's **M3**, surfaced on the post-#135 confirmation run, not the original pass. See `LAUNCH_READINESS_CHECKLIST.md`.

## What was found

Re-running `e2e:reachability:authed` against merged `main` (as part of the standard post-merge full-bar check, per how #132–#134 were each confirmed) turned up a new failure: `/social` at phone-portrait — `.rh-sf-widget-link` ("View All Friends ›" in the friends rail card), 328×42.

`.rh-sf-widget-link` was `min-height: 42px` unconditionally, 2px under the floor. It passed every run before #135's merge — a genuinely new finding, not caused by #135's own change, but exposed by it.

## Layout-shift theory — confirmed by measurement, not left as an open question

`.rh-sf-widget-link` and `.rh-sb-filter` sit in the same `.rh-sf-layout-grid`, which collapses to a single stacked column below 1080px (`grid-template-columns: 1fr`) — covering all three reachability breakpoints. Probed `/social` at 390×844 with the real QA session, forcing `.rh-sb-filter` back to its pre-#135 `height: 30px` via an injected stylesheet and diffing document-relative positions before/after:

- `.rh-sb-filter`'s own height grew from 66px → 94px (wrapped 2 rows × (44-30) = 28px).
- `.rh-sf-widget-link`'s document-relative top shifted by **exactly 28px** — a 1:1 match.

Confirmed: growing one tap target in this shared single-column layout measurably repositions elements below it, which is what flipped the WCAG 2.5.8 spacing exemption that had been masking this element's own pre-existing defect.

## Fix

`min-height: 42px` → `44px`, same convention as `.rh-sb-filter`'s fix (#135).

## Also checked, per instruction — other near-floor interactive elements in the same two files

Found and **not fixed** (reporting only — neither currently fails the harness):
- `.rh-sf-challenge-btn` (`activityFeedScreen.css`, `min-height: 32px`) — real, rendered (`ActivityFeedScreen.tsx`), not currently failing.
- `.rh-sb-btn` (`socialBoard.css`, `height: 34px`) — real, rendered in multiple places (`ActivityFeedPanel.tsx`, `ActivityFeedScreen.tsx`), not currently failing.
- `.rh-sf-chat-btn` (`activityFeedScreen.css`, `height: 32px`) — dead CSS, zero consumers, can never render.

## Verification

`npm run e2e:reachability:authed` — **60/60 pass**, fresh JSONL. Worth recording: the harness's `cells.jsonl` **appends across runs rather than truncating** — cleared it before this run to get an unambiguous signal, and any future confirmation pass should do the same.

Full bar: client typecheck / lint (51/51) / lint:css / vitest (215 files / 1617 tests) / `check:deps` / `check:multiplayer-arch` / `check:socket-registry` / `check:architecture` (20/20 CERTIFIED) / `check:bot-match-lazy` (fresh `--dist` build); server build + vitest (220 files / 1310 tests). All green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pog14A6F9zVfVtECAg8Y7Q