### PR TITLE
H3: alert on tournament bracket invariant violations (T-15)

### DIFF
--- a/server/src/scheduledTournament/engine.gameOver.test.ts
+++ b/server/src/scheduledTournament/engine.gameOver.test.ts
@@ -4,6 +4,11 @@ vi.mock('../social/activityWriter', () => ({
   writeTournamentActivity: vi.fn().mockResolvedValue(undefined),
 }));
 
+const sentryCaptureMessage = vi.fn();
+vi.mock('@sentry/node', () => ({
+  captureMessage: (...args: unknown[]) => sentryCaptureMessage(...args),
+}));
+
 import { applyTournamentGameOverFromRoom } from './engine';
 import type { EnginePersistence } from './persistenceInterface';
 import { inMemoryMatchRpcForArrayStore } from './inMemoryMatchRpc.testkit';
@@ -157,6 +162,103 @@ describe('applyTournamentGameOverFromRoom', () => {
     const updated = await persistence.fetchMatchById('match-direct');
     expect(updated?.status).toBe('completed');
     expect(updated?.winner_id).toBe('u1');
+  });
+
+  it('alerts (T-15) when the completion RPC rejects a non-participant winner', async () => {
+    const persistence = makeGameOverPersistence({ ...liveMatch });
+    (persistence as { completeTournamentMatch: unknown }).completeTournamentMatch = async () => {
+      throw new Error('winner_not_participant');
+    };
+    const io = makeIoMock();
+    const { applyMatchResult } = await import('./engine');
+
+    await expect(
+      applyMatchResult(
+        io,
+        { matchId: 'match-direct', winnerId: 'u3', player1Score: 30, player2Score: 10, winnerSource: 'game_over' },
+        persistence,
+      ),
+    ).rejects.toThrow('winner_not_participant');
+
+    expect(sentryCaptureMessage).toHaveBeenCalledWith(
+      expect.stringContaining('winner_not_participant'),
+      expect.objectContaining({
+        level: 'error',
+        fingerprint: ['tournament-invariant-violation', 'winner_not_participant', 'match-direct'],
+        tags: expect.objectContaining({ tournament_alert: 'invariant_violation' }),
+      }),
+    );
+  });
+
+  it('alerts (T-15) when the bracket advance target is missing', async () => {
+    const persistence = makeGameOverPersistence({ ...liveMatch });
+    (persistence as { completeTournamentMatch: unknown }).completeTournamentMatch = async () => ({
+      status: 'completed',
+      winner_id: 'u1',
+      winner_source: 'game_over',
+      player1_score: 30,
+      player2_score: 10,
+      applied: true,
+      conflict: false,
+      advance_target_missing: true,
+      advanced_to_match_id: null,
+      advanced_to_slot: null,
+      advanced_to_status: null,
+      tournament_completed: false,
+      round_now_complete: false,
+      placements: null,
+    });
+    const io = makeIoMock();
+    const { applyMatchResult } = await import('./engine');
+
+    await applyMatchResult(
+      io,
+      { matchId: 'match-direct', winnerId: 'u1', player1Score: 30, player2Score: 10, winnerSource: 'game_over' },
+      persistence,
+    );
+
+    expect(sentryCaptureMessage).toHaveBeenCalledWith(
+      expect.stringContaining('advance_target_missing'),
+      expect.objectContaining({
+        level: 'error',
+        fingerprint: ['tournament-invariant-violation', 'advance_target_missing', 'match-direct'],
+      }),
+    );
+  });
+
+  it('alerts (T-15) on double advancement — advanced match id with no resulting status', async () => {
+    const persistence = makeGameOverPersistence({ ...liveMatch });
+    (persistence as { completeTournamentMatch: unknown }).completeTournamentMatch = async () => ({
+      status: 'completed',
+      winner_id: 'u1',
+      winner_source: 'game_over',
+      player1_score: 30,
+      player2_score: 10,
+      applied: true,
+      conflict: false,
+      advance_target_missing: false,
+      advanced_to_match_id: 'match-sf1',
+      advanced_to_slot: 'player1',
+      advanced_to_status: null,
+      tournament_completed: false,
+      round_now_complete: false,
+      placements: null,
+    });
+    const io = makeIoMock();
+    const { applyMatchResult } = await import('./engine');
+
+    await applyMatchResult(
+      io,
+      { matchId: 'match-direct', winnerId: 'u1', player1Score: 30, player2Score: 10, winnerSource: 'game_over' },
+      persistence,
+    );
+
+    expect(sentryCaptureMessage).toHaveBeenCalledWith(
+      expect.stringContaining('double_advancement'),
+      expect.objectContaining({
+        fingerprint: ['tournament-invariant-violation', 'double_advancement', 'match-direct'],
+      }),
+    );
   });
 
   it('returns false without throwing when no tournament match resolves', async () => {

--- a/server/src/scheduledTournament/engine.ts
+++ b/server/src/scheduledTournament/engine.ts
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/node';
 import { childLogger } from '../logger';
 import type { Server } from 'socket.io';
 import { supabaseFetch } from '../supabaseUtils';
@@ -15,6 +16,42 @@ import {
 import type { MatchRow, SeededPlayer } from './types';
 
 const log = childLogger('tournament:engine');
+
+/**
+ * T-15: bracket-integrity invariant violations (T-INV-2 / T-INV-5 / T-INV-6).
+ * These "should be impossible" — the atomic completion RPC enforces them — but
+ * if one ever fires in prod it means the bracket is corrupt and a player is
+ * stranded, so it must page rather than sit silently in `log.warn`. Each is
+ * fingerprinted per match so a single bad bracket is one Sentry issue, not N.
+ */
+export const TOURNAMENT_INVARIANT_RPC_ERRORS = new Set([
+  'winner_not_participant',
+  'no_advance_target',
+]);
+
+function alertTournamentInvariantViolation(
+  kind: string,
+  match: { id: string; tournament_id: string; round?: number | null; match_number?: number | null },
+  extra: Record<string, unknown>,
+): void {
+  Sentry.captureMessage(`[tournament] bracket invariant violation — ${kind}`, {
+    level: 'error',
+    fingerprint: ['tournament-invariant-violation', kind, match.id],
+    tags: {
+      tournament_alert: 'invariant_violation',
+      tournament_invariant: kind,
+      tournament_id: match.tournament_id,
+      match_id: match.id,
+    },
+    extra: {
+      matchId: match.id,
+      tournamentId: match.tournament_id,
+      round: match.round ?? null,
+      matchNumber: match.match_number ?? null,
+      ...extra,
+    },
+  });
+}
 
 const MIN_HUMANS_TO_START = 1;
 const BOT_ID_PREFIX = 'bot:fritz:';
@@ -448,18 +485,39 @@ export async function applyMatchResult(
   const match = await persistence.fetchMatchById(params.matchId);
   if (!match) throw new Error('Match not found');
 
-  const result = await persistence.completeTournamentMatch({
-    matchId: match.id,
-    winnerId: params.winnerId,
-    winnerSource: params.winnerSource ?? (params.byeWalkover ? null : 'game_over'),
-    statusReason: params.statusReason ?? null,
-    reportedPlayer1Score: params.player1Score,
-    reportedPlayer2Score: params.player2Score,
-    noShowUserId: params.noShowUserId ?? null,
-    forfeitUserId: params.forfeitUserId ?? null,
-    byeWalkover: params.byeWalkover ?? false,
-    actor: params.winnerSource ?? (params.byeWalkover ? 'bye_walkover' : 'game_over'),
-  });
+  let result: Awaited<ReturnType<typeof persistence.completeTournamentMatch>>;
+  try {
+    result = await persistence.completeTournamentMatch({
+      matchId: match.id,
+      winnerId: params.winnerId,
+      winnerSource: params.winnerSource ?? (params.byeWalkover ? null : 'game_over'),
+      statusReason: params.statusReason ?? null,
+      reportedPlayer1Score: params.player1Score,
+      reportedPlayer2Score: params.player2Score,
+      noShowUserId: params.noShowUserId ?? null,
+      forfeitUserId: params.forfeitUserId ?? null,
+      byeWalkover: params.byeWalkover ?? false,
+      actor: params.winnerSource ?? (params.byeWalkover ? 'bye_walkover' : 'game_over'),
+    });
+  } catch (err) {
+    const code = err instanceof Error ? err.message : String(err);
+    if (TOURNAMENT_INVARIANT_RPC_ERRORS.has(code)) {
+      log.error({
+        event: 'tournament_invariant_violation',
+        kind: code,
+        matchId: match.id,
+        tournamentId: match.tournament_id,
+        attemptedWinnerId: params.winnerId,
+      }, `tournament invariant violation (T-15): ${code}`);
+      alertTournamentInvariantViolation(code, match, {
+        attemptedWinnerId: params.winnerId,
+        attemptedSource: params.winnerSource ?? 'game_over',
+        player1Id: match.player1_id,
+        player2Id: match.player2_id,
+      });
+    }
+    throw err;
+  }
 
   if (!result.applied) {
     if (result.conflict) {
@@ -521,10 +579,32 @@ export async function applyMatchResult(
       round: match.round,
       matchNumber: match.match_number,
     }, 'match completed but its next-round row is missing — bracket may be corrupt');
+    alertTournamentInvariantViolation('advance_target_missing', match, {
+      round: match.round,
+      matchNumber: match.match_number,
+      winnerId: result.winner_id,
+    });
     return;
   }
 
   if (result.advanced_to_match_id) {
+    if (!result.advanced_to_status) {
+      // The advance UPDATE matched no row: the fed slot is already occupied by a
+      // *different* winner (double advancement / T-INV-5). The completion above
+      // is durable, so we do not roll back — but this bracket is now corrupt.
+      log.error({
+        event: 'tournament_invariant_violation',
+        kind: 'double_advancement',
+        matchId: match.id,
+        tournamentId: match.tournament_id,
+        nextMatchId: result.advanced_to_match_id,
+      }, 'tournament invariant violation (T-15): double_advancement');
+      alertTournamentInvariantViolation('double_advancement', match, {
+        nextMatchId: result.advanced_to_match_id,
+        slot: result.advanced_to_slot,
+        winnerId: result.winner_id,
+      });
+    }
     log.info({
       fromMatchId: match.id,
       nextMatchId: result.advanced_to_match_id,


### PR DESCRIPTION
PRE_LAUNCH_HARDENING.md §4 item 3 — "Add alerting on tournament invariant violations (T-15) — currently silent."

## What

`complete_tournament_match` enforces the bracket invariants (T-INV-2 winner-is-participant, T-INV-5 single advancement, T-INV-6 bracket-exact advance target). When one is violated the completion is durable but the bracket is corrupt and a player is stranded — and the only trace was a `log.warn` no one watches.

Adds `Sentry.captureMessage` (level `error`, `fingerprint: ['tournament-invariant-violation', kind, matchId]` so one bad bracket = one issue, tag `tournament_alert: invariant_violation`) for:

| kind | detection |
|---|---|
| `winner_not_participant`, `no_advance_target` | thrown by the RPC → caught in `applyMatchResult`, alerted, **rethrown unchanged** |
| `advance_target_missing` | the completed-but-unadvanced result flag (was `log.warn` only) |
| `double_advancement` | `advanced_to_match_id` set but `advanced_to_status` null — fed slot already holds a different winner |

The winner-conflict slice of T-15 was already handled in #150. Existing log lines / `event` fields are unchanged (greppability, existing tests).

## Test

`engine.gameOver.test.ts` — 3 new cases (non-participant rejection alerts + rethrows; advance-target-missing alerts; double-advancement alerts), each asserting the fingerprint.

Full local server bar green (tsc -b, typecheck:scripts, build, all 4 test shards). Server-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pog14A6F9zVfVtECAg8Y7Q