### PR TITLE
D1 Part B batch 1: 3 leaderboard/history screens → useAsyncData

### DIFF
--- a/client/src/dailyFritz/DailyFritzLeaderboardScreen.tsx
+++ b/client/src/dailyFritz/DailyFritzLeaderboardScreen.tsx
@@ -7,6 +7,7 @@ import { GameOverlayPortal } from '../components/GameOverlayPortal';
 import { fetchFriends } from '../friends/friendsApi';
 import FilterPills from '../social/hub/FilterPills';
 import { avatarHue, getInitials } from '../components/hub/playerInitialsAvatarUtils';
+import { useAsyncData } from '../hooks/useAsyncData';
 import {
   fetchDailyFritzLeaderboard,
   getTodayDailyFritz,
@@ -226,9 +227,19 @@ export default function DailyFritzLeaderboardScreen({
   onBack,
   onNavigate,
 }: DailyFritzLeaderboardScreenProps) {
-  const [rows, setRows] = useState<DailyFritzLeaderboardRow[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  // The hand-rolled version deliberately swallowed the real error and always
+  // showed this one string — keep that by rethrowing a fixed-message Error.
+  const { data: rowsData, loading, error } = useAsyncData<DailyFritzLeaderboardRow[]>(
+    async () => {
+      try {
+        return await fetchDailyFritzLeaderboard(runDate);
+      } catch {
+        throw new Error('Couldn’t load the leaderboard. Please try again.');
+      }
+    },
+    [runDate],
+  );
+  const rows = useMemo(() => rowsData ?? [], [rowsData]);
   const [filter, setFilter] = useState<LeaderboardFilter>('global');
   const [friendUsernames, setFriendUsernames] = useState<Set<string>>(new Set());
   const [countdownTick, setCountdownTick] = useState(0);
@@ -252,26 +263,6 @@ export default function DailyFritzLeaderboardScreen({
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [countdownTick],
   );
-
-  const loadLeaderboard = useCallback(async () => {
-    setLoading(true);
-    setError(null);
-    try {
-      const data = await fetchDailyFritzLeaderboard(runDate);
-      setRows(data);
-    } catch (err) {
-      void err;
-      setError('Couldn’t load the leaderboard. Please try again.');
-      setRows([]);
-    } finally {
-      setLoading(false);
-    }
-  }, [runDate]);
-
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- resets friend usernames on sign-out; the effect runs the async friends fetch
-    void loadLeaderboard();
-  }, [loadLeaderboard]);
 
   useEffect(() => {
     if (!user?.id) {

--- a/client/src/puzzleRush/PuzzleRushLeaderboardScreen.tsx
+++ b/client/src/puzzleRush/PuzzleRushLeaderboardScreen.tsx
@@ -1,6 +1,7 @@
 import { track } from '../lib/analytics';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { GlobalNav } from '../components';
+import { useAsyncData } from '../hooks/useAsyncData';
 import FilterPills from '../social/hub/FilterPills';
 import { avatarHue, getInitials } from '../components/hub/playerInitialsAvatarUtils';
 import { formatCountdownHms, secondsUntilNextPacificMidnight } from '../dailyFritz/format';
@@ -156,31 +157,14 @@ export function PuzzleRushLeaderboardScreen({
   onNavigate?: (mode: AppMode) => void;
   currentUsername?: string | null;
 }) {
-  const [data, setData] = useState<PuzzleRushLeaderboardResponse | null>(null);
-  const [error, setError] = useState<string | null>(null);
-  const [loading, setLoading] = useState(true);
+  const { data, error, loading } = useAsyncData<PuzzleRushLeaderboardResponse>(
+    () => fetchPuzzleRushLeaderboard(),
+    [],
+    { errorMessage: 'Could not load the leaderboard.' },
+  );
   const [filter, setFilter] = useState<Filter>('today');
   const [resetSeconds, setResetSeconds] = useState(() => secondsUntilNextPacificMidnight(new Date()));
   const [shareDone, setShareDone] = useState(false);
-
-  useEffect(() => {
-    let cancelled = false;
-    void (async () => {
-      try {
-        const response = await fetchPuzzleRushLeaderboard();
-        if (!cancelled) setData(response);
-      } catch (caught) {
-        if (!cancelled) {
-          setError(caught instanceof Error ? caught.message : 'Could not load the leaderboard.');
-        }
-      } finally {
-        if (!cancelled) setLoading(false);
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, []);
 
   useEffect(() => {
     const id = window.setInterval(() => setResetSeconds(secondsUntilNextPacificMidnight(new Date())), 1000);

--- a/client/src/ranking/RatingHistoryPage.tsx
+++ b/client/src/ranking/RatingHistoryPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import {
   Area,
   CartesianGrid,
@@ -12,6 +12,7 @@ import {
   YAxis,
 } from 'recharts';
 import LayoutScreen from '../ui/LayoutScreen';
+import { useAsyncData } from '../hooks/useAsyncData';
 import { fetchRatingHistory, fetchRankingLeaderboard, type LeaderboardEntry, type RatingHistoryResponse } from './api';
 
 interface RatingHistoryPageProps {
@@ -72,58 +73,25 @@ export default function RatingHistoryPage({
   username,
   onBack,
 }: RatingHistoryPageProps) {
-  const [history, setHistory] = useState<RatingHistoryResponse | null>(null);
-  const [loading, setLoading] = useState(Boolean(userId));
-  const [error, setError] = useState<string | null>(null);
-  const [leaderboard, setLeaderboard] = useState<LeaderboardEntry[]>([]);
-  const [leaderboardUnavailable, setLeaderboardUnavailable] = useState(false);
+  const { data: history, loading, error } = useAsyncData<RatingHistoryResponse | null>(
+    async () => {
+      if (!userId) return null;
+      const result = await fetchRatingHistory(userId);
+      if (result.error) throw new Error(result.error);
+      return result.data;
+    },
+    [userId],
+    { enabled: Boolean(userId), errorMessage: 'Unable to load rating history.' },
+  );
 
-  useEffect(() => {
-    if (!userId) return;
+  const { data: leaderboardData } = useAsyncData(
+    async () => (await fetchRankingLeaderboard(20)).data,
+    [],
+  );
+  const leaderboard: LeaderboardEntry[] = leaderboardData?.leaderboard ?? [];
+  const leaderboardUnavailable = Boolean(leaderboardData?.leaderboard_load_failed);
 
-    let active = true;
-    void (async () => {
-      await Promise.resolve();
-      if (!active) return;
-      setLoading(true);
-      setError(null);
-
-      try {
-        const result = await fetchRatingHistory(userId);
-        if (!active) return;
-        setLoading(false);
-        if (result.error) {
-          setError(result.error);
-          setHistory(null);
-          return;
-        }
-        setHistory(result.data);
-      } catch (err) {
-        if (!active) return;
-        setLoading(false);
-        setError(err instanceof Error ? err.message : 'Unable to load rating history.');
-      }
-    })();
-
-    return () => {
-      active = false;
-    };
-  }, [userId]);
-
-  useEffect(() => {
-    let active = true;
-    void fetchRankingLeaderboard(20).then((result) => {
-      if (!active) return;
-      if (result.data?.leaderboard_load_failed) {
-        setLeaderboardUnavailable(true);
-      } else {
-        setLeaderboard(result.data?.leaderboard ?? []);
-      }
-    });
-    return () => { active = false; };
-  }, []);
-
-  const displayHistory = userId ? history : null;
+  const displayHistory = userId ? history ?? null : null;
   const displayLoading = userId ? loading : false;
   const displayError = userId ? error : 'Sign in to view your rating history.';
 


### PR DESCRIPTION
**REFACTOR_OPPORTUNITIES.md §3 D1**, Part B, batch 1 of ~3. Migrates the three clean single-fetch screens to the `useAsyncData` hook from #153.

## Migrated (behaviour-identical)

| Screen | Fetch | Notes |
|---|---|---|
| `PuzzleRushLeaderboardScreen` | `fetchPuzzleRushLeaderboard()`, `[]`, throws | `errorMessage: 'Could not load the leaderboard.'` reproduces the old `caught instanceof Error ? caught.message : <fallback>` exactly |
| `DailyFritzLeaderboardScreen` | `fetchDailyFritzLeaderboard(runDate)`, `[runDate]`, throws | old code **deliberately swallowed the real error** and always showed one fixed string — preserved by rethrowing a fixed-message `Error` inside the fetcher (not the `errorMessage` option, which would surface `err.message`). Only the `loadLeaderboard` triad migrated; the seeded-`today` fetch and the friend-usernames fetch are untouched. |
| `RatingHistoryPage` | history (`fetchRatingHistory(userId)`, gated) + global leaderboard (always) | two independent hand-rolled effects → two `useAsyncData` calls. `displayHistory`/`displayLoading`/`displayError` still derive on `userId`, so the "Sign in to view your rating history." copy and gating are unchanged. |

Loading UI, error strings, empty states, and `data`-null handling verified line-by-line against each original.

## Latent bug fixed as a side effect — **called out, not blended in**

`DailyFritzLeaderboardScreen`'s `loadLeaderboard` effect had **no cancellation guard** (`useEffect(() => { void loadLeaderboard(); }, [loadLeaderboard])`, `loadLeaderboard` keyed on `runDate`, no `cancelled` flag, no cleanup). A `runDate` change or an unmount mid-fetch would `setRows`/`setError`/`setLoading` on a stale or unmounted component, and two in-flight loads raced last-writer-wins. `useAsyncData`'s run-id + `AbortController` supersession fixes both.

`PuzzleRushLeaderboardScreen` and `RatingHistoryPage` already had `cancelled`/`active` guards — pure refactor there, no behaviour change.

## Not in this batch

- **`WeeklyStatsScreen`, `ActivityFeedPanel`, `GhostSetupScreen`** — batch 2. Each needs a small *non-mechanical* adaptation (reset-on-close → derive-on-disable; an `onFeedChange` bridge effect + it also picks up the missing-unmount-guard fix; partial migration of 1-of-3 fetches). Kept out of this "safe mechanical swap" batch so the diff stays trivially reviewable.
- **`LeaderboardScreen`** — flagged **not-a-fit**: 4 resources (`globalData`/`friendsData`/`weeklyData`/`modeData`) behind a per-tab "fetch once, never refetch" client cache with one shared `loading`/`error`. `useAsyncData` is single-resource and explicitly not a cache.
- **`FriendsScreen`** — flagged **defer**: multi-resource (`friends`/`incoming`/`outgoing` + presence map), a 30 s presence poll, a socket presence subscription, and `loadFriends()` called from ~10 mutation handlers. The core `fetchFriends` load is migratable in principle but the blast radius is too large for a "zero behaviour change" guarantee without its own dedicated pass.

## Verification

Full local bar green: `tsc -b`, `lint` 50/50 (0 errors), `lint:hooks` 0, `lint:css`, `check:architecture` 20/20, `check:deps`, `check:bot-match-lazy --dist` (fresh build), client vitest **221/1662** (`ActivityFeedPanel.board.test` unchanged, still green), server `tsc -b` + vitest all shards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019CsumV3BdhvCQX8uFt9Ee2