### PR TITLE
Unify Puzzle Rush share text into one builder

### DIFF
--- a/client/src/puzzleRush/PuzzleRushLeaderboardScreen.tsx
+++ b/client/src/puzzleRush/PuzzleRushLeaderboardScreen.tsx
@@ -7,8 +7,7 @@ import { avatarHue, getInitials } from '../components/hub/playerInitialsAvatarUt
 import { formatCountdownHms, secondsUntilNextPacificMidnight } from '../dailyFritz/format';
 import type { AppMode } from '../types';
 import { fetchPuzzleRushLeaderboard } from './api';
-import { calculatePuzzleNumber } from './rushShareCard';
-import { SITE_DOMAIN } from '../lib/siteUrl';
+import { buildRushShareText } from './rushShareCard';
 import type { PuzzleRushLeaderboardEntry, PuzzleRushLeaderboardResponse } from './types';
 // Fritz's board depends on all three, in this order: the tokens the dfl-*
 // rules reference, then the rh-hub-* page/panel/FilterPills layout, then the
@@ -187,18 +186,10 @@ export function PuzzleRushLeaderboardScreen({
   // Only today's official run is shareable, and only what the player actually
   // posted today — not their all-time best. `selfRow` under the Today filter is
   // the caller's row on `data.daily`, so it exists iff they have an official
-  // run today.
+  // run today. Shares the exact `buildRushShareText` format RushResultsView emits.
   const shareText = useMemo(() => {
     if (filter !== 'today' || !selfRow || !data) return '';
-    const puzzleNumber = calculatePuzzleNumber(data.runDate);
-    const emojiBoxes = Array(selfRow.puzzlesSolved).fill('🟩').join('');
-    return [
-      `Racehorse Puzzle Rush #${puzzleNumber}`,
-      emojiBoxes,
-      '',
-      `${selfRow.puzzlesSolved} solved`,
-      SITE_DOMAIN,
-    ].filter(Boolean).join('\n');
+    return buildRushShareText({ solved: selfRow.puzzlesSolved, runDate: data.runDate });
   }, [data, filter, selfRow]);
 
   const handleShareResult = useCallback(() => {

--- a/client/src/puzzleRush/RushResultsView.tsx
+++ b/client/src/puzzleRush/RushResultsView.tsx
@@ -73,15 +73,9 @@ export function RushResultsView({
   const shareText = useMemo(
     () =>
       shareable
-        ? buildRushShareText({
-            score: serverScore,
-            solved: solved ?? 0,
-            puzzles: results.map((r) => ({ solved: r.solved })),
-            secondsBanked,
-            runDate: completion?.run.runDate,
-          })
+        ? buildRushShareText({ solved: solved ?? 0, runDate: completion?.run.runDate })
         : '',
-    [shareable, serverScore, solved, results, secondsBanked, completion],
+    [shareable, solved, completion],
   );
 
   const [shareDone, setShareDone] = useState(false);

--- a/client/src/puzzleRush/rushShareCard.test.ts
+++ b/client/src/puzzleRush/rushShareCard.test.ts
@@ -1,98 +1,78 @@
 import { describe, it, expect } from 'vitest';
-import { buildRushShareText } from './rushShareCard';
+import { buildRushShareText, PUZZLE_RUSH_PUZZLES_PER_RUN } from './rushShareCard';
 import { SITE_DOMAIN } from '../lib/siteUrl';
 
 describe('buildRushShareText', () => {
-  it('shows puzzle number, one emoji per puzzle, solve count, and time', () => {
-    const text = buildRushShareText({
-      score: 250,
-      solved: 2,
-      puzzles: [
-        { solved: true },
-        { solved: false },
-        { solved: true },
-      ],
-      secondsBanked: 2,
-      runDate: '2026-08-31',
-    });
-    expect(text).toContain('Racehorse Puzzle Rush #144');
-    expect(text).toContain('🟩🟥🟩');
-    expect(text).toContain('2 solved');
-    expect(text).toContain('2s');
-    expect(text).toContain(SITE_DOMAIN);
+  it('renders puzzle number, a fixed 15-cell 🟩/🟥 grid, solve count, and site', () => {
+    const text = buildRushShareText({ solved: 11, runDate: '2026-09-09' });
+    expect(text).toBe(
+      [
+        'Racehorse Puzzle Rush #153',
+        '🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟥🟥🟥🟥',
+        '',
+        '11 solved',
+        SITE_DOMAIN,
+      ].join('\n'),
+    );
   });
 
-  it('formats minutes and seconds correctly', () => {
-    const text = buildRushShareText({
-      score: 900,
-      solved: 7,
-      puzzles: [
-        { solved: true },
-        { solved: true },
-        { solved: true },
-        { solved: true },
-        { solved: true },
-        { solved: true },
-        { solved: true },
-      ],
-      secondsBanked: 125, // 2m 5s
-      runDate: '2026-08-31',
-    });
-    expect(text).toContain('2m 5s');
+  it('grid is always exactly PUZZLE_RUSH_PUZZLES_PER_RUN cells', () => {
+    for (const solved of [0, 1, 7, 14, 15]) {
+      const grid = buildRushShareText({ solved, runDate: '2026-09-09' }).split('\n')[1];
+      const cells = [...grid.matchAll(/🟩|🟥/g)].length;
+      expect(cells).toBe(PUZZLE_RUSH_PUZZLES_PER_RUN);
+      expect((grid.match(/🟩/g) ?? []).length).toBe(solved);
+      expect((grid.match(/🟥/g) ?? []).length).toBe(PUZZLE_RUSH_PUZZLES_PER_RUN - solved);
+    }
   });
 
-  it('omits time when no bonuses earned', () => {
-    const text = buildRushShareText({
-      score: 250,
-      solved: 2,
-      puzzles: [
-        { solved: true },
-        { solved: false },
-      ],
-      secondsBanked: 0,
-      runDate: '2026-08-31',
-    });
-    // Should only show solve count, no time bonuses
-    const lines = text.split('\n');
-    expect(lines[2]).toBe('2 solved');
-    expect(text).not.toMatch(/\d+[ms]\s/); // No "5s " or "2m " pattern
+  it('a perfect run is all 🟩, no 🟥', () => {
+    const text = buildRushShareText({ solved: 15, runDate: '2026-09-09' });
+    expect(text.split('\n')[1]).toBe('🟩'.repeat(15));
+    expect(text).toContain('15 solved');
   });
 
-  it('calculates puzzle number from run_date', () => {
-    const text = buildRushShareText({
-      score: 10,
-      solved: 1,
-      puzzles: [{ solved: true }],
-      secondsBanked: 0,
-      runDate: '2026-04-10',
-    });
-    expect(text).toContain('#1');
+  it('a zero-solve run is all 🟥', () => {
+    expect(buildRushShareText({ solved: 0 }).split('\n')[1]).toBe('🟥'.repeat(15));
   });
 
-  it('defaults to puzzle #1 when run_date is missing', () => {
-    const text = buildRushShareText({
-      score: 10,
-      solved: 1,
-      puzzles: [{ solved: true }],
-      secondsBanked: 0,
-    });
-    expect(text).toContain('#1');
+  it('clamps a solve count outside 0..15 and rounds a non-integer', () => {
+    expect(buildRushShareText({ solved: 99 }).split('\n')[1]).toBe('🟩'.repeat(15));
+    expect(buildRushShareText({ solved: -3 }).split('\n')[1]).toBe('🟥'.repeat(15));
+    expect(buildRushShareText({ solved: 10.6 }).split('\n')[3]).toBe('11 solved');
   });
 
-  it('handles max-length run (15 puzzles) without truncation', () => {
-    const puzzles = Array(15).fill(null).map((_, i) => ({ solved: i < 13 }));
-    const text = buildRushShareText({
-      score: 1200,
-      solved: 13,
-      puzzles,
-      secondsBanked: 45,
-      runDate: '2026-08-31',
+  it('calculates the puzzle number from run_date, defaulting to #1', () => {
+    expect(buildRushShareText({ solved: 1, runDate: '2026-04-10' })).toContain('#1');
+    expect(buildRushShareText({ solved: 1 })).toContain('#1');
+    expect(buildRushShareText({ solved: 1, runDate: 'not-a-date' })).toContain('#1');
+  });
+
+  // The reason this builder exists: RushResultsView (end of run) and
+  // PuzzleRushLeaderboardScreen (later, from the persisted board row) used to
+  // format share text separately and disagreed — the leaderboard emitted
+  // squares with no fail marker. Both now derive the input from the same two
+  // run facts, so the output must be byte-identical for the same run.
+  it('RushResultsView and PuzzleRushLeaderboardScreen emit identical text for one run', () => {
+    // One finished run, as each surface sees it.
+    const run = { puzzlesSolved: 9, runDate: '2026-08-31' };
+
+    // RushResultsView: `{ solved: completion.run.puzzlesSolved ?? 0, runDate: completion.run.runDate }`
+    const completion = { run: { ...run } };
+    const fromResultsView = buildRushShareText({
+      solved: completion.run.puzzlesSolved ?? 0,
+      runDate: completion.run.runDate,
     });
-    const emojiLine = text.split('\n')[1];
-    const greenCount = (emojiLine.match(/🟩/g) ?? []).length;
-    const redCount = (emojiLine.match(/🟥/g) ?? []).length;
-    expect(greenCount).toBe(13);
-    expect(redCount).toBe(2);
-    expect(text).toContain('13 solved');
+
+    // PuzzleRushLeaderboardScreen: `{ solved: selfRow.puzzlesSolved, runDate: data.runDate }`
+    const selfRow = { puzzlesSolved: run.puzzlesSolved };
+    const leaderboardResponse = { runDate: run.runDate };
+    const fromLeaderboard = buildRushShareText({
+      solved: selfRow.puzzlesSolved,
+      runDate: leaderboardResponse.runDate,
+    });
+
+    expect(fromResultsView).toBe(fromLeaderboard);
+    expect(fromResultsView).toContain('🟥'); // both carry the fail marker now
   });
 });

--- a/client/src/puzzleRush/rushShareCard.ts
+++ b/client/src/puzzleRush/rushShareCard.ts
@@ -2,28 +2,27 @@ import { SITE_DOMAIN } from '../lib/siteUrl';
 
 const PUZZLE_RUSH_LAUNCH_DATE = new Date('2026-04-10');
 
+/** Mirrors `PUZZLE_RUSH_CONFIG.run.puzzlesPerRun` (server/src/puzzleRush/config.ts). */
+export const PUZZLE_RUSH_PUZZLES_PER_RUN = 15;
+
 /**
  * Share text for a finished Puzzle Rush run.
  *
- * Puzzle number, one emoji per puzzle attempted (🟩 = solved, 🟥 = missed/skipped),
- * solve count, and site URL.
+ * Emitted **identically** by two surfaces — `RushResultsView` (right after the
+ * run) and `PuzzleRushLeaderboardScreen` (later, from the persisted leaderboard
+ * row). They're built from only the two facts both surfaces reliably have: the
+ * run date and the server's authoritative solve count. A fixed 15-cell grid,
+ * 🟩 = solved / 🟥 = not — so every player's share is the same shape and reads
+ * at a glance without the caption.
+ *
+ * Not included: banked seconds and a per-puzzle pass/fail breakdown. Neither is
+ * persisted with the run, so the leaderboard row cannot reproduce them and the
+ * two surfaces would diverge.
  */
-
-export interface RushSharePuzzle {
-  /** Whether this puzzle was solved (true) or missed/skipped (false). */
-  solved: boolean;
-}
-
 export interface RushShareInput {
-  /** The server's replayed total. The only score worth sharing. */
-  score: number;
-  /** Server's actual solve count for the run. */
+  /** The server's replayed solve count for the run. */
   solved: number;
-  /** Per-puzzle result (ordinal order). */
-  puzzles: RushSharePuzzle[];
-  /** Seconds gained from time bonuses. */
-  secondsBanked: number;
-  /** YYYY-MM-DD run date for puzzle numbering. */
+  /** YYYY-MM-DD run date, for puzzle numbering. */
   runDate?: string;
 }
 
@@ -37,30 +36,19 @@ export function calculatePuzzleNumber(runDate: string | undefined): number {
   return Math.max(1, daysSinceLaunch + 1);
 }
 
-function buildEmojiRow(puzzles: RushSharePuzzle[]): string {
-  return puzzles.map((p) => (p.solved ? '🟩' : '🟥')).join('');
-}
-
-function formatTime(secondsBanked: number): string {
-  if (secondsBanked <= 0) return '';
-  const minutes = Math.floor(secondsBanked / 60);
-  const seconds = secondsBanked % 60;
-  if (minutes > 0) return `${minutes}m ${seconds}s`;
-  return `${seconds}s`;
-}
-
 export function buildRushShareText(input: RushShareInput): string {
   const puzzleNumber = calculatePuzzleNumber(input.runDate);
-  const emojiRow = buildEmojiRow(input.puzzles);
-  const solveText = `${input.solved} solved`;
-  const timeText = formatTime(input.secondsBanked);
-  const statLine = [solveText, timeText].filter(Boolean).join(' · ');
+  const solved = Math.max(
+    0,
+    Math.min(PUZZLE_RUSH_PUZZLES_PER_RUN, Math.round(input.solved || 0)),
+  );
+  const grid = '🟩'.repeat(solved) + '🟥'.repeat(PUZZLE_RUSH_PUZZLES_PER_RUN - solved);
 
   return [
     `Racehorse Puzzle Rush #${puzzleNumber}`,
-    emojiRow,
+    grid,
     '',
-    statLine,
+    `${solved} solved`,
     SITE_DOMAIN,
-  ].filter(Boolean).join('\n');
+  ].join('\n');
 }


### PR DESCRIPTION
Found during the recent share-artifact audit: `RushResultsView` and `PuzzleRushLeaderboardScreen` formatted Puzzle Rush share text **separately** and disagreed — the results screen showed a 🟩/🟥 grid + a banked-time line; the leaderboard's inline builder showed squares only, **no fail marker**, no time. Same run → two different strings.

## Change

Both surfaces now call one `buildRushShareText({ solved, runDate })`, built from the only two facts both reliably hold — the run date and the **server's authoritative solve count**:

```
Racehorse Puzzle Rush #153
🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟥🟥🟥🟥
11 solved
playracehorse.com
```

Fixed 15-cell grid (`PUZZLE_RUSH_PUZZLES_PER_RUN`, mirrors `PUZZLE_RUSH_CONFIG.run.puzzlesPerRun`), 🟩 = solved / 🟥 = not. Every player's share is now the same shape.

## Deliberately dropped — flagged, not overlooked

| Dropped | Why |
|---|---|
| **Banked-seconds line** (`1m 12s`) | `secondsBanked` is a client-run reduction (`results.reduce(...bonusSeconds)`) — **never persisted** with the run (`PuzzleRushRun` has no such field). The leaderboard row structurally cannot reproduce it, so keeping it would guarantee the two surfaces diverge. |
| **Per-puzzle 🟩/🟥 from the client `r.solved` flag** | That flag is the old "scored anything" rule — the code comments in `RushResultsView` explicitly call it unreliable, and it could already disagree with the server's "N solved" line printed directly below it. The fixed grid is built from the server count, so **grid and count now always agree** — this also removes that pre-existing contradiction. |

If banked time in the shared format is wanted, that's a follow-up requiring `seconds_banked` to be persisted and added to `PuzzleRushLeaderboardEntry` (server change) — out of scope for this cleanup.

## Test

`rushShareCard.test.ts` rewritten for the new format (grid width, clamping/rounding, puzzle numbering) **plus** an explicit case that derives the args `RushResultsView` and `PuzzleRushLeaderboardScreen` each pass for the same run and asserts byte-identical output.

## Verification

Full local bar green: `tsc -b`, `lint` 49/50 (0 errors), `lint:hooks` 0, `lint:css`, `check:architecture` 20/20, `check:deps`, `check:bot-match-lazy --dist`, client vitest **221/1663**, server `tsc -b` + vitest all shards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019CsumV3BdhvCQX8uFt9Ee2