### PR TITLE
fix(tournament): P1-2 — bracket load failure shows a real error, not a permanent spinner

### DIFF
--- a/client/e2e/routing.spec.ts
+++ b/client/e2e/routing.spec.ts
@@ -60,6 +60,19 @@ test.describe('browser routing', () => {
     await expect(page.locator('#root')).not.toBeEmpty({ timeout: 15_000 });
   });
 
+  test('a bad tournament id shows a real error and a way back, not a spinner', async ({ page }) => {
+    // `route-smoke` is not a UUID → the bracket fetch 400s `invalid_tournament_id`.
+    // Before P1-1/P1-2 this was a permanent "Loading bracket…" with 6 uncaught
+    // promise rejections and no message.
+    await page.goto('/tournament/route-smoke');
+    const alert = page.getByRole('alert');
+    await expect(alert).toContainText(/could not be found/i, { timeout: 15_000 });
+    await expect(alert.getByRole('button', { name: /back to tournament home/i })).toBeVisible();
+    await expect(page.getByText('Loading bracket…')).toHaveCount(0);
+    // The raw server code must not appear as copy.
+    await expect(page.getByText(/invalid_tournament_id/)).toHaveCount(0);
+  });
+
   test('browser back restores the previous routed screen', async ({ page }) => {
     await page.goto('/solo');
     await page.locator('.sp-solo-mode-card').filter({ hasText: 'Play vs Fritz' }).click();

--- a/client/src/match/session/tournament/useTournamentSessionLifecycle.ts
+++ b/client/src/match/session/tournament/useTournamentSessionLifecycle.ts
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import type { AppMode } from '../../../types';
 import * as tournamentApi from '../../../tournament/tournamentApi';
+import { tournamentErrorCopy } from '../../../tournament/tournamentErrorCopy';
 import { isTerminalTournamentMatch, markTerminalTournamentMatch } from '../../../tournament/terminalMatches';
 import { clearLastRoomCode } from '../../recovery/matchRecovery';
 import type { TournamentAttachRuntime } from '../../../multiplayer/runtime/tournamentRuntime';
@@ -165,7 +166,7 @@ export function useTournamentSessionLifecycle({
       })
       .catch((err) => {
         if (cancelled) return;
-        setTournamentResultError(err instanceof Error ? err.message : 'Failed to load tournament result');
+        setTournamentResultError(tournamentErrorCopy(err instanceof Error ? err.message : null));
       })
       .finally(() => {
         if (!cancelled) setTournamentResultLoading(false);

--- a/client/src/routes/tournamentRoutes.tsx
+++ b/client/src/routes/tournamentRoutes.tsx
@@ -1,6 +1,7 @@
 import React, { Suspense } from 'react';
 import { ScreenLoader } from '../ui/ScreenLoader';
 import { ErrorBoundary } from '../components/ErrorBoundary';
+import { tournamentErrorCopy } from '../tournament/tournamentErrorCopy';
 import type {
   AppRoutesShellProps,
   AppRoutesNavigationProps,
@@ -57,6 +58,7 @@ export function TournamentRoute({
           identity={tIdentity}
           tournamentId={activeTournamentId}
           bracket={tournament.activeBracket}
+          bracketError={tournament.bracketError}
           tournamentPhase={tournament.tournamentPhase}
           assignedMatch={
             tournament.assignedMatch?.tournamentId === activeTournamentId
@@ -128,7 +130,7 @@ export function TournamentRoute({
                   setTournamentResultError(null);
                 })
                 .catch((err) => {
-                  setTournamentResultError(err instanceof Error ? err.message : 'Failed to load tournament result');
+                  setTournamentResultError(tournamentErrorCopy(err instanceof Error ? err.message : null));
                 })
                 .finally(() => setTournamentResultLoading(false));
             }

--- a/client/src/tournament/TournamentBracketScreen.tsx
+++ b/client/src/tournament/TournamentBracketScreen.tsx
@@ -19,6 +19,7 @@ import {
   isBracketMatchCompletedForDisplay,
 } from './tournamentBracketDisplay';
 import { isTournamentBotId } from './displayNames';
+import { tournamentErrorCopy } from './tournamentErrorCopy';
 import type {
   BracketView,
   Registration,
@@ -35,6 +36,8 @@ export interface TournamentBracketScreenProps {
   identity: Identity;
   tournamentId: string;
   bracket: BracketView | null;
+  /** A failed bracket load, tagged with the id it belongs to (see useTournament). */
+  bracketError?: { tournamentId: string; code: string } | null;
   tournamentPhase?: TournamentUserPhase | null;
   assignedMatch?: TournamentAssignedMatch | null;
   countdownAt?: string | null;
@@ -600,6 +603,11 @@ export default function TournamentBracketScreen(props: TournamentBracketScreenPr
   const bracket: BracketView | null =
     props.bracket?.tournament.id === props.tournamentId ? props.bracket : null;
 
+  const loadErrorCode =
+    !bracket && props.bracketError?.tournamentId === props.tournamentId
+      ? props.bracketError.code
+      : null;
+
   const bracketDisplay = useMemo<BracketDisplayContext>(
     () => ({
       isBracketLobby,
@@ -856,7 +864,16 @@ export default function TournamentBracketScreen(props: TournamentBracketScreenPr
             </section>
           </div>
         ) : !isWaitingRoom ? (
-          <p className="tb-empty">Loading bracket…</p>
+          loadErrorCode ? (
+            <div className="tb-empty tb-empty--error" role="alert">
+              <p>{tournamentErrorCopy(loadErrorCode)}</p>
+              <button className="tb-terminal-banner__cta" type="button" onClick={props.onExitToHub}>
+                Back to Tournament Home
+              </button>
+            </div>
+          ) : (
+            <p className="tb-empty">Loading bracket…</p>
+          )
         ) : null}
 
         {isTerminalBracket ? (

--- a/client/src/tournament/tournamentBracket.css
+++ b/client/src/tournament/tournamentBracket.css
@@ -488,6 +488,16 @@
   padding: 32px 0;
 }
 
+.tb-empty--error {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+  max-width: 420px;
+  margin: 0 auto;
+  color: var(--text-secondary);
+}
+
 .tb-waiting {
   flex: 1 1 0;
   min-height: 0;

--- a/client/src/tournament/tournamentErrorCopy.test.ts
+++ b/client/src/tournament/tournamentErrorCopy.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { tournamentErrorCopy } from './tournamentErrorCopy';
+
+describe('tournamentErrorCopy', () => {
+  it('turns a missing / bad tournament into human copy, never the raw code', () => {
+    for (const code of ['invalid_tournament_id', 'not_found']) {
+      const copy = tournamentErrorCopy(code);
+      expect(copy).toMatch(/could not be found/i);
+      expect(copy).not.toContain(code);
+    }
+  });
+
+  it('explains an unfinished tournament distinctly', () => {
+    expect(tournamentErrorCopy('not_completed')).toMatch(/has not finished/i);
+  });
+
+  it('falls back to a generic message for unknown / empty codes without echoing them', () => {
+    expect(tournamentErrorCopy('some_internal_thing')).toMatch(/something went wrong/i);
+    expect(tournamentErrorCopy('some_internal_thing')).not.toContain('some_internal_thing');
+    expect(tournamentErrorCopy(null)).toMatch(/something went wrong/i);
+    expect(tournamentErrorCopy('')).toMatch(/something went wrong/i);
+  });
+});

--- a/client/src/tournament/tournamentErrorCopy.ts
+++ b/client/src/tournament/tournamentErrorCopy.ts
@@ -1,0 +1,22 @@
+/**
+ * Server tournament routes reply with machine codes (`invalid_tournament_id`,
+ * `not_found`, `not_completed`, …). Those must never reach a user as copy — a
+ * shared bracket link for a tournament that has since been cleared, a mistyped
+ * URL, or a stale bookmark is an ordinary way to land here.
+ *
+ * Anything not recognised falls through to a generic message rather than
+ * echoing the raw code (FEATURE_COMPLETENESS_AUDIT.md P1-2).
+ */
+export function tournamentErrorCopy(raw: string | null | undefined): string {
+  switch ((raw ?? '').trim()) {
+    case 'invalid_tournament_id':
+    case 'not_found':
+      return 'This tournament could not be found. It may have finished and been cleared, or the link may be out of date.';
+    case 'not_completed':
+      return 'This tournament has not finished yet — there are no results to show.';
+    case 'upstream_timeout':
+      return 'The tournament service is taking too long to respond. Try again in a moment.';
+    default:
+      return 'Something went wrong loading this tournament. Try again in a moment.';
+  }
+}

--- a/client/src/tournament/useTournament.ts
+++ b/client/src/tournament/useTournament.ts
@@ -155,6 +155,9 @@ export function useTournament({ userId }: Args) {
   const [upcoming, setUpcoming] = useState<ScheduledTournament[]>([]);
   const [registrations, setRegistrations] = useState<Registration[]>([]);
   const [activeBracket, setActiveBracket] = useState<BracketView | null>(null);
+  // A failed bracket load, tagged with the id it belongs to so a stale error
+  // never bleeds onto a different tournament's screen.
+  const [bracketError, setBracketError] = useState<{ tournamentId: string; code: string } | null>(null);
   const [pendingMatch, setPendingMatch] = useState<MatchReadyEvent | null>(null);
   const [recoveryMatch, setRecoveryMatch] = useState<TournamentMeResponse['activeAssignedMatch']>(null);
   const [tournamentPhase, setTournamentPhase] = useState<TournamentMeResponse['currentTournamentPhase']>(null);
@@ -205,8 +208,17 @@ export function useTournament({ userId }: Args) {
   }, []);
 
   const fetchAndApplyBracket = useCallback(async (tournamentId: string) => {
-    const view = await api.fetchBracket(tournamentId);
-    applyActiveBracket(view);
+    try {
+      const view = await api.fetchBracket(tournamentId);
+      applyActiveBracket(view);
+      setBracketError((prev) => (prev?.tournamentId === tournamentId ? null : prev));
+    } catch (err) {
+      // Never rethrow: every caller does `void tournament.openBracket(id)`, so a
+      // rejection here is an uncaught promise rejection the user never sees. A
+      // visible error state is the fix (FEATURE_COMPLETENESS_AUDIT.md P1-2).
+      const code = err instanceof Error && err.message ? err.message : 'bracket_load_failed';
+      setBracketError({ tournamentId, code });
+    }
   }, [applyActiveBracket]);
 
   const refresh = useCallback(async (): Promise<boolean> => {
@@ -455,6 +467,7 @@ export function useTournament({ userId }: Args) {
     upcoming,
     registrations,
     activeBracket,
+    bracketError,
     pendingMatch,
     recoveryMatch,
     tournamentPhase,

--- a/client/src/tournament/useTournamentBracketError.test.ts
+++ b/client/src/tournament/useTournamentBracketError.test.ts
@@ -1,0 +1,37 @@
+// @vitest-environment jsdom
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({ fetchBracket: vi.fn(), fetchMe: vi.fn(), fetchUpcoming: vi.fn(), fetchMyRegistrations: vi.fn() }));
+
+vi.mock('./tournamentApi', () => ({
+  fetchBracket: (...a: unknown[]) => mocks.fetchBracket(...a),
+  fetchMe: (...a: unknown[]) => mocks.fetchMe(...a),
+  fetchUpcoming: (...a: unknown[]) => mocks.fetchUpcoming(...a),
+  fetchMyRegistrations: (...a: unknown[]) => mocks.fetchMyRegistrations(...a),
+}));
+vi.mock('./recoverySignals', () => ({ bindTournamentRecoverySignals: () => () => undefined }));
+
+import { useTournament } from './useTournament';
+
+afterEach(() => vi.clearAllMocks());
+
+describe('useTournament bracket error handling (P1-2)', () => {
+  it('openBracket resolves — never rejects — and records the error tagged to the id', async () => {
+    mocks.fetchMe.mockResolvedValue({ registrations: [], activeAssignedMatch: null, currentTournamentPhase: null, activeTournamentId: null, assignedMatch: null, countdown: null });
+    mocks.fetchUpcoming.mockResolvedValue([]);
+    mocks.fetchMyRegistrations.mockResolvedValue([]);
+    mocks.fetchBracket.mockRejectedValue(new Error('invalid_tournament_id'));
+
+    const { result } = renderHook(() => useTournament({ userId: 'u1' }));
+
+    await act(async () => {
+      await expect(result.current.openBracket('bad-id')).resolves.toBeUndefined();
+    });
+
+    await waitFor(() => {
+      expect(result.current.bracketError).toEqual({ tournamentId: 'bad-id', code: 'invalid_tournament_id' });
+    });
+    expect(result.current.activeBracket).toBeNull();
+  });
+});


### PR DESCRIPTION
## FEATURE_COMPLETENESS_AUDIT.md §2 · P1-2

`/tournament/<unknown-id>` was a permanent **"Loading bracket…"** — the fetch 400s `invalid_tournament_id`, `openBracket` had no catch, every caller does `void tournament.openBracket(id)`, so each 20s poll threw an **uncaught promise rejection** and the null state was an unconditional spinner. Reachable via a shared link to a cleared tournament, a mistyped URL, or a stale bookmark.

### Fix
- `fetchAndApplyBracket` catches and records `bracketError` (`{ tournamentId, code }`, tagged so a stale error can't bleed onto another tournament's screen) instead of rethrowing → also kills the uncaught rejection on **every** caller, including the one the `/result` route triggers.
- The bracket screen renders a real error state — friendly message + **"Back to Tournament Home"** — when a load fails, matching `/result`'s "Result unavailable / RETRY" pattern.
- New `tournamentErrorCopy` maps server codes to copy; the raw `invalid_tournament_id` is no longer shown on either tournament sub-route (`/result` printed it verbatim).

### Verification of the specific failure
New e2e case (`routing.spec.ts`) loads `/tournament/route-smoke` (not a UUID → real 400 `invalid_tournament_id` from the server) and asserts: the error copy appears, the back button is visible, **"Loading bracket…" has count 0**, and the raw code never appears. Reproduces the exact original condition and asserts it now resolves.

### Tests
- `tournamentErrorCopy` unit — never echoes the raw code; not-found vs not-completed distinct.
- `useTournament` — `openBracket` resolves (not rejects) and records the tagged error.
- e2e as above.

Local: `tsc -b`, `test:all` (1621), `lint`, `lint:hooks`, `lint:css`, `check:architecture` 20/20. Client-only — server CI unaffected. Not merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pog14A6F9zVfVtECAg8Y7Q