### PR TITLE
D1 Part B batch 3 (final): admin / route / puzzle-rush fetches → useAsyncData

### DIFF
--- a/client/src/admin/DailyFritzHealthAdminScreen.tsx
+++ b/client/src/admin/DailyFritzHealthAdminScreen.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useState } from 'react';
+import { useAsyncData } from '../hooks/useAsyncData';
 import { resolveGameServerUrl } from '../lib/gameServerUrl';
 
 const ADMIN_KEY_STORAGE = 'racehorse:daily-fritz-admin-key';
@@ -102,47 +103,25 @@ async function fetchDailyFritzHealth(key: string): Promise<HealthResponse> {
 export default function DailyFritzHealthAdminScreen() {
   const [adminKey, setAdminKey] = useState(resolveInitialAdminKey);
   const [draftKey, setDraftKey] = useState('');
-  const [health, setHealth] = useState<HealthResponse | null>(null);
-  const [error, setError] = useState<string | null>(null);
-  const [loading, setLoading] = useState(false);
 
-  const refreshHealth = useCallback((key: string) => {
-    void (async () => {
-      setLoading(true);
-      setError(null);
+  const { data, loading, error: fetchError, refetch } = useAsyncData<HealthResponse>(
+    async () => {
       try {
-        setHealth(await fetchDailyFritzHealth(key));
+        return await fetchDailyFritzHealth(adminKey);
       } catch (err: unknown) {
-        setHealth(null);
-        setError(err instanceof Error ? err.message : String(err));
-      } finally {
-        setLoading(false);
+        // Preserve the pre-hook `err instanceof Error ? err.message : String(err)`.
+        throw new Error(err instanceof Error ? err.message : String(err));
       }
-    })();
-  }, []);
+    },
+    [adminKey],
+    { enabled: Boolean(adminKey) },
+  );
 
-  useEffect(() => {
-    if (!adminKey) return;
-    let cancelled = false;
-    void (async () => {
-      setLoading(true);
-      setError(null);
-      try {
-        const data = await fetchDailyFritzHealth(adminKey);
-        if (!cancelled) setHealth(data);
-      } catch (err: unknown) {
-        if (!cancelled) {
-          setHealth(null);
-          setError(err instanceof Error ? err.message : String(err));
-        }
-      } finally {
-        if (!cancelled) setLoading(false);
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [adminKey]);
+  // The hand-rolled version nulled `health` on both sign-out and fetch failure
+  // (catch → `setHealth(null)`); the hook retains `data`, so reproduce both:
+  // gate on `adminKey` (sign-out) and on the absence of an error.
+  const error = adminKey ? fetchError : null;
+  const health = adminKey && !error ? data ?? null : null;
 
   const handleUnlock = (event: React.FormEvent) => {
     event.preventDefault();
@@ -156,9 +135,6 @@ export default function DailyFritzHealthAdminScreen() {
   const handleSignOut = () => {
     clearStoredAdminKey();
     setAdminKey('');
-    setHealth(null);
-    setError(null);
-    setLoading(false);
   };
 
   return (
@@ -209,7 +185,7 @@ export default function DailyFritzHealthAdminScreen() {
         <div style={{ marginBottom: '16px', display: 'flex', gap: '12px', alignItems: 'center' }}>
           <button
             type="button"
-            onClick={() => refreshHealth(adminKey)}
+            onClick={() => void refetch()}
             disabled={loading}
             style={{
               padding: '6px 12px',

--- a/client/src/dailyFritz/DailyFritzLeaderboardRoute.tsx
+++ b/client/src/dailyFritz/DailyFritzLeaderboardRoute.tsx
@@ -1,8 +1,8 @@
-import { useEffect, useState } from 'react';
 import type { User } from '@supabase/supabase-js';
 import type { UserProfile } from '../auth/useAuth';
 import type { AppMode } from '../types';
-import { getTodayDailyFritz, type DailyFritzTodayResponse } from './api';
+import { useAsyncData } from '../hooks/useAsyncData';
+import { getTodayDailyFritz } from './api';
 import DailyFritzLeaderboardScreen from './DailyFritzLeaderboardScreen';
 import { DailyFritzLeaderboardLoading } from './DailyFritzLeaderboardLoading';
 
@@ -32,37 +32,15 @@ export default function DailyFritzLeaderboardRoute({
   onOpenAuth,
   onSignOut,
 }: DailyFritzLeaderboardRouteProps) {
-  const [runDate, setRunDate] = useState<string | null>(null);
-  // Kept so the screen can seed from this response instead of fetching
-  // /api/daily-fritz/today a second time for byte-identical data.
-  const [today, setToday] = useState<DailyFritzTodayResponse | null>(null);
-  const [loading, setLoading] = useState(true);
-
-  useEffect(() => {
-    let cancelled = false;
-    void (async () => {
-      await Promise.resolve();
-      if (cancelled) return;
-      setLoading(true);
-      void getTodayDailyFritz()
-        .then((response) => {
-          if (cancelled) return;
-          setToday(response);
-          setRunDate(response.run_date || pacificRunDateFallback());
-        })
-        .catch(() => {
-          if (cancelled) return;
-          setToday(null);
-          setRunDate(pacificRunDateFallback());
-        })
-        .finally(() => {
-          if (!cancelled) setLoading(false);
-        });
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, []);
+  // `today` is kept so the screen can seed from this response instead of
+  // fetching /api/daily-fritz/today a second time for byte-identical data.
+  const { data, loading, error } = useAsyncData(() => getTodayDailyFritz(), []);
+  const today = data ?? null;
+  const runDate = data
+    ? data.run_date || pacificRunDateFallback()
+    : error
+      ? pacificRunDateFallback()
+      : null;
 
   if (loading || !runDate) {
     return <DailyFritzLeaderboardLoading onBack={onClose} />;

--- a/client/src/puzzleRush/PuzzleRushScreen.tsx
+++ b/client/src/puzzleRush/PuzzleRushScreen.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { useAsyncData } from '../hooks/useAsyncData';
 import { fetchPuzzleRushToday, startPuzzleRush } from './api';
 import { PuzzleRushLeaderboardScreen } from './PuzzleRushLeaderboardScreen';
 import { PuzzleRushHubView } from './PuzzleRushHubView';
@@ -13,7 +14,6 @@ import { useRushRun } from './useRushRun';
 import type {
   PuzzleRushStage,
   PuzzleRushStartResponse,
-  PuzzleRushTodayResponse,
   RushPuzzleResult,
 } from './types';
 import './puzzleRush.css';
@@ -39,26 +39,17 @@ export function PuzzleRushScreen({ onBack, onNavigate }: PuzzleRushScreenProps) 
   const [phase, setPhase] = useState<Phase>('intro');
   const [startResponse, setStartResponse] = useState<PuzzleRushStartResponse | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const [today, setToday] = useState<PuzzleRushTodayResponse | null>(null);
   // Bumped when a run finishes, so returning to the hub re-reads /today and
   // the new personal best / streak show without a hard refresh.
   const [todayNonce, setTodayNonce] = useState(0);
 
-  useEffect(() => {
-    if (phase !== 'intro') return undefined;
-    let cancelled = false;
-    void (async () => {
-      try {
-        const response = await fetchPuzzleRushToday();
-        if (!cancelled) setToday(response);
-      } catch {
-        // A hub that cannot read its stats still has to let you play.
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [phase, todayNonce]);
+  // Soft fetch: a hub that cannot read its stats still has to let you play, so
+  // an error is ignored and the last good `today` (if any) stays on screen.
+  const { data: today } = useAsyncData(
+    () => fetchPuzzleRushToday(),
+    [todayNonce],
+    { enabled: phase === 'intro' },
+  );
 
   const beginRun = useCallback(async () => {
     setPhase('starting');


### PR DESCRIPTION
**REFACTOR_OPPORTUNITIES.md §3 D1**, Part B, batch 3 — the last three hand-rolled fetches worth migrating. **This closes out D1** (doc update follows once merged).

## Migrated

### `DailyFritzHealthAdminScreen`
- `[health]/[loading]/[error]` triad + manual `refreshHealth` → `refetch`, reset-on-signout.
- Fetcher rethrows `new Error(err instanceof Error ? err.message : String(err))` to preserve the exact pre-hook error text (the hook's default fallback would differ for a non-`Error` throw).
- `health` derives `adminKey && !error ? data ?? null : null` — the old `catch` did `setHealth(null)`, so a **failed refresh still hides the table**, not just stacks an error line above stale data.
- `refreshHealth` had no cancellation guard — `refetch`'s run-id + AbortController supersession fixes it (minor; admin screen).

### `DailyFritzLeaderboardRoute` (84 → 62 L)
- One seed fetch (`getTodayDailyFritz`). `today = data`; `runDate` derives **null while loading / fallback on error / `run_date || fallback` on success** — matches the old `.catch` path exactly. Gates the same `<DailyFritzLeaderboardLoading>` component.

### `PuzzleRushScreen` — the `/today` soft-fetch only
- `enabled: phase === 'intro'` + deps `[todayNonce]` reproduces the old `if (phase !== 'intro') return` guard + `[phase, todayNonce]` deps — **including** the `onPlayAgain` case where `todayNonce` bumps while leaving `intro` (correctly does *not* refetch, because `enabled` is false).
- Error stays **fully swallowed** and the last good `today` is retained: the fetcher throws, `error` is ignored, `data` is kept — same as the old empty `catch {}` which never nulled `today`.
- The `startPuzzleRush` **action** path is untouched — it drives the phase state machine, not a fetch-on-mount.

## Verification

Full local bar green: `tsc -b`, `lint` **49/50** (0 errors), `lint:hooks` 0, `lint:css`, `check:architecture` 20/20, `check:deps`, `check:bot-match-lazy --dist`, client vitest **221/1662**, server `tsc -b` + vitest all shards.

## D1 close-out (after merge)

`REFACTOR_OPPORTUNITIES.md` §3 D1 will be marked done: **9 screens migrated** (batches 1–3), **batch 4 skipped deliberately** (`useSinglePlayerHubStats`, `MatchFoundOverlay` — data-only, no loading/error UI, hook buys only an unmount guard), **6 flagged not-a-fit** with reasons recorded so nobody re-proposes forcing them: `LeaderboardScreen`, `FriendsScreen`, `ActivityFeedScreen`, `NoBrainerLabScreen`, `usePlayerIdentityModel`, `GlobalNav` friend-count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019CsumV3BdhvCQX8uFt9Ee2