### PR TITLE
D1 Part B batch 2: WeeklyStats / ActivityFeed / GhostSetup → useAsyncData

### DIFF
--- a/client/src/ghost/GhostSetupScreen.tsx
+++ b/client/src/ghost/GhostSetupScreen.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react';
+import { useAsyncData } from '../hooks/useAsyncData';
 import type { GhostProfileSummary } from './api';
 import { fetchGhostProfileSummary, fetchGhostProfileSummaryByUsername } from './api';
 import { fetchFriends, type FriendRecord } from '../friends/friendsApi';
@@ -80,9 +81,6 @@ export default function GhostSetupScreen({
   onOpenAuth,
   onSignOut,
 }: GhostSetupScreenProps) {
-  const [summary, setSummary] = useState<GhostProfileSummary | null>(null);
-  const [loading, setLoading] = useState(Boolean(userId));
-  const [error, setError] = useState<string | null>(null);
   const [friends, setFriends] = useState<FriendRecord[]>([]);
   const [selectedUserId, setSelectedUserId] = useState<string | null>(userId);
   const [selectedUsername, setSelectedUsername] = useState<string>('Your Ghost');
@@ -93,6 +91,17 @@ export default function GhostSetupScreen({
     [],
   );
   const heroSrc = useDeferredAsset('ghost-setup-hero', loadHeroAsset);
+
+  const { data: summaryData, loading, error: summaryError } = useAsyncData<GhostProfileSummary | null>(
+    () => (selectedUserId ? fetchGhostProfileSummary(selectedUserId) : Promise.resolve(null)),
+    [selectedUserId],
+    { enabled: Boolean(selectedUserId), errorMessage: 'Unable to load Ghost Mode.' },
+  );
+  // The hand-rolled version cleared summary/error whenever no ghost was selected;
+  // the hook retains them, so gate on the same condition at read time.
+  const summary = selectedUserId ? summaryData ?? null : null;
+  const error = selectedUserId ? summaryError : null;
+
   const isViewingOwnGhost = selectedUserId === userId;
   const isLocked = Boolean(userId) && isViewingOwnGhost && fritzGamesPlayed < UNLOCK_THRESHOLD;
   const canPlay = Boolean(summary) && !loading && !isLocked;
@@ -122,33 +131,6 @@ export default function GhostSetupScreen({
       });
     }
   }, [userId]);
-
-  useEffect(() => {
-    if (!selectedUserId) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- resets the summary panel when no user is selected; the effect runs the async summary fetch
-      setLoading(false);
-      setSummary(null);
-      setError(null);
-      return;
-    }
-    let active = true;
-    setLoading(true);
-    setError(null);
-    void fetchGhostProfileSummary(selectedUserId)
-      .then((data) => {
-        if (!active) return;
-        setSummary(data);
-        setLoading(false);
-      })
-      .catch((err) => {
-        if (!active) return;
-        setError(err instanceof Error ? err.message : 'Unable to load Ghost Mode.');
-        setLoading(false);
-      });
-    return () => {
-      active = false;
-    };
-  }, [selectedUserId]);
 
   const handleSelectFriend = (friend: FriendRecord | null) => {
     if (!friend) {

--- a/client/src/social/ActivityFeedPanel.tsx
+++ b/client/src/social/ActivityFeedPanel.tsx
@@ -1,5 +1,6 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import type { User } from '@supabase/supabase-js';
+import { useAsyncData } from '../hooks/useAsyncData';
 import { fetchActivityFeed, type FeedItem } from './socialApi';
 import {
   buildFeedRowViewModel,
@@ -165,24 +166,6 @@ function filterItems(
   }
 }
 
-function feedItemsEqual(a: FeedItem[], b: FeedItem[]): boolean {
-  if (a === b) return true;
-  if (a.length !== b.length) return false;
-  for (let index = 0; index < a.length; index += 1) {
-    const left = a[index];
-    const right = b[index];
-    if (
-      left.id !== right.id ||
-      left.username !== right.username ||
-      left.type !== right.type ||
-      left.created_at !== right.created_at
-    ) {
-      return false;
-    }
-  }
-  return true;
-}
-
 export default function ActivityFeedPanel({
   user,
   filter,
@@ -192,31 +175,41 @@ export default function ActivityFeedPanel({
   emptyAction,
   onFeedChange,
 }: ActivityFeedPanelProps) {
-  const [feed, setFeed] = useState<FeedItem[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
   const [visibleCount, setVisibleCount] = useState(10);
 
-  const load = useCallback(async () => {
-    if (!user) {
-      onFeedChange?.([]);
-      return;
-    }
-    setLoading(true);
-    const result = await fetchActivityFeed();
-    setLoading(false);
-    if (result.error) {
-      setError(result.error);
-      onFeedChange?.([]);
-      return;
-    }
-    setFeed((current) => (feedItemsEqual(current, result.feed) ? current : result.feed));
-    setVisibleCount((current) => (current === 10 ? current : 10));
-    onFeedChange?.(result.feed);
-  }, [onFeedChange, user]);
+  const hasUser = Boolean(user);
+  const { data, loading, error, refetch } = useAsyncData<FeedItem[]>(
+    async () => {
+      const result = await fetchActivityFeed();
+      if (result.error) throw new Error(result.error);
+      return result.feed;
+    },
+    [user?.id],
+    { enabled: hasUser },
+  );
 
-  // eslint-disable-next-line react-hooks/set-state-in-effect -- resets pagination inside the feed-fetch callback this effect runs
-  useEffect(() => { void load(); }, [load]);
+  const feed = useMemo(() => data ?? [], [data]);
+
+  // `onFeedChange` is a plain prop callback — keep it out of the bridge effect's
+  // deps so a parent passing an inline function doesn't re-fire it every render.
+  const onFeedChangeRef = useRef(onFeedChange);
+  useEffect(() => {
+    onFeedChangeRef.current = onFeedChange;
+  });
+
+  // Bridge the fetched feed up to the parent + reset pagination on a fresh load.
+  // Fires only when the fetched data / error / signed-in state actually changes.
+  useEffect(() => {
+    if (!hasUser || error) {
+      onFeedChangeRef.current?.([]);
+      return;
+    }
+    if (data) {
+      onFeedChangeRef.current?.(data);
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- deliberate pagination reset when a new feed lands (matches the pre-hook load())
+      setVisibleCount(10);
+    }
+  }, [data, error, hasUser]);
 
   const filtered = useMemo(
     () => filterItems(feed, filter, friendUsernames),
@@ -244,7 +237,7 @@ export default function ActivityFeedPanel({
           <span className="rh-sb-feed-state__kicker">Feed unavailable</span>
           <strong>{error}</strong>
           <p>
-            <button type="button" className="rh-sb-btn" onClick={() => void load()}>Retry</button>
+            <button type="button" className="rh-sb-btn" onClick={() => void refetch()}>Retry</button>
           </p>
         </div>
       </section>

--- a/client/src/stats/WeeklyStatsScreen.tsx
+++ b/client/src/stats/WeeklyStatsScreen.tsx
@@ -1,6 +1,8 @@
-import { useEffect, useState } from 'react';
 import type { User } from '@supabase/supabase-js';
+import { useAsyncData } from '../hooks/useAsyncData';
 import type { WeeklyRecap } from './statsApi';
+
+const WEEKLY_RECAP_GENERIC_ERROR = 'Unable to load weekly recap.';
 
 type WeeklyStatsScreenProps = {
   open: boolean;
@@ -13,41 +15,32 @@ export default function WeeklyStatsScreen({
   onClose,
   user,
 }: WeeklyStatsScreenProps) {
-  const [recap, setRecap] = useState<WeeklyRecap | null>(null);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const { data, loading, error: fetchError } = useAsyncData<WeeklyRecap | null>(
+    async () => {
+      if (!open || !user) return null;
+      let resp: { data: WeeklyRecap | null; error: string | null };
+      try {
+        const { fetchWeeklyRecap } = await import('./statsApi');
+        resp = await fetchWeeklyRecap(user);
+      } catch {
+        // The hand-rolled version's `.catch` discarded the real error and
+        // always showed the generic string — keep that.
+        throw new Error(WEEKLY_RECAP_GENERIC_ERROR);
+      }
+      // Known API error → surface it; missing data with no error → generic.
+      if (resp.error || !resp.data) {
+        throw new Error(resp.error ?? WEEKLY_RECAP_GENERIC_ERROR);
+      }
+      return resp.data;
+    },
+    [open, user],
+    { enabled: open && Boolean(user) },
+  );
 
-  useEffect(() => {
-    if (!open || !user) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- resets the recap when the panel closes; the effect runs the async recap fetch
-      setRecap(null);
-      setError(null);
-      return;
-    }
-    let active = true;
-    setLoading(true);
-    setError(null);
-    void import('./statsApi')
-      .then(({ fetchWeeklyRecap }) => fetchWeeklyRecap(user))
-      .then((resp) => {
-        if (!active) return;
-        setLoading(false);
-        if (resp.error || !resp.data) {
-          setError(resp.error ?? 'Unable to load weekly recap.');
-          setRecap(null);
-          return;
-        }
-        setRecap(resp.data);
-      })
-      .catch(() => {
-        if (!active) return;
-        setLoading(false);
-        setError('Unable to load weekly recap.');
-      });
-    return () => {
-      active = false;
-    };
-  }, [open, user]);
+  // The hand-rolled version cleared recap/error the moment the panel closed;
+  // the hook retains them, so gate on the same condition at read time.
+  const recap = open && user ? data ?? null : null;
+  const error = open && user ? fetchError : null;
 
   const recapSections = recap
     ? [


### PR DESCRIPTION
**REFACTOR_OPPORTUNITIES.md §3 D1**, Part B, batch 2. The three screens from the "already-read 8" that each needed a small **non-mechanical** adaptation.

## WeeklyStatsScreen

- The hand-rolled effect **cleared `recap`/`error` the instant the modal closed**. The hook retains state on `enabled: false`, so both now derive `open && user ? … : null` at read time — same observable result (the modal is `visibility: hidden` when closed anyway).
- **3-way error rule reproduced exactly** in the fetcher:
  - `import()` or `fetchWeeklyRecap()` throws → generic `"Unable to load weekly recap."` (the real error is discarded, matching the old `.catch(() => setError(generic))`)
  - `resp.error` is a string → surfaced
  - data missing, no error → generic
- `import('./statsApi')` stays **inside** the fetcher — confirmed it still code-splits (build output unchanged; `statsApi` is not pulled into the main chunk).

## ActivityFeedPanel

- `onFeedChange(data)` → a **bridge effect** keyed on `[data, error, hasUser]`, callback held in a ref. Fires **only when the fetched feed / error / signed-in state actually changes** — never on an unrelated parent re-render. (The old `load` had `onFeedChange` in its `useCallback` deps, so an inline callback re-ran the *entire fetch* every parent render — eliminated.)
- Pagination reset (`visibleCount → 10` on a fresh feed) kept in that same effect.
- `feedItemsEqual` referential-stability shim dropped — `data` from the hook is already stable per fetch; identical filtered output.

### Latent bugs fixed — **flagged, not blended in**

1. **No unmount/stale guard at all.** `useEffect(() => { void load() }, [load])` had no cancellation — unmount or a `user` change mid-fetch called setState on a dead/stale component, and two in-flight loads raced. `useAsyncData`'s run-id + `AbortController` supersession fixes it.
2. **Retry was broken on success.** `load` never called `setError(null)`, so a *successful* retry left the error screen up permanently. The hook clears `error` at the start of every attempt → Retry now actually works.
3. **Infinite spinner when signed out.** The `!user` early-return never cleared `loading` (init `true`), so a logged-out render showed "Building your social feed…" forever. Now resolves to the empty state. Unreachable in practice — the panel is auth-gated.

## GhostSetupScreen — partial migration, deliberately

- **Only the `summary`/`loading`/`error` triad migrates** (the `fetchGhostProfileSummary` fetch, keyed on `selectedUserId`).
- **Stays hand-rolled, on purpose:** the featured-ghost lookup (`fetchGhostProfileSummaryByUsername`, `[]`) and the friends list (`fetchFriends`, `[userId]`). Neither has loading/error UI — they just populate a value — so they aren't the D1 "triad" and there's no payoff to routing them through the hook. Called out here so it doesn't read as an oversight later.
- Same reset-on-deselect → derive-`selectedUserId ? … : null` treatment as WeeklyStats.

## Behaviour note — microtask delay

WeeklyStats (modal reopen) and GhostSetup (re-selecting a different ghost) can show the previous payload for up to ~1 frame before the loading state engages, because `useAsyncData` sets its internal `fetching` flag one microtask after `enabled`/deps change. The hand-rolled `useEffect(() => setLoading(true))` had the same sub-frame window (passive effects run after paint) — **not made materially worse**. No tests are timing-sensitive on these screens; `ActivityFeedPanel.board.test` (the only test among the three) is unchanged and green.

## Still not migrated (flagged in batch 1)

- **LeaderboardScreen** — per-tab "fetch once, never refetch" client cache, 4 resources, one shared loading/error.
- **FriendsScreen** — multi-resource + 30 s presence poll + socket presence + `loadFriends()` from ~10 mutation handlers.

## Verification

Full local bar green: `tsc -b`, `lint` **49/50** (0 errors — down one, a `set-state-in-effect` suppression removed), `lint:hooks` 0, `lint:css`, `check:architecture` 20/20, `check:deps`, `check:bot-match-lazy --dist`, client vitest **221/1662**, server `tsc -b` + vitest all shards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019CsumV3BdhvCQX8uFt9Ee2