### PR TITLE
fix(journey): run the content validator under tsx + gate in CI (audit §3 S3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,9 @@ jobs:
       - name: Architecture invariant enforcement
         run: npm run check:architecture --prefix client
 
+      - name: Journey content validation (real shipped chapter content)
+        run: npm run qa:journey-content --prefix client
+
       - name: Client tests
         run: npm run test:all --prefix client
 

--- a/client/scripts/validateJourneyContent.mjs
+++ b/client/scripts/validateJourneyContent.mjs
@@ -10,11 +10,14 @@ import { fileURLToPath } from 'node:url';
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const clientRoot = path.resolve(scriptDir, '..');
 
+// `tsx`, not `ts-node --esm`: this codebase's extensionless / `.ts`-suffixed
+// relative imports don't resolve under ts-node's ESM loader (it threw
+// ERR_MODULE_NOT_FOUND on src/utils/logger). `tsx` handles them, and is what
+// the other script runners here already use (check:architecture, test:analyzer).
 const result = spawnSync(
   'npx',
   [
-    'ts-node',
-    '--esm',
+    'tsx',
     path.join(scriptDir, 'validateJourneyContentRunner.ts'),
     ...process.argv.slice(2),
   ],


### PR DESCRIPTION
## What

`FEATURE_COMPLETENESS_AUDIT.md` §3 **S3**.

`npm run qa:journey-content` couldn't run:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '.../client/src/utils/logger'
  imported from .../client/src/game/openEndsGeometry.ts
```

`scripts/validateJourneyContent.mjs` shelled out to `ts-node --esm`, which can't resolve this codebase's extensionless / `.ts`-suffixed relative imports. The validator itself is fine.

## Change

1. **Runner → `tsx`.** Matches `check:architecture`, `check:socket-registry`, `test:analyzer`, `test:bot-hooks`. `npm run qa:journey-content` and `:summary` both pass:
   > `Journey content validation passed.`
   > `Normalized content: supported=90, legacyFallback=0, placeholder=18, unsupported=0`
2. **CI decision: gate it.** Added as a Client Validation step in `ci.yml`. It's the only check that runs against the **real shipped** Journey content — `journeyContentValidation.test.ts` / `journeyContentResolver.test.ts` both use fixtures — so without it, a Journey node resolving to `unsupported` (a dead node in a shipped chapter) goes uncaught. ~1s.

## Local bar

`tsc -b` · `npm run qa:journey-content` green (exit 0) · `:summary` green · `journeyContentValidation` + `journeyContentResolver` tests 32/32.

🤖 Generated with [Claude Code](https://claude.com/claude-code)