### PR TITLE
hardening(sentry): volume-guard beforeSend so an error loop can't burn the quota

### DIFF
--- a/client/src/lib/sentryVolumeGuard.test.ts
+++ b/client/src/lib/sentryVolumeGuard.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createSentryVolumeGuard,
+  sentryEventSignature,
+  type VolumeGuardEvent,
+} from './sentryVolumeGuard';
+
+const err = (type: string, value: string): VolumeGuardEvent => ({
+  exception: { values: [{ type, value }] },
+});
+
+describe('sentryEventSignature', () => {
+  it('prefers an explicit fingerprint', () => {
+    expect(sentryEventSignature({ fingerprint: ['a', 'b'], message: 'ignored' })).toBe('a|b');
+  });
+  it('falls back to exception type + a message slice', () => {
+    expect(sentryEventSignature(err('TypeError', 'x is not a function'))).toBe('TypeError:x is not a function');
+  });
+  it('falls back to the top-level message', () => {
+    expect(sentryEventSignature({ message: 'plain string' })).toBe(':plain string');
+  });
+  it('truncates a long value so a variable suffix does not defeat grouping', () => {
+    const long = 'boom ' + 'x'.repeat(500);
+    expect(sentryEventSignature(err('E', long)).length).toBeLessThanOrEqual(130);
+  });
+});
+
+describe('createSentryVolumeGuard', () => {
+  const cfg = { windowMs: 60_000, globalMax: 10, perSignatureMax: 3, sampleEvery: 5 };
+
+  it('forwards everything under both caps', () => {
+    const g = createSentryVolumeGuard(cfg);
+    for (let i = 0; i < 3; i += 1) {
+      expect(g.shouldForward(err('A', `msg ${i}`), 1000)).toBe(true);
+    }
+  });
+
+  it('caps one noisy signature and then only heartbeats past it', () => {
+    const g = createSentryVolumeGuard(cfg);
+    const results: boolean[] = [];
+    for (let i = 0; i < 12; i += 1) results.push(g.shouldForward(err('Loop', 'same'), 1000));
+    // first 3 forwarded, then only every 5th (seen == 5, 10) as a heartbeat
+    expect(results.slice(0, 3)).toEqual([true, true, true]);
+    expect(results.filter(Boolean)).toHaveLength(3 + 2);
+  });
+
+  it('a capped signature only spends its first perSignatureMax against the global budget', () => {
+    const g = createSentryVolumeGuard(cfg);
+    for (let i = 0; i < 100; i += 1) g.shouldForward(err('Loop', 'same'), 1000);
+    // The loop's first 3 (perSignatureMax) counted; the ~19 heartbeats past the
+    // cap did not — so other errors still have globalMax - perSignatureMax left.
+    let realForwarded = 0;
+    for (let i = 0; i < 20; i += 1) {
+      if (g.shouldForward(err('Real', `distinct ${i}`), 1000)) realForwarded += 1;
+    }
+    expect(realForwarded).toBe(cfg.globalMax - cfg.perSignatureMax);
+  });
+
+  it('bounds a diverse storm at globalMax forwarded events', () => {
+    const g = createSentryVolumeGuard(cfg);
+    let forwarded = 0;
+    for (let i = 0; i < 50; i += 1) {
+      if (g.shouldForward(err('Storm', `unique ${i}`), 1000)) forwarded += 1;
+    }
+    expect(forwarded).toBe(cfg.globalMax);
+  });
+
+  it('resets when the window rolls over', () => {
+    const g = createSentryVolumeGuard(cfg);
+    for (let i = 0; i < 50; i += 1) g.shouldForward(err('X', `a ${i}`), 1000);
+    expect(g.shouldForward(err('X', 'a new'), 1000)).toBe(false);
+    // next window
+    expect(g.shouldForward(err('X', 'a new'), 1000 + cfg.windowMs)).toBe(true);
+  });
+});

--- a/client/src/lib/sentryVolumeGuard.ts
+++ b/client/src/lib/sentryVolumeGuard.ts
@@ -1,0 +1,98 @@
+/**
+ * Volume guard for Sentry `beforeSend` (PRE_LAUNCH_HARDENING.md §3.1).
+ *
+ * A pure, SDK-agnostic mirror of `server/src/sentryVolumeGuard.ts` — kept as a
+ * copy because client and server are separate packages with no shared util
+ * module. Keep the two in sync.
+ *
+ * Errors are captured at 100% with no sampling. A single runaway error — a
+ * component that throws on every render, a bad network condition that fires the
+ * same exception on a loop — exhausts the free-tier event quota (5k/mo) in
+ * minutes, and once the quota is gone *every subsequent real error is dropped*.
+ * That is the worst failure mode: an error storm both floods and then blinds.
+ *
+ * This caps outbound events per rolling minute:
+ *   - **per signature** (error type + a slice of the message): after
+ *     `perSignatureMax`, only a heartbeat (1 in `sampleEvery`) gets through, so
+ *     one loop can't crowd out everything else and can't burn the quota;
+ *   - **global**: after `globalMax` *forwarded* events in the window, drop the
+ *     rest, so a *diverse* storm is bounded too.
+ *
+ * Deliberately in-memory and lossy — one browser tab's counter, reset on
+ * reload. The point is to survive a burst, not to be a ledger.
+ */
+
+export interface SentryVolumeGuardConfig {
+  windowMs: number;
+  /** Forwarded events per window before the global drop kicks in. */
+  globalMax: number;
+  /** Events for one signature per window before only heartbeats pass. */
+  perSignatureMax: number;
+  /** Past `perSignatureMax`, forward 1 in every `sampleEvery` as a "still happening" beacon. */
+  sampleEvery: number;
+}
+
+export const DEFAULT_SENTRY_VOLUME_GUARD: SentryVolumeGuardConfig = {
+  windowMs: 60_000,
+  globalMax: 20,
+  perSignatureMax: 5,
+  sampleEvery: 20,
+};
+
+/** A minimal, SDK-agnostic view of what a Sentry error event carries. */
+export interface VolumeGuardEvent {
+  message?: string;
+  exception?: { values?: Array<{ type?: string; value?: string }> };
+  fingerprint?: string[];
+}
+
+export function sentryEventSignature(event: VolumeGuardEvent): string {
+  if (event.fingerprint && event.fingerprint.length > 0) {
+    return event.fingerprint.join('|').slice(0, 200);
+  }
+  const first = event.exception?.values?.[0];
+  const type = first?.type ?? '';
+  const value = (first?.value ?? event.message ?? '').slice(0, 120);
+  if (!type && !value) return 'unknown';
+  return `${type}:${value}`;
+}
+
+export interface SentryVolumeGuard {
+  /** True → forward the event to Sentry; false → drop it. */
+  shouldForward(event: VolumeGuardEvent, now?: number): boolean;
+}
+
+export function createSentryVolumeGuard(
+  config: SentryVolumeGuardConfig = DEFAULT_SENTRY_VOLUME_GUARD,
+): SentryVolumeGuard {
+  let windowStart = 0;
+  let forwardedThisWindow = 0;
+  const seenThisWindow = new Map<string, number>();
+
+  return {
+    shouldForward(event, now = Date.now()) {
+      if (now - windowStart >= config.windowMs) {
+        windowStart = now;
+        forwardedThisWindow = 0;
+        seenThisWindow.clear();
+      }
+
+      const sig = sentryEventSignature(event);
+      const seen = seenThisWindow.get(sig) ?? 0;
+      seenThisWindow.set(sig, seen + 1);
+
+      // One noisy signature: after the cap, only a periodic heartbeat.
+      if (seen >= config.perSignatureMax) {
+        return seen % config.sampleEvery === 0;
+      }
+
+      // Diverse storm: bound what we actually forward.
+      if (forwardedThisWindow >= config.globalMax) {
+        return false;
+      }
+
+      forwardedThisWindow += 1;
+      return true;
+    },
+  };
+}

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,4 +1,9 @@
 import * as Sentry from '@sentry/react';
+import { createSentryVolumeGuard } from './lib/sentryVolumeGuard';
+
+// One runaway error must not exhaust the 5k/mo event quota and blind us to
+// everything else (PRE_LAUNCH_HARDENING.md §3.1).
+const sentryVolumeGuard = createSentryVolumeGuard();
 
 Sentry.init({
   dsn: import.meta.env.VITE_SENTRY_DSN ?? '',
@@ -7,6 +12,7 @@ Sentry.init({
   integrations: [Sentry.browserTracingIntegration()],
   tracesSampleRate: 0.1,
   release: import.meta.env.VITE_APP_VERSION ?? 'unknown',
+  beforeSend: (event) => (sentryVolumeGuard.shouldForward(event) ? event : null),
 });
 
 if (import.meta.env.DEV && !import.meta.env.VITE_SENTRY_DSN) {

--- a/server/src/sentryScrubbers.ts
+++ b/server/src/sentryScrubbers.ts
@@ -1,6 +1,11 @@
 import type { ErrorEvent, EventHint } from '@sentry/node';
+import { createSentryVolumeGuard } from './sentryVolumeGuard';
 
 const REDACTED = '[Filtered]';
+
+// Shared across the process — one error loop must not exhaust the event quota
+// and blind us to everything else (PRE_LAUNCH_HARDENING.md §3.1).
+const volumeGuard = createSentryVolumeGuard();
 
 // Exact key match (not substring / not pattern) — kept deliberately narrow so it
 // can't over-redact adjacent fields (e.g. `password_set_at`, `email_confirmed`).
@@ -67,8 +72,12 @@ export function scrubSentryEventSensitiveData<T extends ErrorEvent>(event: T): T
   return event;
 }
 
-/** Sentry hook: strip checkpoint unload tokens before events leave the server. */
-export function sentryBeforeSend(event: ErrorEvent, _hint: EventHint): ErrorEvent {
+/**
+ * Sentry hook: drop events past the per-minute volume cap, then strip sensitive
+ * fields from what's left.
+ */
+export function sentryBeforeSend(event: ErrorEvent, _hint: EventHint): ErrorEvent | null {
   void _hint;
+  if (!volumeGuard.shouldForward(event)) return null;
   return scrubSentryEventSensitiveData(event);
 }

--- a/server/src/sentryVolumeGuard.test.ts
+++ b/server/src/sentryVolumeGuard.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createSentryVolumeGuard,
+  sentryEventSignature,
+  type VolumeGuardEvent,
+} from './sentryVolumeGuard';
+
+const err = (type: string, value: string): VolumeGuardEvent => ({
+  exception: { values: [{ type, value }] },
+});
+
+describe('sentryEventSignature', () => {
+  it('prefers an explicit fingerprint', () => {
+    expect(sentryEventSignature({ fingerprint: ['a', 'b'], message: 'ignored' })).toBe('a|b');
+  });
+  it('falls back to exception type + a message slice', () => {
+    expect(sentryEventSignature(err('TypeError', 'x is not a function'))).toBe('TypeError:x is not a function');
+  });
+  it('falls back to the top-level message', () => {
+    expect(sentryEventSignature({ message: 'plain string' })).toBe(':plain string');
+  });
+  it('truncates a long value so a variable suffix does not defeat grouping', () => {
+    const long = 'boom ' + 'x'.repeat(500);
+    expect(sentryEventSignature(err('E', long)).length).toBeLessThanOrEqual(130);
+  });
+});
+
+describe('createSentryVolumeGuard', () => {
+  const cfg = { windowMs: 60_000, globalMax: 10, perSignatureMax: 3, sampleEvery: 5 };
+
+  it('forwards everything under both caps', () => {
+    const g = createSentryVolumeGuard(cfg);
+    for (let i = 0; i < 3; i += 1) {
+      expect(g.shouldForward(err('A', `msg ${i}`), 1000)).toBe(true);
+    }
+  });
+
+  it('caps one noisy signature and then only heartbeats past it', () => {
+    const g = createSentryVolumeGuard(cfg);
+    const results: boolean[] = [];
+    for (let i = 0; i < 12; i += 1) results.push(g.shouldForward(err('Loop', 'same'), 1000));
+    // first 3 forwarded, then only every 5th (seen == 5, 10) as a heartbeat
+    expect(results.slice(0, 3)).toEqual([true, true, true]);
+    expect(results.filter(Boolean)).toHaveLength(3 + 2);
+  });
+
+  it('a capped signature only spends its first perSignatureMax against the global budget', () => {
+    const g = createSentryVolumeGuard(cfg);
+    for (let i = 0; i < 100; i += 1) g.shouldForward(err('Loop', 'same'), 1000);
+    // The loop's first 3 (perSignatureMax) counted; the ~19 heartbeats past the
+    // cap did not — so other errors still have globalMax - perSignatureMax left.
+    let realForwarded = 0;
+    for (let i = 0; i < 20; i += 1) {
+      if (g.shouldForward(err('Real', `distinct ${i}`), 1000)) realForwarded += 1;
+    }
+    expect(realForwarded).toBe(cfg.globalMax - cfg.perSignatureMax);
+  });
+
+  it('bounds a diverse storm at globalMax forwarded events', () => {
+    const g = createSentryVolumeGuard(cfg);
+    let forwarded = 0;
+    for (let i = 0; i < 50; i += 1) {
+      if (g.shouldForward(err('Storm', `unique ${i}`), 1000)) forwarded += 1;
+    }
+    expect(forwarded).toBe(cfg.globalMax);
+  });
+
+  it('resets when the window rolls over', () => {
+    const g = createSentryVolumeGuard(cfg);
+    for (let i = 0; i < 50; i += 1) g.shouldForward(err('X', `a ${i}`), 1000);
+    expect(g.shouldForward(err('X', 'a new'), 1000)).toBe(false);
+    // next window
+    expect(g.shouldForward(err('X', 'a new'), 1000 + cfg.windowMs)).toBe(true);
+  });
+});

--- a/server/src/sentryVolumeGuard.ts
+++ b/server/src/sentryVolumeGuard.ts
@@ -1,0 +1,99 @@
+/**
+ * Volume guard for Sentry `beforeSend` (PRE_LAUNCH_HARDENING.md §3.1).
+ *
+ * Errors are captured at 100% with no sampling. A single runaway error — a
+ * component that throws every render, a hot server path that
+ * `captureException`s on every request during a Supabase blip — will exhaust
+ * the free-tier event quota (5k/mo) in minutes, and once the quota is gone
+ * *every subsequent real error is dropped*. That is the worst failure mode: an
+ * error storm both floods and then blinds.
+ *
+ * This caps outbound events per rolling minute:
+ *   - **per signature** (error type + a slice of the message): after
+ *     `perSignatureMax`, only a heartbeat (1 in `sampleEvery`) gets through, so
+ *     one loop can't crowd out everything else and can't burn the quota;
+ *   - **global**: after `globalMax` *forwarded* events in the window, drop the
+ *     rest, so a *diverse* storm is bounded too.
+ *
+ * Deliberately process-local and lossy — same class as every other in-memory
+ * structure on the single Render instance (HARDENING_PLAN §2.1.1). It resets on
+ * restart; that's fine, the point is to survive a burst, not to be a ledger.
+ *
+ * `client/src/lib/sentryVolumeGuard.ts` is a copy of this file (separate
+ * packages, no shared util module). Keep the two in sync.
+ */
+
+export interface SentryVolumeGuardConfig {
+  windowMs: number;
+  /** Forwarded events per window before the global drop kicks in. */
+  globalMax: number;
+  /** Events for one signature per window before only heartbeats pass. */
+  perSignatureMax: number;
+  /** Past `perSignatureMax`, forward 1 in every `sampleEvery` as a "still happening" beacon. */
+  sampleEvery: number;
+}
+
+export const DEFAULT_SENTRY_VOLUME_GUARD: SentryVolumeGuardConfig = {
+  windowMs: 60_000,
+  globalMax: 20,
+  perSignatureMax: 5,
+  sampleEvery: 20,
+};
+
+/** A minimal, SDK-agnostic view of what a Sentry error event carries. */
+export interface VolumeGuardEvent {
+  message?: string;
+  exception?: { values?: Array<{ type?: string; value?: string }> };
+  fingerprint?: string[];
+}
+
+export function sentryEventSignature(event: VolumeGuardEvent): string {
+  if (event.fingerprint && event.fingerprint.length > 0) {
+    return event.fingerprint.join('|').slice(0, 200);
+  }
+  const first = event.exception?.values?.[0];
+  const type = first?.type ?? '';
+  const value = (first?.value ?? event.message ?? '').slice(0, 120);
+  if (!type && !value) return 'unknown';
+  return `${type}:${value}`;
+}
+
+export interface SentryVolumeGuard {
+  /** True → forward the event to Sentry; false → drop it. */
+  shouldForward(event: VolumeGuardEvent, now?: number): boolean;
+}
+
+export function createSentryVolumeGuard(
+  config: SentryVolumeGuardConfig = DEFAULT_SENTRY_VOLUME_GUARD,
+): SentryVolumeGuard {
+  let windowStart = 0;
+  let forwardedThisWindow = 0;
+  const seenThisWindow = new Map<string, number>();
+
+  return {
+    shouldForward(event, now = Date.now()) {
+      if (now - windowStart >= config.windowMs) {
+        windowStart = now;
+        forwardedThisWindow = 0;
+        seenThisWindow.clear();
+      }
+
+      const sig = sentryEventSignature(event);
+      const seen = seenThisWindow.get(sig) ?? 0;
+      seenThisWindow.set(sig, seen + 1);
+
+      // One noisy signature: after the cap, only a periodic heartbeat.
+      if (seen >= config.perSignatureMax) {
+        return seen % config.sampleEvery === 0;
+      }
+
+      // Diverse storm: bound what we actually forward.
+      if (forwardedThisWindow >= config.globalMax) {
+        return false;
+      }
+
+      forwardedThisWindow += 1;
+      return true;
+    },
+  };
+}


### PR DESCRIPTION
## PRE_LAUNCH_HARDENING.md §4 · item 1 (priority)

Errors are captured at 100% with no sampling. One runaway error exhausts the free-tier event quota (5k/mo) in minutes, then every real error is dropped — flood, then blind.

- `sentryVolumeGuard.ts` (server + synced copy in `client/src/lib/` — separate packages, no shared util). Per-rolling-minute cap:
  - **per signature** (error type + message slice, or explicit fingerprint): after `perSignatureMax` (5), only a 1-in-20 heartbeat passes.
  - **global**: after `globalMax` (20) *forwarded* events, drop the rest.
  - In-memory, resets on restart — a burst shock-absorber, not a ledger.
- Server `sentryBeforeSend` → `null` past the cap, then scrubs. Client `Sentry.init` gains a `beforeSend` (had none).

Tests both sides: signature derivation, per-sig cap + heartbeat, capped-sig-doesn't-eat-the-global-budget, diverse-storm bound, window rollover.

Local: `tsc -b` both, `lint` 50/50, `lint:hooks`, `check:architecture` 20/20, `check:deps`, client `test:all` 220/1652, server vitest all shards + build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pog14A6F9zVfVtECAg8Y7Q