### PR TITLE
F6 Tier 3: guided-module test coverage — closes #126

### DIFF
--- a/client/src/modules/guided/guidedPlacementHandlers.test.tsx
+++ b/client/src/modules/guided/guidedPlacementHandlers.test.tsx
@@ -1,0 +1,210 @@
+// @vitest-environment jsdom
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { BoardState, Move, PlacementPosition, Tile } from '../../types.ts';
+import { createBotMatch } from '../match/runtime/botEngine.ts';
+import { makeGuidedTurn, makeGuidedTranscript, makeLessonV2, makeLessonV2Event } from './guidedTestFixtures.ts';
+import {
+  useGuidedPlacementHandlers,
+  type GuidedPlacementHandlerDeps,
+} from './guidedPlacementHandlers.ts';
+
+// `buildBotMatchStateFromV2Event` (via the V2-match path) reads the board parser
+// off the lazy registry; the guided V2 state tests stub it the same way.
+const { parseLessonV2BoardState } = vi.hoisted(() => ({
+  parseLessonV2BoardState: vi.fn<(boardAfter: string) => BoardState | null>(() => null),
+}));
+vi.mock('../match/bootstrap/lessonV2LazyRegistry.ts', () => ({ parseLessonV2BoardState }));
+vi.mock('../../utils/sound.ts', () => ({
+  queueSound: vi.fn((fn: () => void) => fn()),
+  playScoreSound: vi.fn(),
+  playTileSound: vi.fn(),
+}));
+
+const tile = (low: number, high: number): Tile => ({ low, high });
+const playMove = (t: Tile, position?: PlacementPosition): Move => ({ type: 'play', tile: t, position });
+
+/**
+ * The hook takes a 76-field deps bag; `handleGuidedPlacement` and its two inline
+ * helpers only read ~15 of them. Everything else is a spy / inert value.
+ */
+function makeDeps(overrides: Partial<GuidedPlacementHandlerDeps> = {}): GuidedPlacementHandlerDeps {
+  const match = createBotMatch();
+  const fn = () => vi.fn();
+  return {
+    isGuidedTranscriptMode: false,
+    guidedTranscript: null,
+    currentTranscriptTurn: null,
+    pushToast: fn(),
+    setIsOffAuthoredLine: fn(),
+    setSelectedTile: fn(),
+    flashLastPlayed: fn(),
+    setMatch: fn(),
+    setGuidedV1Replay: fn(),
+    setLessonStepIndex: fn(),
+    isGuidedV2Mode: false,
+    frozenV2Lesson: null,
+    isGuidedV2OffLine: false,
+    guidedV2EventIndex: 0,
+    setIsGuidedV2OffLine: fn(),
+    setGuidedV2EventIndex: fn(),
+    matchRef: { current: match },
+    opponentLabel: 'Fritz',
+    showScoreToast: fn(),
+    showBoardToast: fn(),
+    isMuted: true,
+    scheduleHandReveal: fn(),
+    match,
+    guidedCoachTip: null,
+    userPlayMoves: [],
+    coach: { recordPlayerMove: vi.fn() } as unknown as GuidedPlacementHandlerDeps['coach'],
+    isAuthoringMode: false,
+    recordAuthoringStep: fn(),
+    applyAndNotify: fn(),
+    appendMove: fn(),
+    setMovesUsed: fn(),
+    fritzDifficulty: 'standard' as GuidedPlacementHandlerDeps['fritzDifficulty'],
+    canPlayCoachedMove: false,
+    currentExpectedV2PlayerEvent: null,
+    frozenLesson: null,
+    currentLessonStep: null,
+    isTransitioningRef: { current: false },
+    ...overrides,
+  };
+}
+
+function handler(deps: GuidedPlacementHandlerDeps) {
+  return renderHook(() => useGuidedPlacementHandlers(deps)).result.current;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  parseLessonV2BoardState.mockReturnValue(null);
+});
+
+describe('handleGuidedPlacement — transcript mode', () => {
+  const transcriptDeps = (turn: GuidedPlacementHandlerDeps['currentTranscriptTurn']) =>
+    makeDeps({
+      isGuidedTranscriptMode: true,
+      guidedTranscript: makeGuidedTranscript(),
+      currentTranscriptTurn: turn,
+    });
+
+  it('rejects a placement when there is no current transcript turn', () => {
+    const deps = transcriptDeps(null);
+    const result = handler(deps).handleGuidedPlacement(playMove(tile(3, 4), 'left'), 'left');
+    expect(result).toBe('handled');
+    expect(deps.setIsOffAuthoredLine).toHaveBeenCalledWith(true);
+    expect(deps.pushToast).toHaveBeenCalledWith('This transcript turn does not accept a tile placement.');
+  });
+
+  it('rejects a placement when the turn does not expect a play', () => {
+    const deps = transcriptDeps(makeGuidedTurn({ expectedPlayerMove: { type: 'pass' } }));
+    const result = handler(deps).handleGuidedPlacement(playMove(tile(3, 4), 'left'), 'left');
+    expect(result).toBe('handled');
+    expect(deps.setIsOffAuthoredLine).toHaveBeenCalledWith(true);
+  });
+
+  it('stops playback when the clicked move is off the authored line', () => {
+    const deps = transcriptDeps(
+      makeGuidedTurn({ expectedPlayerMove: { type: 'play', tile: '3|4', position: 'left' } }),
+    );
+    const result = handler(deps).handleGuidedPlacement(playMove(tile(5, 5), 'left'), 'left');
+    expect(result).toBe('handled');
+    expect(deps.setIsOffAuthoredLine).toHaveBeenCalledWith(true);
+    expect(deps.pushToast).toHaveBeenCalledWith('Off lesson line. Guided playback stopped.');
+    expect(deps.setMatch).not.toHaveBeenCalled();
+  });
+
+  it('accepts the turn when the clicked move matches tile + position', () => {
+    const deps = transcriptDeps(
+      makeGuidedTurn({
+        expectedPlayerMove: { type: 'play', tile: '3|4', position: 'left' },
+        playerStateAfter: '{"handNumber":2}',
+        fritzReplies: [],
+      }),
+    );
+    const result = handler(deps).handleGuidedPlacement(playMove(tile(3, 4), 'left'), 'left');
+    expect(result).toBe('handled');
+    expect(deps.setIsOffAuthoredLine).not.toHaveBeenCalledWith(true);
+    expect(deps.setMatch).toHaveBeenCalledWith({ handNumber: 2 });
+    expect(deps.setLessonStepIndex).toHaveBeenCalled();
+  });
+
+  it('a position-agnostic expected move matches on the tile alone', () => {
+    const deps = transcriptDeps(
+      makeGuidedTurn({
+        expectedPlayerMove: { type: 'play', tile: '3|4' },
+        playerStateAfter: '{"handNumber":1}',
+      }),
+    );
+    const result = handler(deps).handleGuidedPlacement(playMove(tile(3, 4)), 'left');
+    expect(result).toBe('handled');
+    expect(deps.setMatch).toHaveBeenCalled();
+  });
+});
+
+describe('handleGuidedPlacement — guided V2 mode', () => {
+  const v2Deps = (overrides: Partial<GuidedPlacementHandlerDeps> = {}) =>
+    makeDeps({
+      isGuidedV2Mode: true,
+      frozenV2Lesson: makeLessonV2({
+        events: [makeLessonV2Event({ tile: '3|4', position: 'left' })],
+      }),
+      guidedV2EventIndex: 0,
+      ...overrides,
+    });
+
+  it('applies the expected V2 event when tile + position match', () => {
+    const deps = v2Deps();
+    const result = handler(deps).handleGuidedPlacement(playMove(tile(3, 4), 'left'), 'left');
+    expect(result).toBe('handled');
+    expect(deps.setGuidedV2EventIndex).toHaveBeenCalled();
+    expect(deps.setMatch).toHaveBeenCalled();
+    expect(deps.setIsGuidedV2OffLine).not.toHaveBeenCalled();
+  });
+
+  it('goes off-line and continues live when the tile does not match', () => {
+    const deps = v2Deps();
+    const result = handler(deps).handleGuidedPlacement(playMove(tile(5, 5), 'left'), 'left');
+    expect(result).toBe('continue');
+    expect(deps.setIsGuidedV2OffLine).toHaveBeenCalledWith(true);
+    expect(deps.pushToast).toHaveBeenCalledWith('You went off the lesson. Continuing live from here.');
+    expect(deps.setMatch).not.toHaveBeenCalled();
+  });
+
+  it('goes off-line when the tile matches but the position does not', () => {
+    const deps = v2Deps();
+    const result = handler(deps).handleGuidedPlacement(playMove(tile(3, 4), 'right'), 'right');
+    expect(result).toBe('continue');
+    expect(deps.setIsGuidedV2OffLine).toHaveBeenCalledWith(true);
+  });
+
+  it('a V2 event with no position matches on the tile alone', () => {
+    const deps = v2Deps({
+      frozenV2Lesson: makeLessonV2({ events: [makeLessonV2Event({ tile: '3|4', position: undefined })] }),
+    });
+    const result = handler(deps).handleGuidedPlacement(playMove(tile(3, 4), 'right'), 'right');
+    expect(result).toBe('handled');
+  });
+
+  it('does nothing special once already off-line — falls through to live', () => {
+    const deps = v2Deps({ isGuidedV2OffLine: true });
+    const result = handler(deps).handleGuidedPlacement(playMove(tile(3, 4), 'left'), 'left');
+    expect(result).toBe('continue');
+    expect(deps.setGuidedV2EventIndex).not.toHaveBeenCalled();
+    expect(deps.setIsGuidedV2OffLine).not.toHaveBeenCalled();
+    expect(deps.pushToast).not.toHaveBeenCalled();
+  });
+});
+
+describe('handleGuidedPlacement — neither mode', () => {
+  it('returns "continue" and touches nothing', () => {
+    const deps = makeDeps();
+    const result = handler(deps).handleGuidedPlacement(playMove(tile(3, 4), 'left'), 'left');
+    expect(result).toBe('continue');
+    expect(deps.setMatch).not.toHaveBeenCalled();
+    expect(deps.pushToast).not.toHaveBeenCalled();
+    expect(deps.setIsOffAuthoredLine).not.toHaveBeenCalled();
+  });
+});

--- a/client/src/modules/guided/useGuidedLessonBoot.test.tsx
+++ b/client/src/modules/guided/useGuidedLessonBoot.test.tsx
@@ -1,7 +1,14 @@
 // @vitest-environment jsdom
 import { renderHook } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { useGuidedLessonBoot } from './useGuidedLessonBoot';
+import { useGuidedLessonBoot, type UseGuidedLessonBootArgs } from './useGuidedLessonBoot';
+import { makeFrozenLesson, makeAuthoredStep, makeGuidedTranscript, makeLessonV2 } from './guidedTestFixtures.ts';
+import type {
+  AuthoringSession,
+  FrozenLesson,
+  GuidedTranscript,
+  GuidedTranscriptDraft,
+} from '../../learn/guidedAuthoring.ts';
 
 const { getLessonV2Module, isLessonV2Preloaded } = vi.hoisted(() => ({
   getLessonV2Module: vi.fn(),
@@ -13,27 +20,225 @@ vi.mock('../match/bootstrap/lessonV2LazyRegistry.ts', () => ({
   isLessonV2Preloaded,
 }));
 
+const {
+  loadFrozenLesson,
+  loadAuthoringSession,
+  loadOriginalGuidedTranscript,
+  loadOriginalGuidedTranscriptDraft,
+} = vi.hoisted(() => ({
+  loadFrozenLesson: vi.fn<() => FrozenLesson | null>(() => null),
+  loadAuthoringSession: vi.fn<() => AuthoringSession | null>(() => null),
+  loadOriginalGuidedTranscript: vi.fn<() => GuidedTranscript | null>(() => null),
+  loadOriginalGuidedTranscriptDraft: vi.fn<() => GuidedTranscriptDraft | null>(() => null),
+}));
+
+vi.mock('../../learn/guidedAuthoring.ts', async (orig) => ({
+  ...(await orig<typeof import('../../learn/guidedAuthoring.ts')>()),
+  loadFrozenLesson,
+  loadAuthoringSession,
+  loadOriginalGuidedTranscript,
+  loadOriginalGuidedTranscriptDraft,
+}));
+
+/** All boot flags off, `bot` mode. Override per case. */
+function args(overrides: Partial<UseGuidedLessonBootArgs> = {}): UseGuidedLessonBootArgs {
+  return {
+    mode: 'bot',
+    isGuidedModeProp: false,
+    isAuthoringModeProp: false,
+    isAuthoringV2ModeProp: false,
+    isGuidedV2ModeProp: false,
+    ...overrides,
+  };
+}
+
+const boot = (a: Partial<UseGuidedLessonBootArgs> = {}) =>
+  renderHook(() => useGuidedLessonBoot(args(a))).result.current;
+
 describe('useGuidedLessonBoot', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     isLessonV2Preloaded.mockReturnValue(false);
+    loadFrozenLesson.mockReturnValue(null);
+    loadAuthoringSession.mockReturnValue(null);
+    loadOriginalGuidedTranscript.mockReturnValue(null);
+    loadOriginalGuidedTranscriptDraft.mockReturnValue(null);
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
   });
 
   it('does not synchronously touch lesson V2 registry before preload completes', () => {
-    const { result } = renderHook(() =>
-      useGuidedLessonBoot({
-        mode: 'bot',
-        isGuidedModeProp: false,
-        isAuthoringModeProp: false,
-        isAuthoringV2ModeProp: false,
-        isGuidedV2ModeProp: true,
-      }),
-    );
-
+    const r = boot({ isGuidedV2ModeProp: true });
     expect(getLessonV2Module).not.toHaveBeenCalled();
-    expect(result.current.isGuidedV2Mode).toBe(true);
-    expect(result.current.frozenV2Lesson).toBeNull();
-    expect(result.current.guidedV2BootError).toBeNull();
-    expect(result.current.guidedV2PlaybackReady).toBe(false);
+    expect(r.isGuidedV2Mode).toBe(true);
+    expect(r.frozenV2Lesson).toBeNull();
+    expect(r.guidedV2BootError).toBeNull();
+    expect(r.guidedV2PlaybackReady).toBe(false);
+  });
+
+  describe('mode gate — every flag is `prop && mode === "bot"`', () => {
+    it('a non-bot mode forces all four learn flags false even with every prop set', () => {
+      const r = boot({
+        mode: 'ghost',
+        isGuidedModeProp: true,
+        isAuthoringModeProp: true,
+        isAuthoringV2ModeProp: true,
+        isGuidedV2ModeProp: true,
+      });
+      expect(r.isGuidedMode).toBe(false);
+      expect(r.isAuthoringMode).toBe(false);
+      expect(r.isAuthoringV2Mode).toBe(false);
+      expect(r.isGuidedV2Mode).toBe(false);
+      expect(r.isLearnAcademyMode).toBe(false);
+      expect(r.lessonLayoutMode).toBe(false);
+      expect(loadFrozenLesson).not.toHaveBeenCalled();
+    });
+
+    it('bot mode passes each prop straight through', () => {
+      expect(boot({ isGuidedModeProp: true }).isGuidedMode).toBe(true);
+      expect(boot({ isAuthoringModeProp: true }).isAuthoringMode).toBe(true);
+      expect(boot({ isAuthoringV2ModeProp: true }).isAuthoringV2Mode).toBe(true);
+      expect(boot({ isGuidedV2ModeProp: true }).isGuidedV2Mode).toBe(true);
+    });
+
+    it('isLearnAcademyMode is the OR of the four', () => {
+      expect(boot().isLearnAcademyMode).toBe(false);
+      expect(boot({ isAuthoringV2ModeProp: true }).isLearnAcademyMode).toBe(true);
+    });
+  });
+
+  describe('frozenLesson source', () => {
+    it('uses loadFrozenLesson when it returns a lesson', () => {
+      const frozen = makeFrozenLesson();
+      loadFrozenLesson.mockReturnValue(frozen);
+      const r = boot({ isGuidedModeProp: true });
+      expect(r.frozenLesson).toBe(frozen);
+      expect(loadAuthoringSession).not.toHaveBeenCalled();
+      expect(r.isGuidedFrozenLessonMode).toBe(true);
+      expect(r.lessonLayoutMode).toBe(true);
+    });
+
+    it('falls back to the authoring session when it has a step with a chosen move', () => {
+      const authoring = makeFrozenLesson({
+        steps: [makeAuthoredStep({ chosenMove: '0|0:left' })],
+      }) as AuthoringSession;
+      loadAuthoringSession.mockReturnValue(authoring);
+      const r = boot({ isGuidedModeProp: true });
+      expect(r.frozenLesson).toBe(authoring);
+      expect(r.isGuidedFrozenLessonMode).toBe(true);
+    });
+
+    it('ignores an authoring session whose every step has a null chosen move', () => {
+      loadAuthoringSession.mockReturnValue(
+        makeFrozenLesson({ steps: [makeAuthoredStep({ chosenMove: null })] }) as AuthoringSession,
+      );
+      const r = boot({ isGuidedModeProp: true });
+      expect(r.frozenLesson).toBeNull();
+      expect(r.isGuidedFrozenLessonMode).toBe(false);
+    });
+
+    it('does not load a frozen lesson at all when not in guided mode', () => {
+      loadFrozenLesson.mockReturnValue(makeFrozenLesson());
+      const r = boot({ isAuthoringV2ModeProp: true });
+      expect(loadFrozenLesson).not.toHaveBeenCalled();
+      expect(r.frozenLesson).toBeNull();
+    });
+  });
+
+  describe('guidedTranscript source', () => {
+    it('uses the published transcript when present', () => {
+      const published = makeGuidedTranscript();
+      loadOriginalGuidedTranscript.mockReturnValue(published);
+      const r = boot({ isGuidedModeProp: true });
+      expect(r.guidedTranscript).toBe(published);
+      expect(r.isGuidedTranscriptMode).toBe(true);
+      expect(r.lessonLayoutMode).toBe(true);
+    });
+
+    it('falls back to the draft transcript', () => {
+      const draftTranscript = makeGuidedTranscript();
+      loadOriginalGuidedTranscriptDraft.mockReturnValue({ transcript: draftTranscript, activeStepIndex: null });
+      const r = boot({ isGuidedModeProp: true });
+      expect(r.guidedTranscript).toBe(draftTranscript);
+      expect(r.isGuidedTranscriptMode).toBe(true);
+    });
+
+    it('is null in authoring mode even when a transcript is stored', () => {
+      loadOriginalGuidedTranscript.mockReturnValue(makeGuidedTranscript());
+      const r = boot({ isGuidedModeProp: true, isAuthoringModeProp: true });
+      expect(r.guidedTranscript).toBeNull();
+      expect(r.isGuidedTranscriptMode).toBe(false);
+    });
+
+    it('is null in guided V2 mode even when a transcript is stored', () => {
+      loadOriginalGuidedTranscript.mockReturnValue(makeGuidedTranscript());
+      const r = boot({ isGuidedModeProp: true, isGuidedV2ModeProp: true });
+      expect(r.guidedTranscript).toBeNull();
+    });
+  });
+
+  describe('mode truth table', () => {
+    it('transcript present, no frozen lesson → transcript mode only', () => {
+      loadOriginalGuidedTranscript.mockReturnValue(makeGuidedTranscript());
+      const r = boot({ isGuidedModeProp: true });
+      expect(r.isGuidedTranscriptMode).toBe(true);
+      expect(r.isGuidedFrozenLessonMode).toBe(false);
+      expect(r.lessonLayoutMode).toBe(true);
+    });
+
+    it('frozen lesson present, no transcript → frozen mode only', () => {
+      loadFrozenLesson.mockReturnValue(makeFrozenLesson());
+      const r = boot({ isGuidedModeProp: true });
+      expect(r.isGuidedFrozenLessonMode).toBe(true);
+      expect(r.isGuidedTranscriptMode).toBe(false);
+      expect(r.lessonLayoutMode).toBe(true);
+    });
+
+    it('authoring mode suppresses both transcript and frozen modes', () => {
+      loadFrozenLesson.mockReturnValue(makeFrozenLesson());
+      loadOriginalGuidedTranscript.mockReturnValue(makeGuidedTranscript());
+      const r = boot({ isGuidedModeProp: true, isAuthoringModeProp: true });
+      expect(r.isGuidedTranscriptMode).toBe(false);
+      expect(r.isGuidedFrozenLessonMode).toBe(false);
+    });
+
+    it('a ready V2 playback drives lessonLayoutMode with no transcript or frozen lesson', () => {
+      isLessonV2Preloaded.mockReturnValue(true);
+      const lesson = makeLessonV2();
+      getLessonV2Module.mockReturnValue({
+        loadGuidedV2PlaybackLesson: () => lesson,
+        canStartGuidedV2Lesson: () => true,
+        validateGuidedV2Lesson: () => null,
+      });
+      const r = boot({ isGuidedV2ModeProp: true });
+      expect(r.frozenV2Lesson).toBe(lesson);
+      expect(r.guidedV2BootError).toBeNull();
+      expect(r.guidedV2PlaybackReady).toBe(true);
+      expect(r.lessonLayoutMode).toBe(true);
+      expect(r.isGuidedTranscriptMode).toBe(false);
+      expect(r.isGuidedFrozenLessonMode).toBe(false);
+    });
+
+    it('a V2 lesson that cannot start surfaces the validation error and is not playback-ready', () => {
+      isLessonV2Preloaded.mockReturnValue(true);
+      getLessonV2Module.mockReturnValue({
+        loadGuidedV2PlaybackLesson: () => makeLessonV2(),
+        canStartGuidedV2Lesson: () => false,
+        validateGuidedV2Lesson: () => 'lesson has no events',
+      });
+      const r = boot({ isGuidedV2ModeProp: true });
+      expect(r.guidedV2BootError).toBe('lesson has no events');
+      expect(r.guidedV2PlaybackReady).toBe(false);
+      expect(r.lessonLayoutMode).toBe(false);
+    });
+  });
+
+  it('guidedInitSourceRef is a stable mutable ref seeded to null', () => {
+    const { result, rerender } = renderHook(() => useGuidedLessonBoot(args()));
+    const first = result.current.guidedInitSourceRef;
+    expect(first.current).toBeNull();
+    first.current = 'random';
+    rerender();
+    expect(result.current.guidedInitSourceRef).toBe(first);
+    expect(result.current.guidedInitSourceRef.current).toBe('random');
   });
 });

--- a/client/src/modules/guided/useGuidedV2CoordinationState.test.ts
+++ b/client/src/modules/guided/useGuidedV2CoordinationState.test.ts
@@ -1,0 +1,80 @@
+// @vitest-environment jsdom
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useGuidedV2CoordinationState } from './useGuidedV2CoordinationState';
+import { makeLessonV2 } from './guidedTestFixtures.ts';
+import type { UseGuidedLessonBootResult } from './useGuidedLessonBoot.ts';
+
+const { getLessonV2Module, isLessonV2Preloaded } = vi.hoisted(() => ({
+  getLessonV2Module: vi.fn(),
+  isLessonV2Preloaded: vi.fn(() => false),
+}));
+
+vi.mock('../match/bootstrap/lessonV2LazyRegistry.ts', () => ({
+  getLessonV2Module,
+  isLessonV2Preloaded,
+}));
+
+type BootSlice = Pick<UseGuidedLessonBootResult, 'isGuidedV2Mode' | 'frozenV2Lesson'>;
+
+const lesson = makeLessonV2();
+
+function slice(overrides: Partial<BootSlice> = {}): BootSlice {
+  return { isGuidedV2Mode: true, frozenV2Lesson: lesson, ...overrides };
+}
+
+const canStart = vi.fn(() => true);
+const initPlayback = vi.fn(() => ({ firstEventIndex: 3 }));
+
+const index = (boot: BootSlice) =>
+  renderHook(() => useGuidedV2CoordinationState(boot)).result.current.guidedV2EventIndex;
+
+describe('useGuidedV2CoordinationState — lazy-init guard chain', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    isLessonV2Preloaded.mockReturnValue(true);
+    canStart.mockReturnValue(true);
+    initPlayback.mockReturnValue({ firstEventIndex: 3 });
+    getLessonV2Module.mockReturnValue({
+      canStartGuidedV2Lesson: canStart,
+      initGuidedV2Playback: initPlayback,
+    });
+  });
+
+  it('not in guided V2 mode → index 0, registry untouched', () => {
+    expect(index(slice({ isGuidedV2Mode: false }))).toBe(0);
+    expect(isLessonV2Preloaded).not.toHaveBeenCalled();
+    expect(getLessonV2Module).not.toHaveBeenCalled();
+  });
+
+  it('no frozen V2 lesson → index 0, registry untouched', () => {
+    expect(index(slice({ frozenV2Lesson: null }))).toBe(0);
+    expect(getLessonV2Module).not.toHaveBeenCalled();
+  });
+
+  it('lesson present but V2 module not preloaded → index 0, module not fetched', () => {
+    isLessonV2Preloaded.mockReturnValue(false);
+    expect(index(slice())).toBe(0);
+    expect(getLessonV2Module).not.toHaveBeenCalled();
+  });
+
+  it('preloaded but the lesson cannot start → index 0, playback not initialised', () => {
+    canStart.mockReturnValue(false);
+    expect(index(slice())).toBe(0);
+    expect(initPlayback).not.toHaveBeenCalled();
+  });
+
+  it('happy path → initGuidedV2Playback(lesson, 1).firstEventIndex', () => {
+    expect(index(slice())).toBe(3);
+    expect(canStart).toHaveBeenCalledWith(lesson);
+    expect(initPlayback).toHaveBeenCalledWith(lesson, 1);
+  });
+
+  it('seeds the rest of the coordination state', () => {
+    const { result } = renderHook(() => useGuidedV2CoordinationState(slice()));
+    expect(result.current.isGuidedV2OffLine).toBe(false);
+    expect(result.current.fritzV2LastAppliedIndexRef.current).toBe(-1);
+    expect(typeof result.current.setGuidedV2EventIndex).toBe('function');
+    expect(typeof result.current.setIsGuidedV2OffLine).toBe('function');
+  });
+});


### PR DESCRIPTION
Closes **#126** (F6 / `modules/guided/` Tier 2/3 coverage). **Test-only, zero source changes** — `CODE_QUALITY_PLAN.md` §CQ9.5.6 files 6–8, the last of the F6 effort.

## New / extended tests

**`useGuidedLessonBoot.test.tsx`** — extended 1 → 18 cases: the `prop && mode === 'bot'` gate; `frozenLesson` source (`loadFrozenLesson` → authoring-session fallback → none); `guidedTranscript` source (published → draft → suppressed in authoring / V2 mode); the `isGuidedTranscriptMode` / `isGuidedFrozenLessonMode` / `lessonLayoutMode` truth table incl. ready vs unstartable V2 playback. Mocks the `learn/guidedAuthoring` loaders + the lessonV2 lazy registry.

**`useGuidedV2CoordinationState.test.ts`** — new, 6 cases: the lazy-init guard chain (not V2 / no lesson / not preloaded / cannot-start each short-circuit to `0` without touching the registry; happy path → `initGuidedV2Playback(lesson, 1).firstEventIndex`).

**`guidedPlacementHandlers.test.tsx`** — new, 11 cases: `handleGuidedPlacement` **decision logic only** (per §CQ9.5.6 item 8 — no helper extraction; this item was scoped pure test-writing). Transcript mode: no turn / non-play / off-line click → `'handled'` + `setIsOffAuthoredLine`; match → accept + `setMatch`. V2 mode: match → `applyV2PlayerEvent` + `'handled'`; tile/position mismatch → `setIsGuidedV2OffLine` + `'continue'`; already off-line / neither mode → plain `'continue'`.

## F6 status

Files 6–8 landed → **F6 fully covered** (Tiers 1–3, files 1–8). The effect-heavy hooks in §CQ9.5.4 stay deliberately deferred with reasons recorded there.

## Verification

Full local bar green: `tsc -b`, `lint` 49/50, `lint:hooks` 0, `lint:css`, `check:architecture` 20/20, `check:deps`, `check:bot-match-lazy --dist`, client vitest **223/1697**, server `tsc -b` + vitest all shards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019CsumV3BdhvCQX8uFt9Ee2