### PR TITLE
fix(friends): un-nest Invite/Remove from the row button (audit §3 S1)

### DIFF
--- a/client/src/friends/FriendsScreen.test.tsx
+++ b/client/src/friends/FriendsScreen.test.tsx
@@ -1,0 +1,128 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import type { User } from '@supabase/supabase-js';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import FriendsScreen from './FriendsScreen';
+
+const {
+  fetchFriends,
+  removeFriend,
+  sendFriendRequest,
+  acceptFriendRequest,
+  declineFriendRequest,
+  invalidateFriendsCache,
+  fetchFriendsWithPresence,
+  fetchPublicProfile,
+  fetchUserActivity,
+} = vi.hoisted(() => ({
+  fetchFriends: vi.fn(),
+  removeFriend: vi.fn(),
+  sendFriendRequest: vi.fn(),
+  acceptFriendRequest: vi.fn(),
+  declineFriendRequest: vi.fn(),
+  invalidateFriendsCache: vi.fn(),
+  fetchFriendsWithPresence: vi.fn(),
+  fetchPublicProfile: vi.fn(),
+  fetchUserActivity: vi.fn(),
+}));
+
+vi.mock('./friendsApi', () => ({
+  fetchFriends,
+  removeFriend,
+  sendFriendRequest,
+  acceptFriendRequest,
+  declineFriendRequest,
+  invalidateFriendsCache,
+}));
+
+vi.mock('../social/socialApi', () => ({
+  fetchFriendsWithPresence,
+  fetchPublicProfile,
+  fetchUserActivity,
+}));
+
+const user = { id: 'viewer-1', email: 'viewer@example.com' } as User;
+
+const props = {
+  open: true,
+  user,
+  socket: null,
+  joinedRoom: null,
+  currentUsername: 'viewer',
+  onClose: vi.fn(),
+  showToast: vi.fn(),
+  onCopyInviteLink: vi.fn(),
+  onCreatePrivateRoom: vi.fn(),
+  onViewProfile: vi.fn(),
+  onSpectate: vi.fn(),
+};
+
+function friend(over: Partial<{ id: string; userId: string; username: string; online: boolean }> = {}) {
+  return { id: 'f1', userId: 'u1', username: 'maya', online: false, ...over };
+}
+
+describe('FriendsScreen — friend row interactive structure (S1)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fetchFriends.mockResolvedValue({
+      error: null,
+      friends: [friend({ id: 'f1', userId: 'u1', username: 'maya' }), friend({ id: 'f2', userId: 'u2', username: 'alex' })],
+      incoming: [],
+      outgoing: [],
+    });
+    fetchFriendsWithPresence.mockResolvedValue({ error: null, friends: [] });
+    fetchPublicProfile.mockResolvedValue({ error: null, profile: null });
+    fetchUserActivity.mockResolvedValue({ error: null, feed: [] });
+    removeFriend.mockResolvedValue({ error: null });
+  });
+
+  it('renders no <button> nested inside another <button>, and no DOM-nesting warning', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { container } = render(<FriendsScreen {...props} />);
+    await screen.findByText('@maya');
+
+    for (const btn of container.querySelectorAll('button')) {
+      expect(btn.querySelector('button')).toBeNull();
+      expect(btn.parentElement?.closest('button') ?? null).toBeNull();
+    }
+
+    const nestingWarnings = consoleError.mock.calls
+      .map((call) => call.join(' '))
+      .filter((msg) => /cannot (?:be a descendant of|contain a nested)/i.test(msg));
+    expect(nestingWarnings).toEqual([]);
+    consoleError.mockRestore();
+  });
+
+  it('makes the row a non-button container with a dedicated select button', async () => {
+    const { container } = render(<FriendsScreen {...props} />);
+    await screen.findByText('@maya');
+
+    const row = container.querySelector('.friends-page-row--selectable');
+    expect(row).toBeTruthy();
+    expect(row?.tagName).toBe('DIV');
+    expect(row?.querySelector('button.friends-page-row__select')).toBeTruthy();
+  });
+
+  it('selects a friend from the row select button but not from the action buttons', async () => {
+    const { container } = render(<FriendsScreen {...props} />);
+    await screen.findByText('@maya');
+    const row = container.querySelectorAll('.friends-page-row--selectable')[0] as HTMLElement;
+
+    fireEvent.click(within(row).getByRole('button', { name: /Remove/ }));
+    expect(fetchPublicProfile).not.toHaveBeenCalled();
+
+    fireEvent.click(row.querySelector('.friends-page-row__select') as HTMLElement);
+    await waitFor(() => expect(fetchPublicProfile).toHaveBeenCalledWith('maya'));
+  });
+
+  it('keeps the select control keyboard-operable', async () => {
+    const { container } = render(<FriendsScreen {...props} />);
+    await screen.findByText('@maya');
+    const select = container.querySelector('.friends-page-row__select') as HTMLButtonElement;
+
+    select.focus();
+    expect(document.activeElement).toBe(select);
+    fireEvent.click(select); // Enter/Space on a focused <button> dispatches a click
+    await waitFor(() => expect(fetchPublicProfile).toHaveBeenCalledWith('maya'));
+  });
+});

--- a/client/src/friends/FriendsScreen.tsx
+++ b/client/src/friends/FriendsScreen.tsx
@@ -462,22 +462,27 @@ export default function FriendsScreen({
                   const roomCode = presenceInfo?.roomCode ?? null;
                   const isSelected = selectedFriend?.id === friend.id;
                   return (
-                    <button
+                    <div
                       key={friend.id}
-                      type="button"
                       className={`friends-page-row friends-page-row--selectable${isSelected ? ' friends-page-row--selected' : ''}`}
-                      onClick={() => handleSelectFriend(friend)}
                     >
-                      <div className="friends-page-row__left">
-                        <PresenceDot status={presenceStatus} />
-                        <div>
-                          <div className="friends-page-row__name">@{friend.username}</div>
-                          <div className="friends-page-row__meta">
-                            {presenceStatus === 'in_game' ? 'In Game' : presenceStatus === 'online' ? 'Online' : 'Offline'}
+                      <button
+                        type="button"
+                        className="friends-page-row__select"
+                        aria-pressed={isSelected}
+                        onClick={() => handleSelectFriend(friend)}
+                      >
+                        <div className="friends-page-row__left">
+                          <PresenceDot status={presenceStatus} />
+                          <div>
+                            <div className="friends-page-row__name">@{friend.username}</div>
+                            <div className="friends-page-row__meta">
+                              {presenceStatus === 'in_game' ? 'In Game' : presenceStatus === 'online' ? 'Online' : 'Offline'}
+                            </div>
                           </div>
                         </div>
-                      </div>
-                      <div className="friends-page-row__actions" onClick={(e) => e.stopPropagation()}>
+                      </button>
+                      <div className="friends-page-row__actions">
                         {presenceStatus === 'in_game' && roomCode && onSpectate ? (
                           <button
                             type="button"
@@ -542,7 +547,7 @@ export default function FriendsScreen({
                           Remove
                         </button>
                       </div>
-                    </button>
+                    </div>
                   );
                 })}
               </div>

--- a/client/src/friends/friendsScreen.css
+++ b/client/src/friends/friendsScreen.css
@@ -263,20 +263,37 @@
   flex-shrink: 0;
 }
 
-/* Selectable row styles (button reset) */
+/* Selectable row: a plain container. The selection control is the inner
+   .friends-page-row__select <button>, so the Invite / Remove <button>s can
+   sit alongside it instead of nested inside a <button> (invalid HTML). */
 .friends-page-row--selectable {
-  appearance: none;
-  background: none;
-  border: none;
   width: 100%;
-  text-align: left;
-  cursor: pointer;
   border-radius: 8px;
   transition: background 120ms cubic-bezier(0.2, 0, 0, 1);
 }
 
 .friends-page-row--selectable:hover {
   background: rgba(255, 255, 255, 0.04);
+}
+
+.friends-page-row__select {
+  appearance: none;
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+  flex: 1;
+  min-width: 0;
+  font: inherit;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+  border-radius: 8px;
+}
+
+.friends-page-row__select:focus-visible {
+  outline: 2px solid rgba(59, 130, 246, 0.6);
+  outline-offset: 2px;
 }
 
 .friends-page-row--selected {


### PR DESCRIPTION
## What

`FEATURE_COMPLETENESS_AUDIT.md` §3 **S1**.

Each friend row on `/friends` was a `<button>` (`.friends-page-row--selectable`) with the per-row **Invite** / **Remove** action `<button>`s rendered *inside* it. React logs this on every load:

> In HTML, `<button>` cannot be a descendant of `<button>`. This will cause a hydration error.

Invalid HTML, an accessibility defect (nested interactive controls aren't reliably operable by keyboard/AT), and a latent click-target conflict that was papered over with `onClick={(e) => e.stopPropagation()}`.

## Change

- The row is now a `<div class="friends-page-row friends-page-row--selectable">`.
- Selection moves to a dedicated `<button class="friends-page-row__select">` wrapping the presence dot + name/meta.
- The `.friends-page-row__actions` buttons are now **siblings** of the select button, not descendants.
- `stopPropagation` hack removed — no longer needed.
- CSS: `--selectable` drops the button-reset (it's a container now); button-reset + a `:focus-visible` ring move to `__select`.

All three controls are real `<button>`s, independently operable including by keyboard. `--selected` / hover states unchanged visually.

## Tests

New `FriendsScreen.test.tsx` (renders the real component with mock API data):
- no `<button>` nested in another `<button>`, and no DOM-nesting `console.error`
- the row is a `<div>` with a `.friends-page-row__select` button
- clicking **Remove** does not select the friend; clicking the select area does
- the select control is keyboard-focusable and activates on click

All 4 fail on the pre-fix structure.

## Local bar

`tsc -b` · `lint` (49/50) · `lint:hooks` · `lint:css` · `check:architecture` 20/20 · `check:deps` · client `vitest` 224 files / 1701 tests — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)