### PR TITLE
refactor(app-routes): remove the unused homeOverlays prop bundle (audit §3 S8)

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -191,10 +191,6 @@ export default function App() {
     setUsernameModalOpen,
     signingOut,
     setSigningOut,
-    weeklyStatsOpen,
-    setWeeklyStatsOpen,
-    welcomeOpen,
-    setWelcomeOpen,
   } = useAppSessionUi({ authUser: authUser ? { id: authUser.id, email: authUser.email ?? '' } : null, authProfile, authLoading, justVerified, showToast });
 
   // Single tournament hook instance, shared by Hub/Bracket/Result screens.
@@ -730,9 +726,6 @@ export default function App() {
       ? `@${authUser.email.split('@')[0]}`
       : '@player';
   const homeRatingLabel = (authProfile?.glicko_rating != null ? Math.round(Number(authProfile.glicko_rating)) : 800).toLocaleString();
-  const [activeHomeMode, setActiveHomeMode] = useState<
-    'multiplayer' | 'dailyFritz' | 'daily' | 'singlePlayerHub' | 'tournament' | 'learn'
-  >('multiplayer');
   useRenderProfiler('AppNonGame');
   const isRoomHost = players[0]?.id === you;
 
@@ -955,14 +948,6 @@ export default function App() {
         profileOriginMode,
         setProfileOriginMode,
         toast,
-      },
-      homeOverlays: {
-        activeHomeMode,
-        setActiveHomeMode,
-        welcomeOpen,
-        setWelcomeOpen,
-        weeklyStatsOpen,
-        setWeeklyStatsOpen,
       },
       tournament: {
         tournament,

--- a/client/src/appRouteTypes.test.ts
+++ b/client/src/appRouteTypes.test.ts
@@ -16,7 +16,6 @@ const APP_ROUTES_BUNDLE_KEYS: (keyof AppRoutesProps)[] = [
   'botMatch',
   'ghost',
   'social',
-  'homeOverlays',
   'multiplayer',
   'tournament',
 ];
@@ -28,14 +27,13 @@ const HOST_ROUTE_BUNDLE_KEYS: (keyof AppRoutesHostRouteBundles)[] = [
   'botMatch',
   'ghost',
   'social',
-  'homeOverlays',
   'tournament',
   'multiplayerRoute',
 ];
 
 describe('appRouteTypes prop bundles', () => {
-  it('AppRoutesProps exposes exactly 10 domain bundles (replacing 84 flat props)', () => {
-    expect(APP_ROUTES_BUNDLE_KEYS).toHaveLength(10);
+  it('AppRoutesProps exposes exactly 9 domain bundles (replacing the former 84 flat props)', () => {
+    expect(APP_ROUTES_BUNDLE_KEYS).toHaveLength(9);
     expect(APP_ROUTES_BUNDLE_KEYS).toEqual([
       'shell',
       'navigation',
@@ -44,17 +42,16 @@ describe('appRouteTypes prop bundles', () => {
       'botMatch',
       'ghost',
       'social',
-      'homeOverlays',
       'multiplayer',
       'tournament',
     ]);
   });
 
-  it('AppRoutesHostRouteBundles groups host-source route fields into 9 sub-bundles', () => {
-    expect(HOST_ROUTE_BUNDLE_KEYS).toHaveLength(9);
+  it('AppRoutesHostRouteBundles groups host-source route fields into 8 sub-bundles', () => {
+    expect(HOST_ROUTE_BUNDLE_KEYS).toHaveLength(8);
   });
 
-  it('flat bundle field counts sum to former 84-prop surface', () => {
+  it('flat bundle field counts sum to the route-prop surface', () => {
     type ShellKeys = keyof AppRoutesShellProps;
     type NavKeys = keyof AppRoutesNavigationProps;
     const fieldCounts = {
@@ -65,13 +62,12 @@ describe('appRouteTypes prop bundles', () => {
       botMatch: 8 satisfies number,
       ghost: 6 satisfies number,
       social: 9 satisfies number,
-      homeOverlays: 6 satisfies number,
       multiplayer: 9 satisfies number,
       tournament: 17 satisfies number,
     };
 
     const total = Object.values(fieldCounts).reduce((sum, n) => sum + n, 0);
-    expect(total).toBe(84);
+    expect(total).toBe(78);
 
     // Guard against accidental key renames dropping coverage
     const _shell: Record<ShellKeys, unknown> = {

--- a/client/src/appRouteTypes.ts
+++ b/client/src/appRouteTypes.ts
@@ -126,18 +126,6 @@ export type AppRoutesSocialProps = {
   toast: string;
 };
 
-/** Home screen accordion hover state and welcome/weekly-stats overlays. */
-export type AppRoutesHomeOverlayProps = {
-  activeHomeMode: 'multiplayer' | 'dailyFritz' | 'daily' | 'singlePlayerHub' | 'tournament' | 'learn';
-  setActiveHomeMode: Dispatch<
-    SetStateAction<'multiplayer' | 'dailyFritz' | 'daily' | 'singlePlayerHub' | 'tournament' | 'learn'>
-  >;
-  welcomeOpen: boolean;
-  setWelcomeOpen: Dispatch<SetStateAction<boolean>>;
-  weeklyStatsOpen: boolean;
-  setWeeklyStatsOpen: Dispatch<SetStateAction<boolean>>;
-};
-
 /** Multiplayer route: connection bundle, mode controller view, and in-match errors. */
 export type AppRoutesMultiplayerProps = {
   error: string;
@@ -180,7 +168,6 @@ export type AppRoutesProps = {
   botMatch: AppRoutesBotMatchProps;
   ghost: AppRoutesGhostProps;
   social: AppRoutesSocialProps;
-  homeOverlays: AppRoutesHomeOverlayProps;
   multiplayer: AppRoutesMultiplayerProps;
   tournament: AppRoutesTournamentProps;
 };
@@ -193,7 +180,6 @@ export type AppRoutesHostRouteBundles = {
   botMatch: AppRoutesBotMatchProps;
   ghost: AppRoutesGhostProps;
   social: Omit<AppRoutesSocialProps, 'toast' | 'connect'> & { toast: string };
-  homeOverlays: AppRoutesHomeOverlayProps;
   tournament: AppRoutesTournamentProps;
   multiplayerRoute: Pick<AppRoutesMultiplayerProps, 'mpSubView' | 'error' | 'setError'>;
 };

--- a/client/src/auth/useAppSessionUi.ts
+++ b/client/src/auth/useAppSessionUi.ts
@@ -48,6 +48,9 @@ export function useAppSessionUi(params: UseAppSessionUiParams): UseAppSessionUiR
   const [authModalOpen, setAuthModalOpen] = useState(false);
   const [usernameModalOpen, setUsernameModalOpen] = useState(false);
   const [signingOut, setSigningOut] = useState(false);
+  // welcomeOpen (set from the hasSeenWelcome flag below) and weeklyStatsOpen are
+  // exposed for a welcome / weekly-stats modal that has no UI consumer yet — they
+  // used to be routed through the unused `homeOverlays` route bundle (removed).
   const [weeklyStatsOpen, setWeeklyStatsOpen] = useState(false);
   const [welcomeOpen, setWelcomeOpen] = useState(false);
 

--- a/client/src/useAppRoutesInput.tsx
+++ b/client/src/useAppRoutesInput.tsx
@@ -110,7 +110,6 @@ export function useAppRoutesInput(source: UseAppRoutesInputSource): UseAppRoutes
       source.routeBundles.botMatch,
       source.routeBundles.ghost,
       source.routeBundles.social,
-      source.routeBundles.homeOverlays,
       source.routeBundles.tournament,
       source.routeBundles.multiplayerRoute,
       source.friendInvitePopup,

--- a/client/src/useAppRoutesProps.tsx
+++ b/client/src/useAppRoutesProps.tsx
@@ -53,7 +53,7 @@ export type UseAppRoutesPropsSource = {
 
 export function useAppRoutesProps(source: UseAppRoutesPropsSource): AppRoutesProps {
   const { host, routeBundles } = source;
-  const { navigation, auth, learn, botMatch, ghost, social, homeOverlays, tournament, multiplayerRoute } =
+  const { navigation, auth, learn, botMatch, ghost, social, tournament, multiplayerRoute } =
     routeBundles;
 
   const appRootClassName = 'app large-mode';
@@ -368,7 +368,6 @@ export function useAppRoutesProps(source: UseAppRoutesPropsSource): AppRoutesPro
       setProfileOriginMode: social.setProfileOriginMode,
       toast: social.toast,
     },
-    homeOverlays,
     multiplayer: {
       error: multiplayerRoute.error,
       actionError: source.actionError,


### PR DESCRIPTION
## What

`FEATURE_COMPLETENESS_AUDIT.md` §3 **S8**. Approved as a standalone PR — the sanctioned incremental chip at App.tsx per `REFACTOR_OPPORTUNITIES.md` D5, **not** the deferred restructure (15 lines of App.tsx).

`AppRoutesProps` / `AppRoutesHostRouteBundles` declared `homeOverlays: AppRoutesHomeOverlayProps`, it was constructed in `App.tsx` and threaded through `useAppRoutesProps` / `useAppRoutesInput` — but `AppRoutes` **never destructured it**. Dead weight on the prop funnel.

## Change

- `AppRoutesHomeOverlayProps` + both `homeOverlays` bundle fields removed from `appRouteTypes.ts`.
- `homeOverlays` removed from the `useAppRoutesProps` destructure / passthrough and the `useAppRoutesInput` dep list.
- `App.tsx`: dropped the `homeOverlays: { … }` literal and the `activeHomeMode` `useState` (zero logic — it only fed the dead bundle; this also clears the dead `'daily'` arm S7 left in its literal union).
- `welcomeOpen` / `weeklyStatsOpen` **stay** in `useAppSessionUi` — `welcomeOpen` has real first-visit logic (`hasSeenWelcome`) + dedicated tests. They're just no longer routed through the removed bundle; a comment notes they're waiting on a modal UI consumer.
- `appRouteTypes.test.ts` bundle-shape guard updated: **9** domain bundles / **8** host sub-bundles / **78** flat fields.

No runtime behaviour change — the removed bundle was read by nothing.

## Follow-up surfaced (not in this PR)

The "open welcome modal on first visit" mechanism in `useAppSessionUi` (state + effect + tests) has no UI consumer — it was only ever wired into this dead bundle. Either wire it to a modal or delete the half-feature; that's a product call, flagged here.

## Local bar

`tsc -b` · `lint` (49/50) · `lint:hooks` · `lint:css` · `check:architecture` 20/20 · client `vitest` 223 files / 1697 tests — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)