### PR TITLE
refactor(bot): document why bot/botHeuristics.ts is a kept alias (R6)

### DIFF
--- a/client/src/bot/botHeuristics.ts
+++ b/client/src/bot/botHeuristics.ts
@@ -1,1 +1,7 @@
+// Compatibility alias. The Fritz bot heuristics moved to
+// `modules/fritz/botHeuristics.ts` in the `d9e82c8e` architecture refactor;
+// this shim is kept because four `learn/` modules still import
+// `chooseBotMove` / `evaluateMove` / `toBotVisibleState` / `BotChoice` from the
+// old `../bot/botHeuristics` path (LearnScenarioScreen, feedback[.test],
+// guidedMatchRecorderEngine). Not dead — do not delete without repointing them.
 export * from '../modules/fritz/botHeuristics.ts';


### PR DESCRIPTION
## REFACTOR_OPPORTUNITIES.md §2 · R6

`bot/botHeuristics.ts` is a 1-line `export * from '../modules/fritz/botHeuristics.ts'`. Checked consumers: **not dead** — four `learn/` modules import from the old path (`LearnScenarioScreen`, `feedback[.test]`, `guidedMatchRecorderEngine`).

It's a migration alias from `d9e82c8e`. Repointing would touch the CLAUDE.md-protected `learn/` system for no functional gain → per R6's "otherwise leave a comment" branch: kept, with a comment explaining why + a don't-delete-without-repointing warning.

Comment-only. Local: `tsc -b`, `lint`, `check:deps`, `check:architecture` 20/20, `test:all` 218/1632.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pog14A6F9zVfVtECAg8Y7Q