### PR TITLE
hardening(alerts): fingerprint + per-user aggregation for MP move-log and tournament conflict alerts

### DIFF
--- a/server/src/multiplayer/mpAuthorityEventStore.test.ts
+++ b/server/src/multiplayer/mpAuthorityEventStore.test.ts
@@ -5,6 +5,7 @@ vi.mock('../supabaseUtils', () => ({ supabaseFetch: vi.fn() }));
 import { supabaseFetch } from '../supabaseUtils';
 import {
   MP_AUTHORITY_EVENT_WRITE_TIMEOUT_MS,
+  countRecentMoveLogVerificationFailuresForUser,
   flushMpAuthorityEventPersistForTests,
   groupMpAuthorityFunnelMetrics,
   pacificEventDate,
@@ -150,5 +151,28 @@ describe('mp.authority event store', () => {
       { eventDate: '2026-08-20', event: 'private_lobby_created', total: 1 },
       { eventDate: '2026-08-20', event: 'private_match_started', total: 1 },
     ]);
+  });
+
+  describe('countRecentMoveLogVerificationFailuresForUser', () => {
+    it('queries mp_authority_events scoped to the event, user and window', async () => {
+      vi.mocked(supabaseFetch).mockResolvedValue([{ id: '1' }, { id: '2' }, { id: '3' }]);
+      const n = await countRecentMoveLogVerificationFailuresForUser('user-abc', { days: 7 });
+      expect(n).toBe(3);
+      const url = vi.mocked(supabaseFetch).mock.calls[0][0] as string;
+      expect(url).toContain('/rest/v1/mp_authority_events');
+      expect(url).toContain('event=eq.private_move_log_verification_failed');
+      expect(url).toContain('payload->>userId=eq.user-abc');
+      expect(url).toMatch(/ts=gte\./);
+    });
+
+    it('returns 0 for an empty userId without a query', async () => {
+      expect(await countRecentMoveLogVerificationFailuresForUser('')).toBe(0);
+      expect(supabaseFetch).not.toHaveBeenCalled();
+    });
+
+    it('returns 0 (never throws) when the query fails', async () => {
+      vi.mocked(supabaseFetch).mockRejectedValue(new Error('supabase down'));
+      await expect(countRecentMoveLogVerificationFailuresForUser('user-x')).resolves.toBe(0);
+    });
   });
 });

--- a/server/src/multiplayer/mpAuthorityEventStore.ts
+++ b/server/src/multiplayer/mpAuthorityEventStore.ts
@@ -85,6 +85,36 @@ export async function recordMpAuthorityEventBestEffort(row: MpAuthorityEventReco
   }
 }
 
+/**
+ * How many `private_move_log_verification_failed` events one user has produced in
+ * the trailing window. Counts only rows whose `payload.userId` matches — so it
+ * accumulates from the point that field started being written (like DF-G2's
+ * `countRecentDailyFritzVerificationFailures`). Used to escalate the Sentry
+ * alert from `warning` to `error` for a repeat pattern (a tamper signal, not a
+ * verifier edge case). Best-effort — returns 0 on any failure.
+ */
+export async function countRecentMoveLogVerificationFailuresForUser(
+  userId: string,
+  options: { days?: number; cap?: number } = {},
+): Promise<number> {
+  if (!userId) return 0;
+  const days = Math.max(1, Math.min(90, Math.floor(options.days ?? 7)));
+  const cap = Math.max(1, Math.min(200, Math.floor(options.cap ?? 50)));
+  const since = new Date(Date.now() - days * 86_400_000).toISOString();
+  try {
+    const rows = await supabaseFetch<Array<{ id: string }>>(
+      `/rest/v1/mp_authority_events?select=id` +
+        `&event=eq.private_move_log_verification_failed` +
+        `&payload->>userId=eq.${encodeURIComponent(userId)}` +
+        `&ts=gte.${encodeURIComponent(since)}&limit=${cap}`,
+      { method: 'GET', timeoutMs: 2_500, circuitBreakable: true },
+    );
+    return Array.isArray(rows) ? rows.length : 0;
+  } catch {
+    return 0;
+  }
+}
+
 export async function queryMpAuthorityFunnelMetrics(): Promise<MpAuthorityFunnelMetricRow[]> {
   const rows = await supabaseFetch<Array<Record<string, unknown>>>(
     '/rest/v1/mp_authority_funnel_metrics?select=event_date,event,total',

--- a/server/src/realtime/gameOverPersistence.test.ts
+++ b/server/src/realtime/gameOverPersistence.test.ts
@@ -21,6 +21,8 @@ const {
   verifyPlayerMoveLogMock,
   emitMpAuthorityFunnelMock,
   recordOperationalFailureMock,
+  sentryCaptureMessageMock,
+  countRecentMoveLogFailuresMock,
 } = vi.hoisted(() => ({
   applyTournamentGameOverFromRoomMock: vi.fn(),
   findTournamentMatchByRoomMock: vi.fn(),
@@ -38,6 +40,8 @@ const {
   verifyPlayerMoveLogMock: vi.fn(),
   emitMpAuthorityFunnelMock: vi.fn(),
   recordOperationalFailureMock: vi.fn(),
+  sentryCaptureMessageMock: vi.fn(),
+  countRecentMoveLogFailuresMock: vi.fn(async () => 0),
 }));
 
 vi.mock('../ghost/verifier', () => ({
@@ -93,6 +97,14 @@ vi.mock('../logger', () => ({
 
 vi.mock('../multiplayer/mpAuthorityTelemetry', () => ({
   emitMpAuthorityFunnel: (...args: unknown[]) => emitMpAuthorityFunnelMock(...args),
+}));
+
+vi.mock('../multiplayer/mpAuthorityEventStore', () => ({
+  countRecentMoveLogVerificationFailuresForUser: (...args: unknown[]) => countRecentMoveLogFailuresMock(...args),
+}));
+
+vi.mock('@sentry/node', () => ({
+  captureMessage: (...args: unknown[]) => sentryCaptureMessageMock(...args),
 }));
 
 vi.mock('../operationalTelemetry', () => ({
@@ -622,7 +634,40 @@ describe('createGameOverPersistScheduler', () => {
             sourceMatchId: 'match-1',
             reason: 'fabricated board_state',
             entryIndex: 0,
+            // H2: userId on the persisted row so the alert can count per user,
+            // and the opponent so a Fritz failure isn't confused with a human one.
+            userId: 'user-a',
+            opponent: 'fritz',
           }),
+        }),
+      );
+      // H2: a Sentry alert, fingerprinted by user so repeats collapse into one issue.
+      await vi.waitFor(() => expect(sentryCaptureMessageMock).toHaveBeenCalled());
+      expect(sentryCaptureMessageMock).toHaveBeenCalledWith(
+        expect.stringContaining('move log failed verification'),
+        expect.objectContaining({
+          level: 'warning',
+          fingerprint: ['mp-move-log-verification-failed', 'user-a'],
+          tags: expect.objectContaining({ mp_alert: 'move_log_verification_failed', opponent: 'fritz' }),
+          extra: expect.objectContaining({ userRecentMoveLogFailures: 0 }),
+        }),
+      );
+    });
+
+    it('escalates the move-log alert to error + a repeat tag past the threshold', async () => {
+      supabaseFetchMock.mockResolvedValue([{ id: 'user-a', glicko_rating: 1500, glicko_rd: 200 }]);
+      verifyPlayerMoveLogMock.mockReturnValue({ ok: false, reason: 'fabricated', entryIndex: 0 });
+      countRecentMoveLogFailuresMock.mockResolvedValue(4);
+
+      await runPersist(buildFritzInput());
+
+      await vi.waitFor(() => expect(sentryCaptureMessageMock).toHaveBeenCalled());
+      expect(sentryCaptureMessageMock).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          level: 'error',
+          tags: expect.objectContaining({ mp_alert: 'move_log_verification_failed_repeat' }),
+          extra: expect.objectContaining({ userRecentMoveLogFailures: 4 }),
         }),
       );
     });

--- a/server/src/realtime/gameOverPersistence.ts
+++ b/server/src/realtime/gameOverPersistence.ts
@@ -1,4 +1,6 @@
+import * as Sentry from '@sentry/node';
 import { childLogger } from '../logger';
+import { countRecentMoveLogVerificationFailuresForUser } from '../multiplayer/mpAuthorityEventStore';
 import type { Server } from 'socket.io';
 import { completeGhostGame } from '../ghost/service';
 import { verifyPlayerMoveLog } from '../ghost/verifier';
@@ -58,6 +60,65 @@ function verifySeatMoveLog(moveLog: GhostMoveLogEntry[]): GhostMoveLogVerificati
   return verifyPlayerMoveLog(moveLog, { strictHandContinuity: true });
 }
 
+/**
+ * A live-room move log failing verification is recorded (funnel row) but not
+ * blocked — the result stands, Glicko is suppressed. An honest client
+ * effectively never produces one, so a run of failures for one account is a
+ * tamper pattern rather than a string of one-offs. Mirrors DF-G2: the Sentry
+ * alert is fingerprinted by user so repeats collapse into a single issue, and
+ * escalates `warning → error` + a `_repeat` tag past the threshold.
+ */
+export const MOVE_LOG_VERIFICATION_REPEAT_OFFENDER_THRESHOLD = 3;
+
+function reportMoveLogVerificationFailure(params: {
+  userId: string | null;
+  roomCode: string;
+  sourceMatchId: string;
+  seatId: string;
+  reason: string;
+  entryIndex: number;
+  opponentIsFritz: boolean;
+}): void {
+  emitMpAuthorityFunnel('private_move_log_verification_failed', {
+    roomCode: params.roomCode,
+    seatId: params.seatId,
+    failureCode: 'move_log_verification_failed',
+    extra: {
+      sourceMatchId: params.sourceMatchId,
+      reason: params.reason,
+      entryIndex: params.entryIndex,
+      opponent: params.opponentIsFritz ? 'fritz' : 'human',
+      ...(params.userId ? { userId: params.userId } : {}),
+    },
+  });
+
+  // Best-effort alert — never block or throw on the game-over path.
+  void (async () => {
+    const recentFailures = params.userId
+      ? await countRecentMoveLogVerificationFailuresForUser(params.userId)
+      : 0;
+    const repeat = recentFailures >= MOVE_LOG_VERIFICATION_REPEAT_OFFENDER_THRESHOLD;
+    Sentry.captureMessage('[mp] live-room move log failed verification — recorded without Glicko', {
+      level: repeat ? 'error' : 'warning',
+      fingerprint: ['mp-move-log-verification-failed', params.userId ?? params.seatId],
+      tags: {
+        mp_alert: repeat ? 'move_log_verification_failed_repeat' : 'move_log_verification_failed',
+        opponent: params.opponentIsFritz ? 'fritz' : 'human',
+      },
+      extra: {
+        roomCode: params.roomCode,
+        sourceMatchId: params.sourceMatchId,
+        seatId: params.seatId,
+        userId: params.userId,
+        reason: params.reason,
+        entryIndex: params.entryIndex,
+        userRecentMoveLogFailures: recentFailures,
+        repeatOffenderThreshold: MOVE_LOG_VERIFICATION_REPEAT_OFFENDER_THRESHOLD,
+      },
+    });
+  })().catch(() => { /* alerting is best-effort */ });
+}
+
 type HumanMoveLogVerificationFailure = {
   seatId: string;
   reason: string;
@@ -91,15 +152,14 @@ function evaluateHumanMoveLogVerification(
         },
         'human live-room move log failed verification — recording without Glicko',
       );
-      emitMpAuthorityFunnel('private_move_log_verification_failed', {
+      reportMoveLogVerificationFailure({
+        userId: seat.userId,
         roomCode,
+        sourceMatchId,
         seatId: failure.seatId,
-        failureCode: 'move_log_verification_failed',
-        extra: {
-          sourceMatchId,
-          reason: failure.reason,
-          entryIndex: failure.entryIndex,
-        },
+        reason: failure.reason,
+        entryIndex: failure.entryIndex,
+        opponentIsFritz: false,
       });
       return { eligible: false, failure };
     }
@@ -306,15 +366,14 @@ async function persistGameOverOnce(io: Server, input: GameOverPersistInput): Pro
               reason: fritzVerification.reason,
               entryIndex: fritzVerification.entryIndex,
             }, 'fritz in-room move log failed verification — recording without Glicko');
-            emitMpAuthorityFunnel('private_move_log_verification_failed', {
+            reportMoveLogVerificationFailure({
+              userId: p.me.userId,
               roomCode: room.code,
+              sourceMatchId,
               seatId: p.me.id,
-              failureCode: 'move_log_verification_failed',
-              extra: {
-                sourceMatchId,
-                reason: fritzVerification.reason,
-                entryIndex: fritzVerification.entryIndex,
-              },
+              reason: fritzVerification.reason,
+              entryIndex: fritzVerification.entryIndex,
+              opponentIsFritz: true,
             });
           }
           const humanApplyGlicko = humanGlickoEligible ? undefined : false;

--- a/server/src/scheduledTournament/concurrencyRecoveryHarness.test.ts
+++ b/server/src/scheduledTournament/concurrencyRecoveryHarness.test.ts
@@ -17,6 +17,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 const capturedLogs: Array<{ context?: string; msg?: string; [k: string]: unknown }> = [];
+const sentryCaptureMessage = vi.fn();
+
+vi.mock('@sentry/node', () => ({ captureMessage: (...a: unknown[]) => sentryCaptureMessage(...a) }));
 
 vi.mock('../logger', () => ({
   childLogger: (context: string) => ({
@@ -349,6 +352,17 @@ describe('redundant producers on one match (T-INV-1/2/3/5)', () => {
     for (const l of conflictLogs) {
       expect(l.recordedWinnerId).toBe(recordedWinner);
       expect(l.attemptedWinnerId).toBe(otherPlayer);
+    }
+
+    // T-15 / H2: was log-only. Both disagreements now alert, fingerprinted by
+    // matchId so they collapse into one Sentry issue rather than a burst.
+    const conflictAlerts = sentryCaptureMessage.mock.calls.filter(
+      ([, opts]) => (opts as { tags?: Record<string, string> })?.tags?.tournament_alert === 'match_winner_conflict',
+    );
+    expect(conflictAlerts).toHaveLength(2);
+    for (const [msg, opts] of conflictAlerts) {
+      expect(msg).toContain('winner conflict');
+      expect((opts as { fingerprint?: string[] }).fingerprint).toEqual(['tournament-winner-conflict', qf0.id]);
     }
 
     assertBracketConsistentForStore(store, {

--- a/server/src/scheduledTournament/engine.ts
+++ b/server/src/scheduledTournament/engine.ts
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/node';
 import { childLogger } from '../logger';
 import type { Server } from 'socket.io';
 import { supabaseFetch } from '../supabaseUtils';
@@ -475,6 +476,27 @@ export async function applyMatchResult(
         attemptedWinnerId: params.winnerId,
         attemptedSource: params.winnerSource ?? 'game_over',
       }, 'tournament_match_winner_conflict');
+      // T-15: was log-only, so it surfaced only when someone read the logs after
+      // a player complained. Fingerprinted by matchId so N retries of the same
+      // conflict collapse into one Sentry issue rather than a burst of unrelated
+      // alerts; a spike *across* matches (many issues) is the systemic signal.
+      // Not user-attributed — this is a state-machine/concurrency bug, not a
+      // tamper, and tournament conflicts have no queryable store to count per
+      // tournament (log-only), so per-actor escalation à la DF-G2 doesn't apply.
+      Sentry.captureMessage('[tournament] winner conflict — two producers disagreed on a completed match', {
+        level: 'warning',
+        fingerprint: ['tournament-winner-conflict', match.id],
+        tags: {
+          tournament_alert: 'match_winner_conflict',
+          tournament_id: match.tournament_id,
+          match_id: match.id,
+        },
+        extra: {
+          recordedWinnerId: result.winner_id,
+          attemptedWinnerId: params.winnerId,
+          attemptedSource: params.winnerSource ?? 'game_over',
+        },
+      });
     } else {
       log.info({
         matchId: match.id,


### PR DESCRIPTION
## PRE_LAUNCH_HARDENING.md §4 · item 2 (+ the winner-conflict slice of item 3 / T-15)

Both alerts were `log.warn`-only (T-15, MP-G14) — visible only when someone read the logs after a complaint. Item 3's remaining T-15 conditions (advance-target-missing, non-participant winner) are a follow-up PR.

**MP live-room move-log verification failure** — a tamper pattern for one account, not N one-offs. Mirrors DF-G2:
- funnel row carries `userId` + `opponent`;
- `countRecentMoveLogVerificationFailuresForUser` (7-day, `payload->>userId`, best-effort);
- `Sentry.captureMessage` fingerprinted by user, escalating `warning → error` + `_repeat` tag at ≥3.

**Tournament winner conflict** — a concurrency bug, not a tamper, no queryable store → no per-actor escalation. Fingerprinted by `matchId` so retries collapse into one issue; a spike across matches is the systemic signal.

Both pass through the H1 volume guard.

Tests: query-shape / never-throws for the count helper; funnel-extra + fingerprint + error-escalation for the MP alert; the existing D-3 conflict test now asserts 2 fingerprinted Sentry alerts.

Local: server `tsc -b`, `typecheck:scripts`, `build`, `npm test` all shards; client `test:all` 219/1643 (server-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pog14A6F9zVfVtECAg8Y7Q