### PR TITLE
refactor(date): one shiftDateKey, not five copies of the same day math (R2)

### DIFF
--- a/server/src/generatePuzzles.ts
+++ b/server/src/generatePuzzles.ts
@@ -1,4 +1,5 @@
 import { applyMove, getLegalMoves } from './game/engine';
+import { shiftDateKey } from './shared/pacificDate';
 import { computeOpenEndsSum } from './game/openEndsGeometry';
 import type { GameState, Move, PlayMove, PlacementPosition } from './game/types';
 
@@ -134,12 +135,6 @@ function isIsoDate(value: string): boolean {
 
 function formatDateUtc(date: Date): string {
   return date.toISOString().slice(0, 10);
-}
-
-function addDays(dateSeed: string, days: number): string {
-  const date = new Date(`${dateSeed}T00:00:00Z`);
-  date.setUTCDate(date.getUTCDate() + days);
-  return formatDateUtc(date);
 }
 
 function hashString(value: string): number {
@@ -1704,7 +1699,7 @@ async function main(): Promise<void> {
     throw new Error('SUPABASE_SERVICE_KEY is required.');
   }
 
-  const finalDate = addDays(options.from, options.days - 1);
+  const finalDate = shiftDateKey(options.from, options.days - 1);
   const existingDates = await fetchExistingPuzzleDates(
     supabaseUrl,
     serviceKey,
@@ -1714,7 +1709,7 @@ async function main(): Promise<void> {
   let hadFailures = false;
 
   for (let offset = 0; offset < options.days; offset += 1) {
-    const dateSeed = addDays(options.from, offset);
+    const dateSeed = shiftDateKey(options.from, offset);
     const generators: Array<{
       puzzleType: DailyPuzzleType;
       build: (seed: string, attempt: number) => CuratedDailyPuzzle;

--- a/server/src/homeDailySummary.ts
+++ b/server/src/homeDailySummary.ts
@@ -1,3 +1,5 @@
+import { shiftDateKey } from './shared/pacificDate';
+
 export const HOME_WEEK_LABELS = ['MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT', 'SUN'] as const;
 
 export interface HomeDailyCompletionEntry {
@@ -47,12 +49,6 @@ export function createHomeDailyCompletionMap(
   return map;
 }
 
-function addDateKeyDays(dateKey: string, deltaDays: number): string {
-  const date = new Date(`${dateKey}T00:00:00Z`);
-  date.setUTCDate(date.getUTCDate() + deltaDays);
-  return date.toISOString().slice(0, 10);
-}
-
 function getWeekdayIndexForPacificDate(date: Date): number {
   const weekday = new Intl.DateTimeFormat('en-US', {
     timeZone: 'America/Los_Angeles',
@@ -69,9 +65,9 @@ export function buildHomeDailySummary(
   now: Date = new Date(),
 ): HomeDailySummaryPayload {
   const todayWeekIndex = getWeekdayIndexForPacificDate(now);
-  const weekStart = addDateKeyDays(todayDateKey, -todayWeekIndex);
+  const weekStart = shiftDateKey(todayDateKey, -todayWeekIndex);
   const week = HOME_WEEK_LABELS.map((label, index) => {
-    const dateKey = addDateKeyDays(weekStart, index);
+    const dateKey = shiftDateKey(weekStart, index);
     const entry = completionMap[dateKey] ?? { fritz: false, puzzle: false, complete: false };
     const isFuture = dateKey > todayDateKey;
     const complete = isFuture ? false : entry.complete;
@@ -88,7 +84,7 @@ export function buildHomeDailySummary(
 
   const weeklyCompletedCount = week.filter((day) => day.complete).length;
   const todayComplete = Boolean(completionMap[todayDateKey]?.complete);
-  const yesterdayKey = addDateKeyDays(todayDateKey, -1);
+  const yesterdayKey = shiftDateKey(todayDateKey, -1);
   const yesterdayComplete = Boolean(completionMap[yesterdayKey]?.complete);
 
   let currentStreakCount = 0;
@@ -97,7 +93,7 @@ export function buildHomeDailySummary(
     let cursor = anchorDateKey;
     while (completionMap[cursor]?.complete) {
       currentStreakCount += 1;
-      cursor = addDateKeyDays(cursor, -1);
+      cursor = shiftDateKey(cursor, -1);
     }
   }
 

--- a/server/src/http/stores/dailyFritzHealthSummary.ts
+++ b/server/src/http/stores/dailyFritzHealthSummary.ts
@@ -1,5 +1,6 @@
 import { supabaseFetch } from '../../supabaseUtils';
 import { childLogger } from '../../logger';
+import { shiftDateKey } from '../../shared/pacificDate';
 import type { DailyFritzDayHealthMetrics } from '../routes/dailyFritzHealthPolicy';
 
 const log = childLogger('daily-fritz');
@@ -155,10 +156,7 @@ export function formatDailyFritzRunDatePacific(date = new Date()): string {
 }
 
 export function previousDailyFritzRunDate(runDate: string): string {
-  const [year, month, day] = runDate.split('-').map(Number);
-  const anchor = new Date(Date.UTC(year, month - 1, day, 20, 0, 0));
-  anchor.setUTCDate(anchor.getUTCDate() - 1);
-  return anchor.toISOString().slice(0, 10);
+  return shiftDateKey(runDate, -1);
 }
 
 export function buildDailyFritzHealthDeltas(

--- a/server/src/platform/health/dailyPuzzleGenerationHealth.test.ts
+++ b/server/src/platform/health/dailyPuzzleGenerationHealth.test.ts
@@ -1,18 +1,13 @@
 import { describe, expect, it } from 'vitest';
+import { shiftDateKey } from '../../shared/pacificDate';
 import {
   DAILY_PUZZLE_GENERATION_MIN_LOOKAHEAD_DAYS,
-  addDaysToIsoDate,
   assessDailyPuzzleGenerationHealth,
   daysBetweenIsoDates,
 } from './dailyPuzzleGenerationHealth';
 
-describe('addDaysToIsoDate', () => {
-  it('adds calendar days, crossing month and year boundaries', () => {
-    expect(addDaysToIsoDate('2026-09-05', 30)).toBe('2026-10-05');
-    expect(addDaysToIsoDate('2026-12-20', 30)).toBe('2027-01-19');
-    expect(addDaysToIsoDate('2024-02-28', 1)).toBe('2024-02-29'); // leap year
-  });
-});
+// `addDaysToIsoDate` was folded into `shiftDateKey` (REFACTOR_OPPORTUNITIES R2) —
+// its own boundary cases now live in `shared/pacificDate.test.ts`.
 
 describe('daysBetweenIsoDates', () => {
   it('returns whole calendar days, signed', () => {
@@ -25,11 +20,11 @@ describe('daysBetweenIsoDates', () => {
 describe('assessDailyPuzzleGenerationHealth', () => {
   const today = '2026-09-05';
   const N = DAILY_PUZZLE_GENERATION_MIN_LOOKAHEAD_DAYS; // 30
-  const requiredThrough = addDaysToIsoDate(today, N); // 2026-10-05
+  const requiredThrough = shiftDateKey(today, N); // 2026-10-05
 
   it('is ok when the furthest published date is far beyond the horizon (healthy cron)', () => {
     // gen-puzzles.yml seeds ~363 days out
-    const snap = assessDailyPuzzleGenerationHealth(today, addDaysToIsoDate(today, 363));
+    const snap = assessDailyPuzzleGenerationHealth(today, shiftDateKey(today, 363));
     expect(snap.ok).toBe(true);
     expect(snap.shouldAlert).toBe(false);
     expect(snap.alertReason).toBeNull();
@@ -44,7 +39,7 @@ describe('assessDailyPuzzleGenerationHealth', () => {
   });
 
   it('trips one day inside the horizon (furthest === today + N - 1)', () => {
-    const snap = assessDailyPuzzleGenerationHealth(today, addDaysToIsoDate(today, N - 1));
+    const snap = assessDailyPuzzleGenerationHealth(today, shiftDateKey(today, N - 1));
     expect(snap.ok).toBe(false);
     expect(snap.shouldAlert).toBe(true);
     expect(snap.alertReason).toContain('generation is behind');
@@ -63,12 +58,12 @@ describe('assessDailyPuzzleGenerationHealth', () => {
   it('does not false-positive on a single missing near-term day (still 300d of runway)', () => {
     // One bad day in the near term is invisible to a horizon check as long as the
     // furthest date is still far out — which is the point of the repurpose.
-    const snap = assessDailyPuzzleGenerationHealth(today, addDaysToIsoDate(today, 300));
+    const snap = assessDailyPuzzleGenerationHealth(today, shiftDateKey(today, 300));
     expect(snap.ok).toBe(true);
   });
 
   it('honours a custom minLookaheadDays', () => {
-    expect(assessDailyPuzzleGenerationHealth(today, addDaysToIsoDate(today, 10), 7).ok).toBe(true);
-    expect(assessDailyPuzzleGenerationHealth(today, addDaysToIsoDate(today, 10), 14).ok).toBe(false);
+    expect(assessDailyPuzzleGenerationHealth(today, shiftDateKey(today, 10), 7).ok).toBe(true);
+    expect(assessDailyPuzzleGenerationHealth(today, shiftDateKey(today, 10), 14).ok).toBe(false);
   });
 });

--- a/server/src/platform/health/dailyPuzzleGenerationHealth.ts
+++ b/server/src/platform/health/dailyPuzzleGenerationHealth.ts
@@ -1,3 +1,5 @@
+import { shiftDateKey } from '../../shared/pacificDate';
+
 /**
  * `/ready.checks.dailyPuzzleGeneration` — is the Daily Puzzle **generation
  * pipeline** still producing content?
@@ -31,14 +33,6 @@ export type DailyPuzzleGenerationHealthSnapshot = {
   alertReason: string | null;
 };
 
-/** Add `days` calendar days to a `YYYY-MM-DD` string. Pure day math, timezone-free. */
-export function addDaysToIsoDate(iso: string, days: number): string {
-  const [year, month, day] = iso.split('-').map(Number);
-  const dt = new Date(Date.UTC(year, month - 1, day));
-  dt.setUTCDate(dt.getUTCDate() + days);
-  return dt.toISOString().slice(0, 10);
-}
-
 /** Whole calendar days from `fromIso` to `toIso` (negative if `toIso` is earlier). */
 export function daysBetweenIsoDates(fromIso: string, toIso: string): number {
   const [fy, fm, fd] = fromIso.split('-').map(Number);
@@ -53,7 +47,7 @@ export function assessDailyPuzzleGenerationHealth(
   furthestPublishedDate: string | null,
   minLookaheadDays: number = DAILY_PUZZLE_GENERATION_MIN_LOOKAHEAD_DAYS,
 ): DailyPuzzleGenerationHealthSnapshot {
-  const requiredThroughDate = addDaysToIsoDate(todayPt, minLookaheadDays);
+  const requiredThroughDate = shiftDateKey(todayPt, minLookaheadDays);
   const lookaheadDays = furthestPublishedDate
     ? daysBetweenIsoDates(todayPt, furthestPublishedDate)
     : null;

--- a/server/src/puzzleRush/puzzleStatsSummary.ts
+++ b/server/src/puzzleRush/puzzleStatsSummary.ts
@@ -13,6 +13,8 @@
  * gap. `rush_runs` has deny-all RLS, so this must be computed server-side.
  */
 
+import { shiftDateKey } from '../shared/pacificDate';
+
 export interface PuzzleDayResult {
   /** `YYYY-MM-DD` (Pacific calendar day). */
   date: string;
@@ -38,12 +40,6 @@ export interface PuzzleStatsSummary {
 
 const DAY_KEY = /^\d{4}-\d{2}-\d{2}$/;
 
-function addDays(dateKey: string, deltaDays: number): string {
-  const date = new Date(`${dateKey}T00:00:00Z`);
-  date.setUTCDate(date.getUTCDate() + deltaDays);
-  return date.toISOString().slice(0, 10);
-}
-
 export function buildPuzzleStatsSummary(input: {
   /** Today's Pacific calendar day (`YYYY-MM-DD`). */
   todayDateKey: string;
@@ -63,7 +59,7 @@ export function buildPuzzleStatsSummary(input: {
 
   // Streak: anchor on today if complete, else yesterday, then walk back.
   let currentStreak = 0;
-  const yesterdayKey = addDays(todayDateKey, -1);
+  const yesterdayKey = shiftDateKey(todayDateKey, -1);
   const anchor = completedDays.has(todayDateKey)
     ? todayDateKey
     : completedDays.has(yesterdayKey)
@@ -73,7 +69,7 @@ export function buildPuzzleStatsSummary(input: {
     let cursor = anchor;
     while (completedDays.has(cursor)) {
       currentStreak += 1;
-      cursor = addDays(cursor, -1);
+      cursor = shiftDateKey(cursor, -1);
     }
   }
 
@@ -83,12 +79,12 @@ export function buildPuzzleStatsSummary(input: {
   let runLength = 0;
   let prevDay: string | null = null;
   for (const day of sortedDays) {
-    runLength = prevDay != null && addDays(prevDay, 1) === day ? runLength + 1 : 1;
+    runLength = prevDay != null && shiftDateKey(prevDay, 1) === day ? runLength + 1 : 1;
     if (runLength > bestStreak) bestStreak = runLength;
     prevDay = day;
   }
 
-  const weekFloor = addDays(todayDateKey, -6);
+  const weekFloor = shiftDateKey(todayDateKey, -6);
   let completionsThisWeek = 0;
   for (const day of completedDays) {
     if (day >= weekFloor && day <= todayDateKey) completionsThisWeek += 1;

--- a/server/src/shared/pacificDate.test.ts
+++ b/server/src/shared/pacificDate.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { shiftDateKey } from './pacificDate';
+
+describe('shiftDateKey', () => {
+  it('adds and subtracts whole days', () => {
+    expect(shiftDateKey('2026-09-09', 1)).toBe('2026-09-10');
+    expect(shiftDateKey('2026-09-09', -1)).toBe('2026-09-08');
+    expect(shiftDateKey('2026-09-09', 0)).toBe('2026-09-09');
+    expect(shiftDateKey('2026-09-09', 7)).toBe('2026-09-16');
+  });
+
+  it('rolls over month boundaries in both directions', () => {
+    expect(shiftDateKey('2026-09-30', 1)).toBe('2026-10-01');
+    expect(shiftDateKey('2026-10-01', -1)).toBe('2026-09-30');
+    expect(shiftDateKey('2026-08-31', 1)).toBe('2026-09-01');
+  });
+
+  it('rolls over year boundaries', () => {
+    expect(shiftDateKey('2026-12-31', 1)).toBe('2027-01-01');
+    expect(shiftDateKey('2027-01-01', -1)).toBe('2026-12-31');
+    expect(shiftDateKey('2026-12-20', 30)).toBe('2027-01-19');
+  });
+
+  it('handles leap years', () => {
+    expect(shiftDateKey('2024-02-28', 1)).toBe('2024-02-29');
+    expect(shiftDateKey('2024-02-29', 1)).toBe('2024-03-01');
+    expect(shiftDateKey('2026-02-28', 1)).toBe('2026-03-01'); // 2026 is not a leap year
+  });
+
+  it('is timezone-independent — no DST spring-forward/fall-back drift', () => {
+    // US DST transitions (2nd Sun Mar, 1st Sun Nov) — a naive local-time impl
+    // would drop or double a day here.
+    expect(shiftDateKey('2026-03-07', 2)).toBe('2026-03-09');
+    expect(shiftDateKey('2026-11-01', 2)).toBe('2026-11-03');
+  });
+});

--- a/server/src/shared/pacificDate.ts
+++ b/server/src/shared/pacificDate.ts
@@ -55,6 +55,20 @@ export function getPacificDateKeyDaysFromNow(daysFromNow: number): string {
   return getPacificDateKey(new Date(Date.now() + daysFromNow * 86400000));
 }
 
+/**
+ * Add `deltaDays` calendar days to a `YYYY-MM-DD` date key. Pure UTC day math —
+ * timezone-free, DST-free; the key is a calendar day, not an instant.
+ *
+ * Five server modules each carried their own copy of this (`addDateKeyDays`,
+ * two `addDays`, `addDaysToIsoDate`, `previousDailyFritzRunDate`).
+ */
+export function shiftDateKey(dateKey: string, deltaDays: number): string {
+  const [year, month, day] = dateKey.split('-').map(Number);
+  const date = new Date(Date.UTC(year, month - 1, day));
+  date.setUTCDate(date.getUTCDate() + deltaDays);
+  return date.toISOString().slice(0, 10);
+}
+
 export function getNextPacificWarmupAt(hour = 0, minute = 2): Date {
   const now = new Date();
   const pacific = getPacificDateTimeParts(now);


### PR DESCRIPTION
## REFACTOR_OPPORTUNITIES.md §2 · R2

`YYYY-MM-DD` + N days was reimplemented in five server modules (`addDateKeyDays`, two `addDays`, `addDaysToIsoDate`, `previousDailyFritzRunDate`).

- `shared/pacificDate.ts` gains `shiftDateKey(dateKey, deltaDays)`.
- All five switched to it. `addDaysToIsoDate` (a verbatim duplicate) removed; `previousDailyFritzRunDate` keeps its name, delegates.
- New `shared/pacificDate.test.ts` — month/year rollover both directions, leap years, DST-transition dates. Old `addDaysToIsoDate` boundary cases folded in.

No behaviour change. Client untouched.

Local: server `tsc -b`, `typecheck:scripts`, `build`, `npm test` all shards (56/56/56/55).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pog14A6F9zVfVtECAg8Y7Q