### PR TITLE
fix(nav): one shared tab table for desktop + mobile nav (audit §3 S4)

### DIFF
--- a/client/src/components/GlobalNav.activeTab.test.tsx
+++ b/client/src/components/GlobalNav.activeTab.test.tsx
@@ -1,0 +1,56 @@
+// @vitest-environment jsdom
+import { render } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { APP_PRIMARY_TABS } from './nav/appPrimaryTabs';
+
+const mockAuth = vi.fn();
+vi.mock('../auth/useAuth', () => ({ useAuth: () => mockAuth() }));
+vi.mock('../friends/friendsApi', () => ({ fetchFriends: () => new Promise(() => {}) }));
+vi.mock('./BrandLogo', () => ({ BrandLogo: () => null }));
+vi.mock('./nav/AppBottomTabBar', () => ({ AppBottomTabBar: () => null }));
+
+const { GlobalNav } = await import('./GlobalNav');
+
+const signedIn = {
+  user: { id: 'user-1', email: 'qa@racehorse.test' },
+  profile: { id: 'user-1', username: 'oliver', glicko_rating: 1500 },
+  loading: false,
+};
+
+/** The label of the desktop tab currently showing the glow underline. */
+function activeTabLabel(container: HTMLElement): string | null {
+  const underline = container.querySelector('.rh-glow-underline--global-nav');
+  const button = underline?.closest('button');
+  return button?.textContent?.trim() ?? null;
+}
+
+describe('GlobalNav — desktop active tab is driven by APP_PRIMARY_TABS (S4)', () => {
+  beforeEach(() => {
+    mockAuth.mockReset();
+    mockAuth.mockReturnValue(signedIn);
+  });
+
+  it('highlights the correct tab for every mode in the shared table', () => {
+    for (const tab of APP_PRIMARY_TABS) {
+      for (const mode of tab.activeModes) {
+        const { container, unmount } = render(<GlobalNav currentMode={mode} />);
+        expect(activeTabLabel(container)).toBe(tab.label);
+        unmount();
+      }
+    }
+  });
+
+  it('highlights Single Player on /daily-fritz/leaderboard and Learn on /learn/recorder', () => {
+    const { container: a, unmount: unmountA } = render(<GlobalNav currentMode="dailyFritzLeaderboard" />);
+    expect(activeTabLabel(a)).toBe('Single Player');
+    unmountA();
+
+    const { container: b } = render(<GlobalNav currentMode="guidedMatchRecorder" />);
+    expect(activeTabLabel(b)).toBe('Learn');
+  });
+
+  it('highlights no tab for a mode outside the primary nav', () => {
+    const { container } = render(<GlobalNav currentMode="settings" />);
+    expect(activeTabLabel(container)).toBeNull();
+  });
+});

--- a/client/src/components/GlobalNav.tsx
+++ b/client/src/components/GlobalNav.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useMemo, useRef } from 'react';
 import { BrandLogo } from './BrandLogo';
 import { Button } from './primitives';
 import { AppBottomTabBar } from './nav/AppBottomTabBar';
+import { APP_PRIMARY_TABS, APP_PRIMARY_TAB_COLORS } from './nav/appPrimaryTabs';
 import { useAuth } from '../auth/useAuth';
 import { fetchFriends } from '../friends/friendsApi';
 import type { AppMode } from '../types';
@@ -45,21 +46,9 @@ interface GlobalNavProps {
   solidDarkChrome?: boolean;
 }
 
-const TABS: { label: string; mode: AppMode; activeModes: AppMode[] }[] = [
-  { label: 'Multiplayer', mode: 'multiplayer', activeModes: ['multiplayer'] },
-  { label: 'Single Player', mode: 'singlePlayerHub', activeModes: ['singlePlayerHub', 'journey', 'botSetup', 'ghostSetup', 'dailyFritz', 'daily'] },
-  { label: 'Tournament', mode: 'tournament', activeModes: ['tournament'] },
-  { label: 'Social', mode: 'feed', activeModes: ['feed', 'friends', 'leaderboard', 'profile', 'stats'] },
-  { label: 'Learn', mode: 'learn', activeModes: ['learn', 'noBrainer'] },
-];
-
-const TAB_COLORS: Record<string, string> = {
-  'Single Player': '#9B6CFF', // Purple
-  'Multiplayer': '#3FA7FF',   // Blue
-  'Learn': '#19D8A2',         // Green
-  'Tournament': '#F5A524',    // Gold
-  'Social': '#0ea5e9',        // Cyan
-};
+// Desktop nav and the mobile bottom tab bar are driven by the SAME table
+// (`APP_PRIMARY_TABS`) so they can't disagree about which tab is active — the
+// two hand-maintained copies had drifted (audit §3 S4).
 
 /** `mode` navigates; its absence means sign out. */
 const ACCOUNT_MENU_ITEMS: { label: string; mode?: AppMode }[] = [
@@ -281,9 +270,9 @@ export function GlobalNav({
             </div>
           ) : (
             <div className={`flex items-center ${compactChrome ? 'gap-6' : 'gap-8'}`}>
-              {TABS.map((tab) => {
+              {APP_PRIMARY_TABS.map((tab) => {
                 const isActive = tab.activeModes.includes(currentMode as AppMode);
-                const accentColor = (isActive && activeColor) || TAB_COLORS[tab.label] || 'var(--tier-elite)';
+                const accentColor = (isActive && activeColor) || APP_PRIMARY_TAB_COLORS[tab.label] || 'var(--tier-elite)';
                 const textColor = isActive
                   ? (tab.label === 'Social' && activeColor ? 'var(--text-primary)' : accentColor)
                   : 'var(--text-muted)';


### PR DESCRIPTION
## What

`FEATURE_COMPLETENESS_AUDIT.md` §3 **S4**.

`GlobalNav.tsx` (desktop nav row) declared its own `TABS` / `TAB_COLORS`; `AppBottomTabBar` (mobile bottom bar) uses `APP_PRIMARY_TABS` / `APP_PRIMARY_TAB_COLORS`. The two hand-maintained copies drifted: `APP_PRIMARY_TABS` lists `dailyFritzLeaderboard`, `ratingHistory`, `guidedMatchRecorder`, `guidedMatchAnnotator` among `activeModes`; GlobalNav's copy listed none.

Observable: on `/daily-fritz/leaderboard` and `/learn/recorder` (both render the desktop nav), mobile highlights Solo / Learn and **desktop highlights nothing**. (`/rating-history` and `/learn/guided-annotator` render standalone screens with no global nav, so they can't exhibit it.)

## Change

`GlobalNav` imports `APP_PRIMARY_TABS` / `APP_PRIMARY_TAB_COLORS` and deletes its local `TABS` / `TAB_COLORS`. One source of truth drives both navs — the same fix `appRouteTypes.ts:27-38` already documents for the `AppMode` union. `shortLabel` (mobile-only) is ignored by the desktop render; no visual change on desktop.

`APP_PRIMARY_TABS` still carries the orphaned `daily` / `dailyPuzzleLeaderboard` modes — those are removed in **S7**, which now has a single table to clean.

## Tests

New `GlobalNav.activeTab.test.tsx`:
- for **every** mode in `APP_PRIMARY_TABS`, the matching desktop tab shows the glow underline
- explicit: `dailyFritzLeaderboard` → Single Player, `guidedMatchRecorder` → Learn
- a non-nav mode (`settings`) highlights nothing

Both audit-named cases fail on the pre-fix `TABS`.

## Local bar

`tsc -b` · `lint` (49/50) · `lint:hooks` · `lint:css` · `check:architecture` 20/20 · client `vitest` 224 files / 1700 tests — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)