### PR TITLE
refactor(api): consolidate the four throw-on-error API wrappers (R1)

### DIFF
--- a/client/src/api/client.ts
+++ b/client/src/api/client.ts
@@ -253,3 +253,62 @@ export async function apiDelete<T>(
     ...(body ? { body: JSON.stringify(body) } : {}),
   });
 }
+
+/**
+ * Throw-on-error variants of the request helpers above.
+ *
+ * Several feature API modules (`tournamentApi`, `ghost/api`, `homeDailySummaryApi`,
+ * `socialApi`) each declared their own 3-line `throwingGet` / `throwingPost`
+ * wrapper over `apiGet` / `apiPost`. Same shape every time: call, `throw` on
+ * `result.error`, return `result.data as T`. These are the shared version.
+ *
+ * `onError` lets a caller wrap the message before it throws (ghost turns a
+ * transport failure into a "start the server" hint); the default throws a plain
+ * `Error(message)`.
+ */
+type ApiThrowExtras = { onError?: (message: string, status?: number) => never };
+
+function throwApiError(
+  message: string,
+  status: number | undefined,
+  onError: ApiThrowExtras['onError'],
+): never {
+  if (onError) return onError(message, status);
+  throw new Error(message);
+}
+
+export async function apiGetOrThrow<T>(
+  path: string,
+  options?: { auth?: boolean; signal?: AbortSignal; headers?: Record<string, string> } & ApiThrowExtras,
+): Promise<T> {
+  const { onError, ...rest } = options ?? {};
+  const result = await apiGet<T>(path, rest);
+  if (result.error) throwApiError(result.error, result.status, onError);
+  return result.data as T;
+}
+
+export async function apiPostOrThrow<T>(
+  path: string,
+  body: unknown = {},
+  options?: {
+    auth?: boolean;
+    keepalive?: boolean;
+    signal?: AbortSignal;
+    headers?: Record<string, string>;
+  } & ApiThrowExtras,
+): Promise<T> {
+  const { onError, ...rest } = options ?? {};
+  const result = await apiPost<T>(path, body, rest);
+  if (result.error) throwApiError(result.error, result.status, onError);
+  return result.data as T;
+}
+
+export async function apiDeleteOrThrow<T>(
+  path: string,
+  body: unknown = {},
+  options?: ApiThrowExtras,
+): Promise<T> {
+  const result = await apiDelete<T>(path, body);
+  if (result.error) throwApiError(result.error, result.status, options?.onError);
+  return result.data as T;
+}

--- a/client/src/features/daily/homeDailySummaryApi.ts
+++ b/client/src/features/daily/homeDailySummaryApi.ts
@@ -1,10 +1,4 @@
-import { apiGet } from '../../api/client';
-
-async function throwingGet<T>(path: string): Promise<T> {
-  const result = await apiGet<T>(path);
-  if (result.error) throw new Error(result.error);
-  return result.data as T;
-}
+import { apiGetOrThrow } from '../../api/client';
 
 export interface HomeDailySummaryWeekDay {
   dateKey: string;
@@ -26,5 +20,5 @@ export interface HomeDailySummaryResponse {
 }
 
 export async function getHomeDailySummary(): Promise<HomeDailySummaryResponse> {
-  return throwingGet<HomeDailySummaryResponse>('/api/home/daily-summary');
+  return apiGetOrThrow<HomeDailySummaryResponse>('/api/home/daily-summary');
 }

--- a/client/src/ghost/api.ts
+++ b/client/src/ghost/api.ts
@@ -1,4 +1,4 @@
-import { apiGet, apiPost } from '../api/client';
+import { apiGetOrThrow, apiPostOrThrow } from '../api/client';
 import type { PlacementPosition, Tile } from '../types';
 
 const DEFAULT_SERVER_ORIGIN = 'http://localhost:3001';
@@ -14,17 +14,9 @@ function throwGhostError(error: string): never {
   throw new Error(error);
 }
 
-async function throwingGet<T>(path: string): Promise<T> {
-  const result = await apiGet<T>(path);
-  if (result.error) throwGhostError(result.error);
-  return result.data as T;
-}
-
-async function throwingPost<T>(path: string, body: unknown): Promise<T> {
-  const result = await apiPost<T>(path, body);
-  if (result.error) throwGhostError(result.error);
-  return result.data as T;
-}
+const throwingGet = <T>(path: string) => apiGetOrThrow<T>(path, { onError: throwGhostError });
+const throwingPost = <T>(path: string, body: unknown) =>
+  apiPostOrThrow<T>(path, body, { onError: throwGhostError });
 
 export type GhostMoveLogEntry = {
   turn: number;

--- a/client/src/social/socialApi.ts
+++ b/client/src/social/socialApi.ts
@@ -1,4 +1,4 @@
-import { apiGet } from '../api/client';
+import { apiGet, apiGetOrThrow } from '../api/client';
 import { supabase } from '../lib/supabase';
 import { getCachedSession } from '../auth/sessionToken';
 
@@ -15,13 +15,6 @@ async function authCacheScope(): Promise<string> {
     };
   });
   return userId ?? 'anon';
-}
-
-/** Throws on HTTP/auth failure — caught by exported loaders that return `{ error }`. */
-async function apiFetch<T>(path: string): Promise<T> {
-  const result = await apiGet<T>(path);
-  if (result.error) throw new Error(result.error);
-  return result.data as T;
 }
 
 type CacheEntry<T> = {
@@ -247,7 +240,7 @@ export async function fetchFriendsWithPresence(): Promise<{ friends: FriendWithP
     ttlMs: FRIENDS_WITH_PRESENCE_TTL_MS,
     load: async () => {
       try {
-        const data = await apiFetch<{ ok: boolean; friends: FriendWithPresence[] }>('/api/social/friends/with-presence');
+        const data = await apiGetOrThrow<{ ok: boolean; friends: FriendWithPresence[] }>('/api/social/friends/with-presence');
         return { friends: data.friends, error: null };
       } catch (err) {
         return { friends: [], error: err instanceof Error ? err.message : 'Failed to load friends.' };
@@ -265,7 +258,7 @@ export async function fetchActivityFeed(): Promise<{ feed: FeedItem[]; error: st
     ttlMs: ACTIVITY_FEED_TTL_MS,
     load: async () => {
       try {
-        const data = await apiFetch<{ ok: boolean; feed: FeedItem[] }>('/api/social/feed');
+        const data = await apiGetOrThrow<{ ok: boolean; feed: FeedItem[] }>('/api/social/feed');
         return { feed: data.feed, error: null };
       } catch (err) {
         return { feed: [], error: err instanceof Error ? err.message : 'Failed to load feed.' };
@@ -283,7 +276,7 @@ export async function fetchGlobalLeaderboard(): Promise<{ leaderboard: GlobalLea
     ttlMs: GLOBAL_LEADERBOARD_TTL_MS,
     load: async () => {
       try {
-        const data = await apiFetch<{ ok: boolean; leaderboard: GlobalLeaderboardEntry[]; self: GlobalLeaderboardEntry | null }>('/api/social/leaderboard/global');
+        const data = await apiGetOrThrow<{ ok: boolean; leaderboard: GlobalLeaderboardEntry[]; self: GlobalLeaderboardEntry | null }>('/api/social/leaderboard/global');
         return { leaderboard: data.leaderboard, self: data.self, error: null };
       } catch (err) {
         return { leaderboard: [], self: null, error: err instanceof Error ? err.message : 'Failed to load leaderboard.' };
@@ -294,7 +287,7 @@ export async function fetchGlobalLeaderboard(): Promise<{ leaderboard: GlobalLea
 
 export async function fetchFriendsLeaderboard(): Promise<{ leaderboard: LeaderboardEntry[]; error: string | null }> {
   try {
-    const data = await apiFetch<{ ok: boolean; leaderboard: LeaderboardEntry[] }>('/api/social/leaderboard/friends');
+    const data = await apiGetOrThrow<{ ok: boolean; leaderboard: LeaderboardEntry[] }>('/api/social/leaderboard/friends');
     return { leaderboard: data.leaderboard, error: null };
   } catch (err) {
     return { leaderboard: [], error: err instanceof Error ? err.message : 'Failed to load leaderboard.' };
@@ -303,7 +296,7 @@ export async function fetchFriendsLeaderboard(): Promise<{ leaderboard: Leaderbo
 
 export async function fetchWeeklyLeaderboard(): Promise<{ leaderboard: WeeklyLeaderboardEntry[]; self: WeeklyLeaderboardEntry | null; error: string | null }> {
   try {
-    const data = await apiFetch<{ ok: boolean; leaderboard: WeeklyLeaderboardEntry[]; self: WeeklyLeaderboardEntry | null }>('/api/social/leaderboard/weekly');
+    const data = await apiGetOrThrow<{ ok: boolean; leaderboard: WeeklyLeaderboardEntry[]; self: WeeklyLeaderboardEntry | null }>('/api/social/leaderboard/weekly');
     return { leaderboard: data.leaderboard, self: data.self, error: null };
   } catch (err) {
     return { leaderboard: [], self: null, error: err instanceof Error ? err.message : 'Failed to load leaderboard.' };
@@ -312,7 +305,7 @@ export async function fetchWeeklyLeaderboard(): Promise<{ leaderboard: WeeklyLea
 
 export async function fetchModeLeaderboard(mode: string): Promise<{ leaderboard: ModeLeaderboardEntry[]; self: ModeLeaderboardEntry | null; error: string | null }> {
   try {
-    const data = await apiFetch<{ ok: boolean; leaderboard: ModeLeaderboardEntry[]; self: ModeLeaderboardEntry | null }>(`/api/social/leaderboard/mode/${encodeURIComponent(mode)}`);
+    const data = await apiGetOrThrow<{ ok: boolean; leaderboard: ModeLeaderboardEntry[]; self: ModeLeaderboardEntry | null }>(`/api/social/leaderboard/mode/${encodeURIComponent(mode)}`);
     return { leaderboard: data.leaderboard, self: data.self, error: null };
   } catch (err) {
     return { leaderboard: [], self: null, error: err instanceof Error ? err.message : 'Failed to load leaderboard.' };
@@ -328,7 +321,7 @@ export async function fetchRivals(): Promise<{ rivals: RivalEntry[]; error: stri
     ttlMs: RIVALS_TTL_MS,
     load: async () => {
       try {
-        const data = await apiFetch<{ ok: boolean; rivals: RivalEntry[] }>('/api/social/rivals');
+        const data = await apiGetOrThrow<{ ok: boolean; rivals: RivalEntry[] }>('/api/social/rivals');
         return { rivals: data.rivals, error: null };
       } catch (err) {
         return { rivals: [], error: err instanceof Error ? err.message : 'Failed to load rivals.' };
@@ -346,7 +339,7 @@ export async function fetchUserActivity(userId: string): Promise<{ feed: FeedIte
     ttlMs: USER_ACTIVITY_TTL_MS,
     load: async () => {
       try {
-        const data = await apiFetch<{ ok: boolean; feed: FeedItem[] }>(`/api/social/feed/user/${encodeURIComponent(userId)}`);
+        const data = await apiGetOrThrow<{ ok: boolean; feed: FeedItem[] }>(`/api/social/feed/user/${encodeURIComponent(userId)}`);
         return { feed: data.feed, error: null };
       } catch (err) {
         return { feed: [], error: err instanceof Error ? err.message : 'Activity unavailable.' };
@@ -364,7 +357,7 @@ export async function fetchPublicProfile(username: string): Promise<{ profile: P
     cacheKey: `${cacheScope}:${normalizedUsername}`,
     ttlMs: PUBLIC_PROFILE_TTL_MS,
     load: async () => {
-      // Not the throwing `apiFetch` helper: the status/code decides the copy.
+      // Not the throw-on-error helper: the status/code decides the copy.
       // Profiles are auth-gated by design, so a guest always 401s here — that is
       // a sign-in gate, not "session expired", and a real 404 must read as a
       // distinct not-found rather than an auth failure (P1-4).

--- a/client/src/social/socialApiRivalsCache.test.ts
+++ b/client/src/social/socialApiRivalsCache.test.ts
@@ -16,6 +16,12 @@ vi.mock('../api/client', () => ({
   apiGet: (...args: unknown[]) => apiGet(...args),
   apiPost: vi.fn(),
   apiDelete: vi.fn(),
+  // Thin throw-on-error wrapper over the same mocked apiGet, matching the real one.
+  apiGetOrThrow: async (path: string, options?: unknown) => {
+    const r = await apiGet(path, options);
+    if (r.error) throw new Error(r.error);
+    return r.data;
+  },
 }));
 
 import { fetchRivals } from './socialApi';

--- a/client/src/tournament/tournamentApi.ts
+++ b/client/src/tournament/tournamentApi.ts
@@ -1,4 +1,4 @@
-import { apiDelete, apiGet, apiPost } from '../api/client';
+import { apiDeleteOrThrow, apiGetOrThrow, apiPostOrThrow } from '../api/client';
 import type {
   BracketView,
   Registration,
@@ -7,50 +7,23 @@ import type {
   TournamentResultView,
 } from './types';
 
-async function throwingGet<T>(path: string, auth = true): Promise<T> {
-  const result = await apiGet<T>(path, { auth });
-  if (result.error) throw new Error(result.error);
-  return result.data as T;
-}
-
-async function throwingPost<T>(path: string, body: unknown = {}): Promise<T> {
-  const result = await apiPost<T>(path, body);
-  if (result.error) throw new Error(result.error);
-  return result.data as T;
-}
-
-async function throwingDelete<T>(path: string, body: unknown = {}): Promise<T> {
-  const result = await apiDelete<T>(path, body);
-  if (result.error) throw new Error(result.error);
-  return result.data as T;
-}
-
 export async function fetchUpcoming(): Promise<ScheduledTournament[]> {
-  const r = await throwingGet<{ ok: boolean; tournaments: ScheduledTournament[] }>(
-    '/api/tournaments/upcoming',
-    false,
-  );
+  const r = await apiGetOrThrow<{ ok: boolean; tournaments: ScheduledTournament[] }>('/api/tournaments/upcoming', { auth: false });
   return r.tournaments;
 }
 
 export async function fetchBracket(tournamentId: string): Promise<BracketView> {
-  const r = await throwingGet<{ ok: boolean; view: BracketView }>(
-    `/api/tournaments/${encodeURIComponent(tournamentId)}/bracket`,
-    false,
-  );
+  const r = await apiGetOrThrow<{ ok: boolean; view: BracketView }>(`/api/tournaments/${encodeURIComponent(tournamentId)}/bracket`, { auth: false });
   return r.view;
 }
 
 export async function fetchMyRegistrations(userId: string): Promise<Registration[]> {
-  const r = await throwingGet<{ ok: boolean; registrations: Registration[] }>(
-    `/api/tournaments/my?userId=${encodeURIComponent(userId)}`,
-    false,
-  );
+  const r = await apiGetOrThrow<{ ok: boolean; registrations: Registration[] }>(`/api/tournaments/my?userId=${encodeURIComponent(userId)}`, { auth: false });
   return r.registrations;
 }
 
 export async function fetchMe(): Promise<TournamentMeResponse> {
-  const r = await throwingGet<{
+  const r = await apiGetOrThrow<{
     ok: boolean;
     registrations: Registration[];
     activeAssignedMatch: TournamentMeResponse['activeAssignedMatch'];
@@ -70,22 +43,19 @@ export async function fetchMe(): Promise<TournamentMeResponse> {
 }
 
 export async function fetchResult(tournamentId: string): Promise<TournamentResultView> {
-  const r = await throwingGet<{ ok: boolean; result: TournamentResultView }>(
-    `/api/tournaments/${encodeURIComponent(tournamentId)}/result`,
-    false,
-  );
+  const r = await apiGetOrThrow<{ ok: boolean; result: TournamentResultView }>(`/api/tournaments/${encodeURIComponent(tournamentId)}/result`, { auth: false });
   return r.result;
 }
 
 export async function registerForTournament(tournamentId: string, _userId: string): Promise<void> {
-  await throwingPost<{ ok: boolean }>(
+  await apiPostOrThrow<{ ok: boolean }>(
     `/api/tournaments/${encodeURIComponent(tournamentId)}/register`,
     {},
   );
 }
 
 export async function withdrawFromTournament(tournamentId: string, _userId: string): Promise<void> {
-  await throwingDelete<{ ok: boolean }>(
+  await apiDeleteOrThrow<{ ok: boolean }>(
     `/api/tournaments/${encodeURIComponent(tournamentId)}/register`,
     {},
   );


### PR DESCRIPTION
## REFACTOR_OPPORTUNITIES.md §2 · R1

`tournamentApi`, `ghost/api`, `homeDailySummaryApi`, `socialApi` each had their own 3-line `throwingGet`/`throwingPost`/`apiFetch` over `apiGet`/`apiPost` — call, throw on `result.error`, return `result.data as T`.

- `api/client.ts` gains `apiGetOrThrow` / `apiPostOrThrow` / `apiDeleteOrThrow` (same options as the underlying helper + optional `onError(message, status) => never`).
- The four modules drop their local wrappers. `ghost/api` keeps a 2-line binding supplying only `onError: throwGhostError` (ghost-specific copy stays local).
- Test mock updated (`socialApiRivalsCache.test.ts`).

No behaviour change — same throw, same messages.

Local: `tsc -b`, `lint`, `lint:hooks`, `lint:css`, `check:architecture` 20/20, `check:deps`, client `test:all` 218/1632, server vitest all shards. Not merging until CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pog14A6F9zVfVtECAg8Y7Q