### PR TITLE
fix(matchmaking): real aria-label for the Match Found record line (audit §3 S2)

### DIFF
--- a/client/src/matchmaking/MatchFoundOverlay.test.tsx
+++ b/client/src/matchmaking/MatchFoundOverlay.test.tsx
@@ -1,0 +1,62 @@
+// @vitest-environment jsdom
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { MatchFoundOverlay } from './MatchFoundOverlay';
+import type { MatchFoundPayload } from './types';
+
+const { fetchRankingProfile, fetchUserStatsByUserId } = vi.hoisted(() => ({
+  fetchRankingProfile: vi.fn(),
+  fetchUserStatsByUserId: vi.fn(),
+}));
+
+vi.mock('../stats/statsApi', () => ({ fetchRankingProfile, fetchUserStatsByUserId }));
+
+const payload: MatchFoundPayload = {
+  roomCode: 'ROOM1',
+  opponent: { userId: 'opp-1', username: 'alex', rating: 1180, isSim: false },
+  yourRating: 1240,
+  countdownMs: 5000,
+};
+
+const props = { payload, onComplete: vi.fn(), yourUsername: 'maya', yourUserId: 'you-1' };
+
+describe('MatchFoundOverlay — record accessible name (S2)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('never labels a record line "Record placeholder"', async () => {
+    fetchRankingProfile.mockResolvedValue({ data: null });
+    fetchUserStatsByUserId.mockResolvedValue({ data: null });
+    render(<MatchFoundOverlay {...props} />);
+
+    await waitFor(() => expect(fetchUserStatsByUserId).toHaveBeenCalled());
+    expect(screen.queryByLabelText('Record placeholder')).toBeNull();
+  });
+
+  it('labels the unknown record as not available', async () => {
+    fetchRankingProfile.mockResolvedValue({ data: null });
+    fetchUserStatsByUserId.mockResolvedValue({ data: null });
+    render(<MatchFoundOverlay {...props} />);
+
+    const unknowns = await screen.findAllByLabelText('Win–loss–draw record: not available');
+    expect(unknowns).toHaveLength(2); // both seats
+    expect(unknowns[0].textContent).toBe('— · — · —');
+  });
+
+  it('spells out a loaded record in the accessible name', async () => {
+    fetchRankingProfile.mockImplementation((id: string) =>
+      Promise.resolve({ data: { currentWinStreak: id === 'you-1' ? 3 : 0 } }),
+    );
+    fetchUserStatsByUserId.mockImplementation((id: string) =>
+      Promise.resolve({ data: id === 'you-1' ? { wins: 12, losses: 5 } : { wins: 4, losses: 9 } }),
+    );
+    render(<MatchFoundOverlay {...props} />);
+
+    const you = await screen.findByLabelText('Win–loss–draw record: 12 wins, 5 losses, 0 draws');
+    expect(you.textContent).toBe('12 · 5 · 0');
+    expect(
+      await screen.findByLabelText('Win–loss–draw record: 4 wins, 9 losses, 0 draws'),
+    ).toBeTruthy();
+  });
+});

--- a/client/src/matchmaking/MatchFoundOverlay.tsx
+++ b/client/src/matchmaking/MatchFoundOverlay.tsx
@@ -53,6 +53,21 @@ function stakeLabelFromElapsed(elapsedMs: number): string {
 const RING_R = 52;
 const RING_C = 2 * Math.PI * RING_R;
 
+type SeatStats = { wins: number; losses: number; draws: number; streak: number };
+
+/** Visible "W · L · D" line, or an em-dash placeholder while unknown. */
+function recordText(s: SeatStats | null): string {
+  return s ? `${s.wins} · ${s.losses} · ${s.draws}` : '— · — · —';
+}
+
+/** Accessible name for the record line — spells out what "W · L · D" means,
+ *  and says so plainly when the lookup hasn't landed (or failed). */
+function recordLabel(s: SeatStats | null): string {
+  return s
+    ? `Win–loss–draw record: ${s.wins} wins, ${s.losses} losses, ${s.draws} draws`
+    : 'Win–loss–draw record: not available';
+}
+
 /**
  * Full-screen match-found layout: dual player columns, center countdown ring,
  * match facts row, footer parameters. Shown after `queue:matched`.
@@ -67,8 +82,8 @@ export function MatchFoundOverlay({ payload, onComplete, yourUsername, yourUserI
     setSecondsLeft(totalSeconds);
   }
 
-  const [youStats, setYouStats] = useState<{ record: string; streak: number } | null>(null);
-  const [oppStats, setOppStats] = useState<{ record: string; streak: number } | null>(null);
+  const [youStats, setYouStats] = useState<SeatStats | null>(null);
+  const [oppStats, setOppStats] = useState<SeatStats | null>(null);
 
   useEffect(() => {
     if (secondsLeft <= 0) {
@@ -88,11 +103,17 @@ export function MatchFoundOverlay({ payload, onComplete, yourUsername, yourUserI
         const ratingProfile = profileResp.data;
         const stats = statsResp.data;
         if (ratingProfile || stats) {
-          const record = stats ? `${stats.wins} · ${stats.losses} · 0` : '0 · 0 · 0';
-          const streak = ratingProfile?.currentWinStreak ?? 0;
-          setYouStats({ record, streak });
+          setYouStats({
+            wins: stats?.wins ?? 0,
+            losses: stats?.losses ?? 0,
+            draws: 0,
+            streak: ratingProfile?.currentWinStreak ?? 0,
+          });
         }
-      }).catch(() => {});
+        // else: leave youStats null — the record line reads "not available".
+      }).catch(() => {
+        // Transient overlay; a failed lookup keeps the "not available" record.
+      });
     }
   }, [yourUserId]);
 
@@ -106,11 +127,17 @@ export function MatchFoundOverlay({ payload, onComplete, yourUsername, yourUserI
         const ratingProfile = profileResp.data;
         const stats = statsResp.data;
         if (ratingProfile || stats) {
-          const record = stats ? `${stats.wins} · ${stats.losses} · 0` : '0 · 0 · 0';
-          const streak = ratingProfile?.currentWinStreak ?? 0;
-          setOppStats({ record, streak });
+          setOppStats({
+            wins: stats?.wins ?? 0,
+            losses: stats?.losses ?? 0,
+            draws: 0,
+            streak: ratingProfile?.currentWinStreak ?? 0,
+          });
         }
-      }).catch(() => {});
+        // else: leave oppStats null — the record line reads "not available".
+      }).catch(() => {
+        // Transient overlay; a failed lookup keeps the "not available" record.
+      });
     }
   }, [payload.opponent.userId]);
 
@@ -151,8 +178,8 @@ export function MatchFoundOverlay({ payload, onComplete, yourUsername, yourUserI
                   </span>
                   <span>Rated</span>
                 </p>
-                <p className="mm-found-seat__record" aria-label="Record placeholder">
-                  {youStats ? youStats.record : '— · — · —'}
+                <p className="mm-found-seat__record" aria-label={recordLabel(youStats)}>
+                  {recordText(youStats)}
                 </p>
                 <p className="mm-found-seat__elo-row">
                   <span className="mm-found-seat__elo-num">{formatElo(payload.yourRating)}</span>
@@ -207,8 +234,8 @@ export function MatchFoundOverlay({ payload, onComplete, yourUsername, yourUserI
                   </span>
                   <span>Rated</span>
                 </p>
-                <p className="mm-found-seat__record" aria-label="Record placeholder">
-                  {oppStats ? oppStats.record : '— · — · —'}
+                <p className="mm-found-seat__record" aria-label={recordLabel(oppStats)}>
+                  {recordText(oppStats)}
                 </p>
                 <p className="mm-found-seat__elo-row">
                   <span className="mm-found-seat__elo-num mm-found-seat__elo-num--blue">


### PR DESCRIPTION
## What

`FEATURE_COMPLETENESS_AUDIT.md` §3 **S2**.

`MatchFoundOverlay.tsx` rendered `aria-label="Record placeholder"` on **both** seat record lines — the overlay shown before every ranked multiplayer match. Screen-reader users heard the win/loss/draw record announced as the literal words "Record placeholder". The visible `— · — · —` fallback was fine; only the label was wrong.

## Change

- `aria-label` now describes the content:
  - loaded → `Win–loss–draw record: 12 wins, 5 losses, 0 draws`
  - unknown (pending or failed lookup) → `Win–loss–draw record: not available`
- Seat stats state moved from a pre-formatted `{ record: string }` to `{ wins, losses, draws, streak }`; the visible `W · L · D` string and the label are both derived from it (`recordText` / `recordLabel`).
- The two `.catch(() => {})` on the stats fetches now carry a comment (`// Transient overlay; a failed lookup keeps the "not available" record.`) — matches the repo's "every catch is documented" standard noted in audit §4.

No visible change. `winStreak` derivation unchanged.

## Tests

New `MatchFoundOverlay.test.tsx`:
- no record line is ever labelled `Record placeholder`
- unknown record → both seats labelled `…: not available`, visible text `— · — · —`
- loaded record → label spells out `N wins, N losses, N draws`, visible text `N · N · N`

## Local bar

`tsc -b` · `lint` (49/50) · `lint:hooks` · `lint:css` · `check:architecture` 20/20 · client `vitest` 224 files / 1700 tests — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)