### PR TITLE
H4: bound /ready's Supabase probe (timeout + circuit-break)

### DIFF
--- a/server/src/platform/health/registerHealthRoutes.test.ts
+++ b/server/src/platform/health/registerHealthRoutes.test.ts
@@ -137,6 +137,30 @@ describe('GET /ready — dailyPuzzleGeneration is observed but not gating', () =
     expect(body.ok).toBe(false);
   });
 
+  it('bounds the supabase readiness probe: short timeout + circuit-breakable', async () => {
+    const request = makeHarness();
+    await request('GET', '/ready');
+
+    const readinessCall = supabaseFetchMock.mock.calls.find(
+      ([path]) => typeof path === 'string' && path.startsWith('/rest/v1/profiles?select=id'),
+    );
+    expect(readinessCall).toBeDefined();
+    const opts = readinessCall![1] as { timeoutMs?: number; circuitBreakable?: boolean };
+    expect(opts.circuitBreakable).toBe(true);
+    expect(opts.timeoutMs).toBeLessThanOrEqual(2_000);
+  });
+
+  it('still 503s /ready (does not hang) when the probe is short-circuited by an open breaker', async () => {
+    supabaseFetchMock
+      .mockReset()
+      .mockRejectedValue(new Error('Supabase circuit breaker is open — skipping read: /rest/v1/profiles'));
+    const request = makeHarness();
+    const { status, body } = await request('GET', '/ready');
+
+    expect(status).toBe(503);
+    expect(body.ok).toBe(false);
+  });
+
   it('does not probe or alert when required env is missing', async () => {
     delete process.env.SUPABASE_URL;
     const probe = vi.fn(async () => '2027-09-01');

--- a/server/src/platform/health/registerHealthRoutes.ts
+++ b/server/src/platform/health/registerHealthRoutes.ts
@@ -43,12 +43,22 @@ function getProcessErrorLogPayload(error: unknown): { name?: string; message: st
   return { message: typeof error === 'string' ? error : JSON.stringify(error) };
 }
 
+/**
+ * Hard ceiling for the readiness probe. Render polls `/ready` frequently; a
+ * Supabase that is slow rather than down must not let those requests pile up.
+ * `supabaseFetch` aborts at `timeoutMs`, and `circuitBreakable` lets the shared
+ * breaker fail this read fast (no socket at all) once Supabase has been failing
+ * — so a sustained outage costs one timeout, not one per health check.
+ */
+const SUPABASE_READINESS_TIMEOUT_MS = 2_000;
+
 async function getSupabaseReadiness(): Promise<{ ok: boolean; latencyMs: number; error?: string }> {
   const startedAt = Date.now();
   try {
     await supabaseFetch('/rest/v1/profiles?select=id&limit=1', {
       method: 'GET',
-      timeoutMs: 3_000,
+      timeoutMs: SUPABASE_READINESS_TIMEOUT_MS,
+      circuitBreakable: true,
       headers: { Prefer: 'return=minimal' },
     });
     return { ok: true, latencyMs: Date.now() - startedAt };


### PR DESCRIPTION
PRE_LAUNCH_HARDENING.md §4 item 4 — "Bound /ready's Supabase probe (timeout/circuit-break) so a slow Supabase response doesn't hang health checks."

## What

`getSupabaseReadiness()` already passed `timeoutMs: 3_000` (`supabaseFetch` aborts via `AbortController`), so the probe was bounded — but 3s is long for an endpoint Render polls frequently, and the read was not `circuitBreakable`, so a sustained outage cost one 3s timeout *per poll*.

Changes: `timeoutMs` → `2_000`; add `circuitBreakable: true`. Once Supabase trips the shared breaker (3 failures / 10s), `/ready`'s probe fails instantly for 30s and still reports `503 degraded`.

## Test

`registerHealthRoutes.test.ts` — asserts probe opts (`circuitBreakable: true`, `timeoutMs <= 2000`) and that an open-breaker rejection still yields `503` (no hang).

Full local server bar green. Server-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pog14A6F9zVfVtECAg8Y7Q