### PR TITLE
fix(profile): P1-4 — signed-out visitors see a sign-in gate, not "Session expired"

### DIFF
--- a/client/e2e/routing.spec.ts
+++ b/client/e2e/routing.spec.ts
@@ -70,6 +70,15 @@ test.describe('browser routing', () => {
     await expect(page.getByRole('heading', { name: /single player/i })).toBeVisible();
   });
 
+  test('a signed-out visitor to a profile link sees a sign-in gate, not "session expired" (P1-4)', async ({ page }) => {
+    await page.goto('/players/route-smoke');
+    const alert = page.getByRole('alert');
+    await expect(alert).toContainText(/sign in to view player profiles/i, { timeout: 15_000 });
+    await expect(page.getByText(/session expired/i)).toHaveCount(0);
+    await expect(page.getByRole('button', { name: 'Sign in' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Back to home' })).toBeVisible();
+  });
+
   test('Social opens the global rating leaderboard', async ({ page }) => {
     await page.goto('/social');
     await page.getByRole('button', { name: 'View Leaderboard' }).click();

--- a/client/src/api/client.ts
+++ b/client/src/api/client.ts
@@ -147,9 +147,13 @@ async function apiFetch<T>(
     if (hadToken && typeof window !== 'undefined') {
       window.dispatchEvent(new CustomEvent('rh:session-expired'));
     }
+    // "again" only makes sense if there was a session to expire. A guest hitting
+    // a protected endpoint (e.g. a shared /players/:username link) never had one
+    // — telling them their session expired is factually wrong (P1-4).
     return {
       data: null,
-      error: 'Session expired. Please sign in again.',
+      error: hadToken ? 'Session expired. Please sign in again.' : 'Sign in to continue.',
+      errorCode: hadToken ? 'session_expired' : 'auth_required',
       status: 401,
     };
   }

--- a/client/src/routes/socialRoutes.tsx
+++ b/client/src/routes/socialRoutes.tsx
@@ -289,7 +289,7 @@ export function ProfileRoute({
 }) {
   const { withAuthModals, appRootClassName } = shell;
   const { setAppMode } = navigation;
-  const { authUser } = auth;
+  const { authUser, handleOpenAuthModal } = auth;
   const {
     showToast,
     profileTarget,
@@ -311,6 +311,7 @@ export function ProfileRoute({
             setProfileOriginMode(null);
             setAppMode(nextMode);
           }}
+          onOpenAuth={handleOpenAuthModal}
           onChallenge={() => setAppMode('multiplayer')}
         />
       </Suspense>

--- a/client/src/social/PublicProfileScreen.test.tsx
+++ b/client/src/social/PublicProfileScreen.test.tsx
@@ -90,6 +90,32 @@ describe('PublicProfileScreen identity presentation', () => {
     expect(screen.queryByText('Peak Rating')).toBeNull();
   });
 
+  it('shows a signed-out visitor a sign-in gate, not "session expired" (P1-4)', () => {
+    identityState.current = {
+      model: model({ sourceStatus: { ...model().sourceStatus, public_profile: 'error' } }),
+      loading: false,
+      error: 'Sign in to view player profiles.',
+    };
+    const onOpenAuth = vi.fn();
+    render(<PublicProfileScreen {...props} user={null} onOpenAuth={onOpenAuth} />);
+    expect(screen.getByRole('alert')).toHaveTextContent('Sign in to view player profiles.');
+    expect(screen.queryByText(/session expired/i)).toBeNull();
+    fireEvent.click(screen.getByRole('button', { name: 'Sign in' }));
+    expect(onOpenAuth).toHaveBeenCalled();
+    expect(screen.getByRole('button', { name: 'Back to home' })).toBeTruthy();
+  });
+
+  it('shows a signed-in visitor a distinct not-found state for an unknown username (P1-4)', () => {
+    identityState.current = {
+      model: model({ sourceStatus: { ...model().sourceStatus, public_profile: 'error' } }),
+      loading: false,
+      error: 'We couldn’t find a player called “ghostuser”.',
+    };
+    render(<PublicProfileScreen {...props} username="ghostuser" />);
+    expect(screen.getByRole('alert')).toHaveTextContent('We couldn’t find a player called “ghostuser”.');
+    expect(screen.queryByRole('button', { name: 'Sign in' })).toBeNull();
+  });
+
   it('provides a final-shape loading region', () => {
     identityState.current = { model: model(), loading: true, error: null };
     render(<PublicProfileScreen {...props} />);

--- a/client/src/social/PublicProfileScreen.tsx
+++ b/client/src/social/PublicProfileScreen.tsx
@@ -19,9 +19,10 @@ interface PublicProfileScreenProps {
   showToast: (msg: string) => void;
   onChallenge?: (username: string) => void;
   onSpectate?: (roomCode: string) => void;
+  onOpenAuth?: () => void;
 }
 
-export default function PublicProfileScreen({ username, user, onClose, showToast, onChallenge, onSpectate }: PublicProfileScreenProps) {
+export default function PublicProfileScreen({ username, user, onClose, showToast, onChallenge, onSpectate, onOpenAuth }: PublicProfileScreenProps) {
   const identityState = usePlayerIdentityModel({ subjectUserId: null, subjectUsername: username, currentUserId: user?.id ?? null });
   const model = identityState.model;
   const [addingFriend, setAddingFriend] = useState(false);
@@ -40,7 +41,31 @@ export default function PublicProfileScreen({ username, user, onClose, showToast
   }
 
   if (!model || model.sourceStatus.public_profile === 'error' || model.sourceStatus.public_profile === 'unavailable') {
-    return <div className="rh-pp-screen"><div className="rh-pp-header"><button type="button" className="rh-pp-back" onClick={onClose} aria-label="Back"><span aria-hidden="true">←</span></button></div><div className="rh-pp-error-state" role="alert">{identityState.error ?? 'Player not found.'}</div></div>;
+    // Profiles are auth-gated by design, so a signed-out visitor following a
+    // shared link always lands here — that is a sign-in gate, not an error, and
+    // it needs a way forward (P1-4).
+    const isGuestGate = !user;
+    return (
+      <div className="rh-pp-screen">
+        <div className="rh-pp-header">
+          <button type="button" className="rh-pp-back" onClick={onClose} aria-label="Back"><span aria-hidden="true">←</span></button>
+          <span className="rh-pp-breadcrumb">Player Profile</span>
+        </div>
+        <div className="rh-pp-error-state" role="alert">
+          <p className="rh-pp-error-state__message">
+            {isGuestGate
+              ? 'Sign in to view player profiles.'
+              : (identityState.error ?? `We couldn’t find a player called “${username}”.`)}
+          </p>
+          <div className="rh-pp-error-state__actions">
+            {isGuestGate && onOpenAuth ? (
+              <button type="button" className="rh-pp-error-state__cta" onClick={onOpenAuth}>Sign in</button>
+            ) : null}
+            <button type="button" className="rh-pp-error-state__link" onClick={onClose}>Back to home</button>
+          </div>
+        </div>
+      </div>
+    );
   }
 
   const featuredRelationship = model.identitySignals.featured.some((signal) => signal.domain === 'rivalry');

--- a/client/src/social/publicProfile.css
+++ b/client/src/social/publicProfile.css
@@ -48,7 +48,33 @@
 }
 
 .rh-pp-loading, .rh-pp-error-state { display: grid; place-items: center; min-height: 240px; color: var(--text-dim); }
-.rh-pp-error-state { color: var(--accent-red); }
+.rh-pp-error-state { gap: 20px; text-align: center; padding: 0 24px; }
+.rh-pp-error-state__message { margin: 0; color: var(--text-secondary); font-size: 15px; max-width: 360px; }
+.rh-pp-error-state__actions { display: flex; flex-wrap: wrap; gap: 12px; justify-content: center; align-items: center; }
+.rh-pp-error-state__cta {
+  border: 1px solid var(--tier-standard);
+  background: var(--tier-standard);
+  color: var(--bg-obsidian);
+  border-radius: var(--radius-control);
+  padding: 10px 20px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 120ms cubic-bezier(0.2, 0, 0, 1), box-shadow 120ms cubic-bezier(0.2, 0, 0, 1);
+}
+.rh-pp-error-state__cta:hover { transform: translateY(-1px); }
+.rh-pp-error-state__cta:active { transform: scale(0.97); }
+.rh-pp-error-state__link {
+  border: 1px solid var(--border-light);
+  background: transparent;
+  color: var(--text-secondary);
+  border-radius: var(--radius-control);
+  padding: 10px 20px;
+  font-size: 13px;
+  cursor: pointer;
+}
+.rh-pp-error-state__link:hover { color: var(--text-primary); }
+.rh-pp-error-state__cta:focus-visible, .rh-pp-error-state__link:focus-visible { outline: 2px solid var(--tier-standard); outline-offset: 3px; }
 .identity-loading-skeleton { display: grid; grid-template-columns: 76px minmax(180px, 320px); gap: 12px 18px; width: min(100% - 36px, 720px); padding: 24px; border: 1px solid var(--border-subtle); border-radius: var(--radius-md); background: var(--glass-bg); }
 .identity-loading-skeleton > * { background: rgba(255, 255, 255, 0.09); animation: identity-skeleton-pulse 1.4s ease-in-out infinite; }
 .identity-loading-skeleton__avatar { grid-row: span 2; width: 76px; height: 76px; border-radius: 50%; }

--- a/client/src/social/publicProfileGate.test.ts
+++ b/client/src/social/publicProfileGate.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+let currentUserId: string | null = 'user-0';
+vi.mock('../lib/supabase', () => ({
+  supabase: {
+    auth: {
+      getSession: async () => ({ data: { session: currentUserId ? { user: { id: currentUserId } } : null } }),
+    },
+  },
+}));
+
+const apiGet = vi.fn();
+vi.mock('../api/client', () => ({
+  apiGet: (...args: unknown[]) => apiGet(...args),
+  apiPost: vi.fn(),
+  apiDelete: vi.fn(),
+}));
+
+import { fetchPublicProfile } from './socialApi';
+import { clearCachedSession } from '../auth/sessionToken';
+
+let n = 0;
+beforeEach(() => {
+  n += 1;
+  currentUserId = `viewer-${n}`;
+  clearCachedSession();
+  apiGet.mockReset();
+});
+
+describe('fetchPublicProfile — P1-4 gate copy', () => {
+  it('a 401 reads as a sign-in gate, never "session expired"', async () => {
+    apiGet.mockResolvedValue({ data: null, error: 'Sign in to continue.', errorCode: 'auth_required', status: 401 });
+    const result = await fetchPublicProfile(`nobody-${n}`);
+    expect(result.profile).toBeNull();
+    expect(result.error).toBe('Sign in to view player profiles.');
+    expect(result.error).not.toMatch(/session expired/i);
+  });
+
+  it('a 404 reads as a distinct not-found, naming the username', async () => {
+    apiGet.mockResolvedValue({ data: null, error: 'Player not found.', status: 404 });
+    const result = await fetchPublicProfile(`Ghostuser${n}`);
+    expect(result.error).toContain(`ghostuser${n}`);
+    expect(result.error).toMatch(/couldn.t find/i);
+  });
+});

--- a/client/src/social/socialApi.ts
+++ b/client/src/social/socialApi.ts
@@ -364,14 +364,23 @@ export async function fetchPublicProfile(username: string): Promise<{ profile: P
     cacheKey: `${cacheScope}:${normalizedUsername}`,
     ttlMs: PUBLIC_PROFILE_TTL_MS,
     load: async () => {
-      try {
-        const data = await apiFetch<PublicProfileApiResponse>(
-          `/api/profile/${encodeURIComponent(normalizedUsername)}`,
-        );
-        return { profile: mapPublicProfileFromApi(data), error: null };
-      } catch (err) {
-        return { profile: null, error: err instanceof Error ? err.message : 'Player not found.' };
+      // Not the throwing `apiFetch` helper: the status/code decides the copy.
+      // Profiles are auth-gated by design, so a guest always 401s here — that is
+      // a sign-in gate, not "session expired", and a real 404 must read as a
+      // distinct not-found rather than an auth failure (P1-4).
+      const result = await apiGet<PublicProfileApiResponse>(
+        `/api/profile/${encodeURIComponent(normalizedUsername)}`,
+      );
+      if (!result.error && result.data) {
+        return { profile: mapPublicProfileFromApi(result.data), error: null };
       }
+      if (result.status === 401 || result.errorCode === 'auth_required') {
+        return { profile: null, error: 'Sign in to view player profiles.' };
+      }
+      if (result.status === 404) {
+        return { profile: null, error: `We couldn’t find a player called “${normalizedUsername}”.` };
+      }
+      return { profile: null, error: result.error ?? 'Player profile unavailable.' };
     },
   });
 }


### PR DESCRIPTION
## FEATURE_COMPLETENESS_AUDIT.md §2 · P1-4

A guest at any `/players/:username` URL saw **"← Session expired. Please sign in again."** — identical for a real username, a nonexistent one, and a garbage segment, with no route back but the arrow. The copy is false for someone who never had a session (the common case: a new player following a shared profile link), and a typo'd username was indistinguishable from an auth failure.

Profiles are auth-gated by design — this changes only what the client does with the 401.

### Fix
- `apiFetch` 401 branch distinguishes token vs no-token: had a token → "Session expired. Please sign in again." (`session_expired`); guest → "Sign in to continue." (`auth_required`).
- `fetchPublicProfile` reads status/code: 401 → "Sign in to view player profiles."; 404 → "We couldn't find a player called "x"."
- `PublicProfileScreen` failure state is a real gate: message + **"Sign in"** (opens the auth modal, threaded through `ProfileRoute`) + **"Back to home"**. Guests get the gate regardless of raw error; signed-in users get not-found / generic copy.

### Verification of the specific failure
- e2e: load `/players/route-smoke` **signed out** → assert "sign in to view player profiles", assert **"session expired" count 0**, assert Sign in + Back to home buttons visible.
- unit: `fetchPublicProfile` 401 → gate copy (never "session expired"); 404 → username-named not-found. `PublicProfileScreen` — guest gate with working Sign in; signed-in distinct not-found, no Sign in button.

Local: `tsc -b`, `test:all` (1621), `lint`, `lint:hooks`, `lint:css`, `check:architecture` 20/20. Client-only.

Note: trivial conflict with #139 in `PublicProfileScreen.test.tsx` (a `perfectDays` fixture field #139 removes) if #139 merges first — resolves by taking #139's line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pog14A6F9zVfVtECAg8Y7Q