### PR TITLE
feat(scrubber): tighten the mid-match live pill — chip + no hover disc

### DIFF
--- a/client/src/modules/replay/MatchHistoryScrubber.css
+++ b/client/src/modules/replay/MatchHistoryScrubber.css
@@ -53,11 +53,11 @@
 }
 
 /*
- * Chevron steppers — circular, quiet until hovered. The button is a full
- * 44×44 tap target (mobile floor / reachability gate), but `background-clip`
- * + padding keep the visible chevron and its hover disc at ~30px so the strip
- * still reads at the 38px HUD-pill height. Same 44px-hit / smaller-visual
- * pattern the other pill buttons use.
+ * Chevron steppers — quiet until hovered, when only the glyph brightens
+ * (no hover disc — at the 44px tap size it spilled past the 38px pill edge).
+ * The button keeps a full 44×44 tap target (mobile floor / reachability gate);
+ * padding keeps the visible chevron small, and negative margins on the strip
+ * pull the tap boxes in so the pill stays tight around the readout.
  */
 .rh-scrubber-step.rh-btn {
   flex-shrink: 0;
@@ -66,30 +66,43 @@
   height: 44px;
   padding: 6px;
   border-radius: var(--radius-pill);
-  background-clip: content-box;
+  background: transparent;
   font-family: var(--font-display);
   font-size: 19px;
   line-height: 1;
   color: rgba(247, 226, 181, 0.42);
 }
 
-.rh-scrubber-step.rh-btn:hover:not(:disabled) {
+.rh-scrubber-step.rh-btn:hover:not(:disabled),
+.rh-scrubber-step.rh-btn:focus-visible:not(:disabled) {
   color: #f2dc9a;
-  background: rgba(231, 182, 74, 0.1);
+  background: transparent;
+}
+
+.rh-scrubber-step.rh-btn:first-child {
+  margin-right: -10px;
+}
+
+/* The forward chevron — second stepper, whether or not a back-to-live
+   button follows it — pulls in from the readout the same way. */
+.rh-scrubber-step.rh-btn ~ .rh-scrubber-step.rh-btn {
+  margin-left: -10px;
 }
 
 .rh-scrubber-readout {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 7px;
-  min-width: 62px;
-  padding: 0 6px;
+  gap: 6px;
+  min-width: 34px;
+  padding: 0 2px;
   font-variant-numeric: tabular-nums;
 }
 
 /* "Live" state — green pip + cream label, the way a broadcast marks "on air". */
 .rh-scrubber-readout--live {
+  min-width: 0;
+  padding: 0;
   font-size: 12.5px;
   font-weight: 800;
   letter-spacing: 0.17em;
@@ -145,19 +158,30 @@
   color: rgba(247, 226, 181, 0.48);
 }
 
-/* Return-to-live — gold-outlined circle with a corner count badge. */
+/*
+ * Return-to-live — a small "● LIVE" chip. It reads as the destination
+ * ("tap to go back to the live board"), and matches the green-pip + cream
+ * label the readout already uses for the live state, so the same signal
+ * means the same thing in both places. The "+N" is how many moves have
+ * landed since you stepped away.
+ */
 .rh-scrubber-live.rh-btn {
-  position: relative;
-  width: 30px;
-  min-width: 30px;
-  height: 30px;
-  margin-left: 3px;
-  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  width: auto;
+  min-width: 0;
+  height: 26px;
+  margin-left: 5px;
+  padding: 0 10px;
   border-radius: var(--radius-pill);
   border: 1px solid rgba(231, 182, 74, 0.5);
   background: rgba(231, 182, 74, 0.09);
   font-family: var(--font-display);
-  font-size: 16px;
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
   line-height: 1;
   color: #f2dc9a;
 }
@@ -167,22 +191,16 @@
   color: #f2dc9a;
 }
 
+/* Smaller than the readout's pip — it sits inside a chip, not the strip. */
+.rh-scrubber-live .rh-scrubber-dot {
+  width: 5px;
+  height: 5px;
+}
+
 .rh-scrubber-live-count {
-  position: absolute;
-  top: -4px;
-  right: -4px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 15px;
-  height: 15px;
-  padding: 0 3px;
-  border-radius: var(--radius-pill);
-  background: var(--tier-elite);
-  color: var(--bg-obsidian);
-  font-family: var(--font-display);
-  font-size: 9.5px;
-  font-weight: 800;
+  letter-spacing: 0.02em;
+  font-size: 10px;
+  font-weight: 700;
   font-variant-numeric: tabular-nums;
-  border: 1.5px solid var(--bg-obsidian);
+  color: rgba(247, 226, 181, 0.5);
 }

--- a/client/src/modules/replay/MatchHistoryScrubber.test.tsx
+++ b/client/src/modules/replay/MatchHistoryScrubber.test.tsx
@@ -55,7 +55,7 @@ describe('MatchHistoryScrubber', () => {
     expect(screen.queryByText(/Move 3/)).toBeNull();
     // Hand detail is carried on the readout's accessible name, not visible text.
     expect(screen.getByLabelText('Move 3 of 6, hand 2')).toBeTruthy();
-    expect(screen.getByText('3', { selector: '.rh-scrubber-live-count' })).toBeTruthy();
+    expect(screen.getByText('+3', { selector: '.rh-scrubber-live-count' })).toBeTruthy();
     expect(screen.getByLabelText('Back to live, 3 new moves')).toBeTruthy();
   });
 

--- a/client/src/modules/replay/MatchHistoryScrubber.tsx
+++ b/client/src/modules/replay/MatchHistoryScrubber.tsx
@@ -95,9 +95,12 @@ export function MatchHistoryScrubber({ scrubber }: MatchHistoryScrubberProps) {
           onClick={backToLive}
           aria-label={backToLiveLabel}
         >
-          <span aria-hidden="true">⟲</span>
+          <span className="rh-scrubber-dot" aria-hidden="true" />
+          <span>Live</span>
           {movesBehindLive > 0 ? (
-            <span className="rh-scrubber-live-count">{movesBehindLive}</span>
+            <span className="rh-scrubber-live-count" aria-hidden="true">
+              +{movesBehindLive}
+            </span>
           ) : null}
         </Button>
       ) : null}


### PR DESCRIPTION
## What

UI polish on the mid-match move-history scrubber (`MatchHistoryScrubber`), from an earlier session.

**Note on naming:** this is the *chip* iteration — a single tightened pill. The two-pill `‹ N/M ›` + `● LIVE` *split* was prototyped and **abandoned**; this branch is the state you signed off as "looked fine".

## Change (CSS + 7 lines of TSX)

- **Chevron hover disc removed.** The `‹` `›` steppers no longer paint a background on hover/focus — only the glyph brightens. At the 44px tap size the round hover fill spilled past the 38px pill edge and read as a bug. Tap targets stay 44×44.
- **Pill narrowed.** Readout `min-width` 62→34px, tighter gaps/padding, chevrons pulled in with negative margins so the pill hugs its content instead of carrying dead space.
- **"back to live" control**: circle-arrow `⟲` glyph → a **`● LIVE +N` chip** (green pip + "Live" + a dim `+N` moves-behind count). Reads as the destination; matches the green-pip treatment the live readout already uses.

No change to `useMatchHistoryScrubber` logic. Existing `MatchHistoryScrubber.test.tsx` updated for the `+N` text (was bare `N`).

## Local bar — all green

`tsc -b` · `lint` (49/50) · `lint:hooks` · `lint:css` · `check:deps` · `check:multiplayer-arch` · `check:multiplayer-cycles` · `check:socket-registry` · `check:architecture` 20/20 · client `vitest` 223 files / 1697 tests · client `build` + prerender · `size-check`.

`mid-match-scrubber.spec.ts` (the e2e that drives this component) is compatible: `Live` text still present, `Previous move` box still ≥44×44, `Move N of M` label and `Back to live` button name unchanged. Watch for the known `mid-match-scrubber.spec.ts:66` flake on CI (move-not-logged-in-45s) — rerun, not a real failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)