### PR TITLE
refactor(modes): drop orphaned daily / dailyPuzzleLeaderboard modes (audit §3 S7)

### DIFF
--- a/client/src/components/nav/appPrimaryTabs.ts
+++ b/client/src/components/nav/appPrimaryTabs.ts
@@ -25,8 +25,6 @@ export const APP_PRIMARY_TABS: AppPrimaryTab[] = [
       'ghostSetup',
       'dailyFritz',
       'dailyFritzLeaderboard',
-      'daily',
-      'dailyPuzzleLeaderboard',
     ],
   },
   {

--- a/client/src/home/components/HomeNextMoveBar.test.tsx
+++ b/client/src/home/components/HomeNextMoveBar.test.tsx
@@ -7,10 +7,10 @@ import { HomeNextMoveBar } from './HomeNextMoveBar';
 const actions: HomePrimaryAction[] = [
   { type: 'continue_tournament', title: 'Tournament Match', reason: 'Quarterfinal ready.', cta: 'Enter Match', route: 'tournament', priority: 90, expiresAt: null, tournamentId: 't1', matchId: 'm1' },
   { type: 'continue_daily_fritz', title: 'Continue Daily Fritz', reason: 'Game 2 is waiting.', cta: 'Continue', route: 'dailyFritz', priority: 70, expiresAt: null },
-  { type: 'continue_daily_puzzle', title: 'Continue Daily Puzzle', reason: 'Puzzle 2 is ready.', cta: 'Continue', route: 'daily', priority: 60, expiresAt: null },
+  { type: 'continue_daily_puzzle', title: 'Continue Daily Puzzle', reason: 'Puzzle 2 is ready.', cta: 'Continue', route: 'puzzleRush', priority: 60, expiresAt: null },
   { type: 'continue_lesson', title: 'Continue Learning', reason: 'Lesson 5 is waiting.', cta: 'Continue', route: 'journey', priority: 40, expiresAt: null, chapterId: 'chapter-5' },
   { type: 'play_daily_fritz', title: "Today's Race", reason: 'The series is ready.', cta: 'Play', route: 'dailyFritz', priority: 30, expiresAt: null },
-  { type: 'play_daily_puzzle', title: 'Daily Puzzle', reason: "Today's puzzle is ready.", cta: 'Play', route: 'daily', priority: 20, expiresAt: null },
+  { type: 'play_daily_puzzle', title: 'Daily Puzzle', reason: "Today's puzzle is ready.", cta: 'Play', route: 'puzzleRush', priority: 20, expiresAt: null },
   { type: 'challenge_online_rival', title: 'Challenge Maya', reason: 'Maya is online.', cta: 'Open Friends', route: 'friends', priority: 10, expiresAt: null, rivalId: 'maya' },
   { type: 'play_recommended_mode', title: 'Ready to play?', reason: 'Jump into Play vs Fritz.', cta: 'Play', route: 'singlePlayerHub', priority: 0, expiresAt: null },
 ];

--- a/client/src/home/homeActivityTimeline.ts
+++ b/client/src/home/homeActivityTimeline.ts
@@ -116,7 +116,7 @@ export function buildHomeActivityTimeline(
       occurredAt: null,
       priority: HOME_ACTIVITY_EVENT_PRIORITIES.daily_puzzle_started,
       source: 'daily_puzzle',
-      route: 'daily',
+      route: 'puzzleRush',
       status: 'active',
       payload: { score: puzzle.score, nextAvailableSlotIndex: puzzle.nextAvailableSlotIndex, runDate: puzzle.runDate },
     });
@@ -131,7 +131,7 @@ export function buildHomeActivityTimeline(
       occurredAt,
       priority: HOME_ACTIVITY_EVENT_PRIORITIES.daily_puzzle_completed,
       source: 'daily_puzzle',
-      route: 'daily',
+      route: 'puzzleRush',
       status: 'completed',
       payload: { score: puzzle.score, runDate: puzzle.runDate },
     });

--- a/client/src/home/homePersonalization.ts
+++ b/client/src/home/homePersonalization.ts
@@ -136,7 +136,7 @@ function secondaryModes(scores: ModeScores, primaryMode: HomePersonalizationPrim
   const routeFor: Record<HomePersonalizationPrimaryMode, HomePersonalization['secondaryModes'][number]> = {
     journey: 'journey',
     daily_fritz: 'dailyFritz',
-    daily_puzzle: 'daily',
+    daily_puzzle: 'puzzleRush',
     multiplayer: 'multiplayer',
     tournament: 'tournament',
     friends: 'friends',

--- a/client/src/home/homePrimaryAction.ts
+++ b/client/src/home/homePrimaryAction.ts
@@ -173,7 +173,7 @@ export function selectHomePrimaryAction(
         ? `Puzzle ${puzzleStarted.payload.nextAvailableSlotIndex} is ready.`
         : 'Your daily puzzle is in progress.',
       cta: 'Continue',
-      route: 'daily',
+      route: 'puzzleRush',
       priority: PRIORITY.continueDailyPuzzle,
       expiresAt: null,
       stableId: puzzleStarted.id,
@@ -223,7 +223,7 @@ export function selectHomePrimaryAction(
       title: 'Play Daily Puzzle',
       reason: 'Today’s three puzzles are ready.',
       cta: 'Play',
-      route: 'daily',
+      route: 'puzzleRush',
       priority: PRIORITY.playDailyPuzzle,
       expiresAt: null,
       stableId: `daily-puzzle:${puzzle.runDate ?? 'today'}`,

--- a/client/src/home/homeWelcomeBack.ts
+++ b/client/src/home/homeWelcomeBack.ts
@@ -112,7 +112,7 @@ export function calculateWelcomeBack(
       'Daily Puzzle complete',
       puzzleEvent.payload.score === null ? 'Your result is ready to review.' : `You scored ${puzzleEvent.payload.score} points.`,
       'puzzle',
-      'daily',
+      'puzzleRush',
     ));
   }
 

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -92,8 +92,6 @@ export type AppMode =
   | 'bot'
   | 'ghostSetup'
   | 'ghost'
-  | 'daily'
-  | 'dailyPuzzleLeaderboard'
   | 'dailyFritz'
   | 'dailyFritzLeaderboard'
   | 'puzzleRush'


### PR DESCRIPTION
## What

`FEATURE_COMPLETENESS_AUDIT.md` §3 **S7**. (Reopened from #164 — its base branch #162 was deleted on merge; rebased onto `main`.)

`daily` and `dailyPuzzleLeaderboard` were still in the `AppMode` union with **no branch in `AppRoutes.tsx`** — either would fall through to the childless `MultiplayerConnectionHost`, i.e. a blank screen. Currently unreachable, so latent — but the union advertised them, `APP_PRIMARY_TABS` listed them, and the home recommendation engine still emitted `route: 'daily'`.

## Change

- **`AppMode`** — removed both.
- **`APP_PRIMARY_TABS`** — removed both from the Single Player tab's `activeModes` (single table since S4 / #162).
- **`route: 'daily'` → `route: 'puzzleRush'`** in `homePrimaryAction`, `homeActivityTimeline`, `homePersonalization`, `homeWelcomeBack` + 2 `HomeNextMoveBar` fixtures.

## Decision — the home recommendation engine

`useHomeCommandCenter`'s `primaryAction` / `activityTimeline` / `personalization` / `momentum` / `welcomeBack` are **computed but rendered nowhere**. Kept as-is (self-contained, tested, off the render path); this PR only defuses its dead route values. If it's confirmed not planned, remove it wholesale in a dedicated cleanup.

## Not touched — needs the queued App.tsx session

*(now landed via S8 / #165)* — the `activeHomeMode` literal union's dead `'daily'` arm is removed there.

## Local bar

`tsc -b` · `lint` 49/50 · `lint:hooks` · `check:architecture` 20/20 · client `vitest` (home + nav + appRouteTypes suites) — green after rebase onto `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)