### PR TITLE
D1 Part A: shared useAsyncData hook + unit tests

### DIFF
--- a/client/src/hooks/useAsyncData.test.ts
+++ b/client/src/hooks/useAsyncData.test.ts
@@ -1,0 +1,215 @@
+// @vitest-environment jsdom
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useAsyncData } from './useAsyncData';
+
+/** A promise whose resolution/rejection the test controls. */
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe('useAsyncData', () => {
+  let consoleError: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleError.mockRestore();
+    vi.restoreAllMocks();
+  });
+
+  it('starts in loading with no data or error, then resolves to data', async () => {
+    const fetcher = vi.fn().mockResolvedValue({ value: 42 });
+    const { result } = renderHook(() => useAsyncData(fetcher, []));
+
+    expect(result.current.loading).toBe(true);
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.error).toBeNull();
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.data).toEqual({ value: 42 });
+    expect(result.current.error).toBeNull();
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it('surfaces a thrown Error message and leaves data undefined', async () => {
+    const fetcher = vi.fn().mockRejectedValue(new Error('boom'));
+    const { result } = renderHook(() => useAsyncData(fetcher, []));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.error).toBe('boom');
+    expect(result.current.data).toBeUndefined();
+  });
+
+  it('falls back to options.errorMessage when the error has no message', async () => {
+    const fetcher = vi.fn().mockRejectedValue(new Error(''));
+    const { result } = renderHook(() =>
+      useAsyncData(fetcher, [], { errorMessage: 'Could not load the leaderboard.' }),
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.error).toBe('Could not load the leaderboard.');
+  });
+
+  it('normalises a non-Error rejection to the fallback string', async () => {
+    const fetcher = vi.fn().mockRejectedValue('a bare string');
+    const { result } = renderHook(() =>
+      useAsyncData(fetcher, [], { errorMessage: 'Nope.' }),
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.error).toBe('Nope.');
+  });
+
+  it('refetch() re-runs the fetcher, clears the prior error, and keeps stale data meanwhile', async () => {
+    const first = deferred<{ n: number }>();
+    const second = deferred<{ n: number }>();
+    const fetcher = vi
+      .fn()
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise);
+
+    const { result } = renderHook(() => useAsyncData(fetcher, []));
+
+    await act(async () => {
+      first.resolve({ n: 1 });
+    });
+    expect(result.current.data).toEqual({ n: 1 });
+    expect(result.current.loading).toBe(false);
+
+    let refetchDone = false;
+    await act(async () => {
+      void result.current.refetch().then(() => {
+        refetchDone = true;
+      });
+    });
+
+    // Mid-refetch: loading again, but the previous data is still on screen.
+    expect(result.current.loading).toBe(true);
+    expect(result.current.data).toEqual({ n: 1 });
+    expect(refetchDone).toBe(false);
+
+    await act(async () => {
+      second.resolve({ n: 2 });
+    });
+    expect(result.current.data).toEqual({ n: 2 });
+    expect(result.current.loading).toBe(false);
+    expect(refetchDone).toBe(true);
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
+  it('refetch() recovers from an errored state', async () => {
+    const fetcher = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('flaky'))
+      .mockResolvedValueOnce({ ok: true });
+
+    const { result } = renderHook(() => useAsyncData(fetcher, []));
+    await waitFor(() => expect(result.current.error).toBe('flaky'));
+
+    await act(async () => {
+      await result.current.refetch();
+    });
+    expect(result.current.error).toBeNull();
+    expect(result.current.data).toEqual({ ok: true });
+  });
+
+  it('refetches when a dep changes and ignores the superseded (slower) first response', async () => {
+    const slowOld = deferred<string>();
+    const fastNew = deferred<string>();
+    const fetcher = vi
+      .fn<(id: string) => Promise<string>>()
+      .mockReturnValueOnce(slowOld.promise)
+      .mockReturnValueOnce(fastNew.promise);
+
+    const { result, rerender } = renderHook(({ id }) => useAsyncData(() => fetcher(id), [id]), {
+      initialProps: { id: 'a' },
+    });
+
+    // First request (id: 'a') is in flight.
+    await waitFor(() => expect(fetcher).toHaveBeenCalledTimes(1));
+    expect(fetcher).toHaveBeenLastCalledWith('a');
+
+    rerender({ id: 'b' });
+    await waitFor(() => expect(fetcher).toHaveBeenCalledTimes(2));
+    expect(fetcher).toHaveBeenLastCalledWith('b');
+
+    // The second (id: 'b') request resolves first...
+    await act(async () => {
+      fastNew.resolve('B');
+    });
+    expect(result.current.data).toBe('B');
+
+    // ...then the stale id: 'a' request resolves and must be dropped.
+    await act(async () => {
+      slowOld.resolve('A');
+      await Promise.resolve();
+    });
+    expect(result.current.data).toBe('B');
+  });
+
+  it('does not fetch while enabled is false, and fetches once it flips true', async () => {
+    const fetcher = vi.fn().mockResolvedValue('ready');
+    const { result, rerender } = renderHook(
+      ({ enabled }) => useAsyncData(fetcher, [], { enabled }),
+      { initialProps: { enabled: false } },
+    );
+
+    expect(result.current.loading).toBe(false);
+    expect(fetcher).not.toHaveBeenCalled();
+
+    rerender({ enabled: true });
+    await waitFor(() => expect(result.current.data).toBe('ready'));
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it('drops the response and aborts the signal when unmounted mid-fetch (no setState-after-unmount)', async () => {
+    const pending = deferred<string>();
+    let capturedSignal: AbortSignal | undefined;
+    const fetcher = vi.fn((ctx: { signal: AbortSignal }) => {
+      capturedSignal = ctx.signal;
+      return pending.promise;
+    });
+
+    const { result, unmount } = renderHook(() => useAsyncData(fetcher, []));
+    expect(result.current.loading).toBe(true);
+
+    await waitFor(() => expect(fetcher).toHaveBeenCalledTimes(1));
+    expect(capturedSignal?.aborted).toBe(false);
+
+    unmount();
+    expect(capturedSignal?.aborted).toBe(true);
+
+    await act(async () => {
+      pending.resolve('too late');
+    });
+
+    // Last snapshot before unmount is unchanged, and React logged nothing.
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.loading).toBe(true);
+    expect(consoleError).not.toHaveBeenCalled();
+  });
+
+  it('drops a rejection that lands after unmount without an unhandled rejection', async () => {
+    const pending = deferred<string>();
+    const fetcher = vi.fn(() => pending.promise);
+    const { unmount } = renderHook(() => useAsyncData(fetcher, []));
+
+    await waitFor(() => expect(fetcher).toHaveBeenCalledTimes(1));
+    unmount();
+    await act(async () => {
+      pending.reject(new Error('late failure'));
+      await Promise.resolve();
+    });
+
+    expect(consoleError).not.toHaveBeenCalled();
+  });
+});

--- a/client/src/hooks/useAsyncData.ts
+++ b/client/src/hooks/useAsyncData.ts
@@ -1,0 +1,142 @@
+import { useCallback, useEffect, useRef, useState, type DependencyList } from 'react';
+
+/**
+ * Shared replacement for the hand-rolled `[data] / [loading] / [error]` +
+ * `useEffect` fetch triad that ~15 screens each re-implement with subtly
+ * different abort handling (REFACTOR_OPPORTUNITIES.md §3 D1).
+ *
+ * What it standardises — the parts the copy-pasted versions get wrong:
+ *  - a response from a superseded request (deps changed, or the component
+ *    unmounted mid-flight) is *dropped*, never applied → no "setState on an
+ *    unmounted component", no last-writer-wins race between two in-flight loads;
+ *  - the previous `data` stays visible while a refetch is in flight (no flash to
+ *    empty) — matches what every current triad already does;
+ *  - `error` is cleared at the start of every attempt;
+ *  - an `AbortSignal` is handed to the fetcher for APIs that can honour it.
+ *
+ * It deliberately does NOT do caching, stale-while-revalidate across mounts, or
+ * request dedup — those are `socialApi`'s `withCachedRequest` job. This is the
+ * per-screen "load this when these inputs change" primitive only.
+ */
+
+export interface UseAsyncDataOptions {
+  /**
+   * When false the fetcher does not run and `loading` is false. Use for screens
+   * that gate on an id being present (`enabled: Boolean(userId)`). Flipping it
+   * true triggers a fetch; flipping it false leaves the last `data`/`error` in
+   * place (the screen decides what to render when disabled).
+   */
+  enabled?: boolean;
+  /**
+   * Message to surface when the thrown error carries no usable `.message`.
+   * Lets a migrated screen keep its exact copy ("Could not load the
+   * leaderboard.") without a per-render fallback expression.
+   */
+  errorMessage?: string;
+}
+
+export interface UseAsyncDataResult<T> {
+  /** `undefined` until the first successful load; retained across refetches. */
+  data: T | undefined;
+  loading: boolean;
+  /** Normalised to a display string, or null when the last attempt succeeded. */
+  error: string | null;
+  /**
+   * Re-run the fetcher now (e.g. after a mutation, or a manual "retry" button).
+   * Resolves when that run settles; never rejects. No-op while `enabled` is
+   * false.
+   */
+  refetch: () => Promise<void>;
+}
+
+const DEFAULT_ERROR_MESSAGE = 'Something went wrong. Please try again.';
+
+export function useAsyncData<T>(
+  fetcher: (context: { signal: AbortSignal }) => Promise<T>,
+  deps: DependencyList,
+  options: UseAsyncDataOptions = {},
+): UseAsyncDataResult<T> {
+  const { enabled = true, errorMessage } = options;
+
+  const [data, setData] = useState<T | undefined>(undefined);
+  const [error, setError] = useState<string | null>(null);
+  // Raw in-flight flag, mutated only from inside `execute` (never synchronously
+  // in an effect). The value handed to the caller is derived below so a disabled
+  // hook always reports `loading: false` even if a request was superseded
+  // mid-flight by `enabled` flipping false.
+  const [fetching, setFetching] = useState(enabled);
+
+  // Monotonic id of the latest request. A settled promise whose id no longer
+  // matches has been superseded (deps change / unmount / manual refetch) and its
+  // result is discarded.
+  const runIdRef = useRef(0);
+  const activeControllerRef = useRef<AbortController | null>(null);
+
+  // Always call the newest fetcher/fallback without making them refetch triggers
+  // (only `deps` decides that).
+  const fetcherRef = useRef(fetcher);
+  const errorMessageRef = useRef(errorMessage);
+  useEffect(() => {
+    fetcherRef.current = fetcher;
+    errorMessageRef.current = errorMessage;
+  });
+
+  const execute = useCallback(async (): Promise<void> => {
+    activeControllerRef.current?.abort();
+    const controller = new AbortController();
+    activeControllerRef.current = controller;
+    const runId = ++runIdRef.current;
+
+    // Push the state updates off the synchronous call stack so this is never a
+    // setState *within* the effect body (avoids cascading renders — the same
+    // `await Promise.resolve()` guard the hand-rolled triads use).
+    await Promise.resolve();
+    if (runId !== runIdRef.current) return;
+
+    setFetching(true);
+    setError(null);
+
+    try {
+      const result = await fetcherRef.current({ signal: controller.signal });
+      if (runId === runIdRef.current) {
+        setData(result);
+        setFetching(false);
+      }
+    } catch (err) {
+      if (runId !== runIdRef.current || controller.signal.aborted) return;
+      const message =
+        err instanceof Error && err.message
+          ? err.message
+          : errorMessageRef.current ?? DEFAULT_ERROR_MESSAGE;
+      setError(message);
+      setFetching(false);
+    }
+  }, []);
+
+  const refetch = useCallback(async (): Promise<void> => {
+    if (!enabled) return;
+    await execute();
+  }, [enabled, execute]);
+
+  useEffect(() => {
+    if (!enabled) {
+      // Supersede any request left in flight by the transition to disabled; the
+      // derived `loading` below already reads false while disabled.
+      runIdRef.current += 1;
+      activeControllerRef.current?.abort();
+      return;
+    }
+    void execute();
+    return () => {
+      // Supersede the in-flight request and abort it so its resolution is a
+      // no-op.
+      runIdRef.current += 1;
+      activeControllerRef.current?.abort();
+    };
+    // `deps` is the caller's declared list of refetch triggers; `execute` is
+    // stable. Spreading a param array is invisible to the rule.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [enabled, execute, ...deps]);
+
+  return { data, loading: enabled && fetching, error, refetch };
+}


### PR DESCRIPTION
**REFACTOR_OPPORTUNITIES.md §3 D1**, Part A of 2. Hook + tests only — **no screens migrated** (that's Part B, batched by feature area).

## Why

~15 screens (`RatingHistoryPage`, `PuzzleRushLeaderboardScreen`, `DailyFritzLeaderboardScreen`, `LeaderboardScreen`, `FriendsScreen`, `WeeklyStatsScreen`, `ActivityFeedPanel`, `GhostSetupScreen`, …) each hand-roll the same `[data]/[loading]/[error]` + `useEffect` fetch triad, with **subtly different** abort handling:
- `RatingHistoryPage` — `let active` flag, `await Promise.resolve()` defer, fetcher returns `{data,error}`
- `PuzzleRushLeaderboardScreen` — `let cancelled`, `try/catch/finally`, fetcher **throws**
- `ActivityFeedPanel` — **no unmount guard at all** (latent setState-after-unmount)
- `LeaderboardScreen` / `FriendsScreen` — `{error}` Result shape, per-tab load fns

## The hook

```ts
const { data, loading, error, refetch } = useAsyncData(fetcher, deps, options?)
```

| Concern | Decision |
|---|---|
| Interface | `{ data: T \| undefined, loading: boolean, error: string \| null, refetch: () => Promise<void> }` — every current call site renders `error` as a plain string, so `string \| null` (not `Error`) minimises migration churn |
| Superseded responses | monotonic run-id + `AbortController`; a response from a stale run (deps changed, unmounted, or a newer `refetch`) is **dropped, never applied** — fixes the setState-after-unmount and last-writer-wins races |
| Refetch | keeps previous `data` visible while loading (matches every current triad); clears `error` at the start of each attempt |
| `enabled` | for screens gating on an id (`enabled: Boolean(userId)`); `loading` is **derived** (`enabled && fetching`) so a disabled hook always reads `false` even if a request was superseded mid-flight |
| Error string | thrown `Error.message`, else `options.errorMessage`, else a generic fallback — lets a migrated screen keep its exact copy without a per-render expression |
| AbortSignal | handed to the fetcher for APIs that honour it (most here don't yet; the run-id guard is what actually prevents bad setState) |
| Out of scope | caching / SWR-across-mounts / request dedup — that's `socialApi`'s `withCachedRequest` |

One behavioural note for Part B: the hook does `await Promise.resolve()` before the first `setState` (same idiom `RatingHistoryPage` already uses) to satisfy `react-hooks/set-state-in-effect` — fetches start one microtask later than a synchronous hand-rolled effect. Imperceptible, but noted.

## Tests (`useAsyncData.test.ts`, 10 cases)

success · thrown-Error message · `errorMessage` fallback · non-Error rejection · `refetch` keeps stale data + resolves on settle · `refetch` recovers from error · **dep-change race** (slow superseded response dropped) · `enabled` gating (no fetch → fetch on flip) · **unmount mid-fetch** (signal aborted, no setState, `console.error` clean) · rejection after unmount (no unhandled rejection)

## Verification

Full local bar green: `tsc -b`, `lint` 50/50 (0 errors), `lint:hooks` 0, `lint:css`, `check:architecture` 20/20, `check:deps`, `check:bot-match-lazy --dist` (fresh build), client vitest **221/1662**, server `tsc -b` + vitest all shards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019CsumV3BdhvCQX8uFt9Ee2