### PR TITLE
test(scrubber): mechanics → component test, e2e → smoke only

### DIFF
--- a/client/e2e/mid-match-scrubber.spec.ts
+++ b/client/e2e/mid-match-scrubber.spec.ts
@@ -1,11 +1,19 @@
 import { test, expect, type Page } from '@playwright/test';
 
 /**
- * Mid-match move-history scrubber (solo scope: Play vs Fritz).
+ * Mid-match move-history scrubber — e2e **smoke** only.
  *
- * Verifies the scrubber appears once a move is logged, steps into history
- * view-only, returns to live, and that its `< / >` controls meet the 44px
- * mobile tap-target minimum (docs/mid-match-move-scrubber-plan.md item 7).
+ * This proves the dock actually mounts in a real Play-vs-Fritz match once a
+ * move is logged, and that its "Previous move" control meets the 44px mobile
+ * tap-target minimum with real CSS applied (docs/mid-match-move-scrubber-plan.md
+ * item 7).
+ *
+ * The step-back / step-forward / back-to-live *mechanics* are covered
+ * deterministically in `client/src/modules/replay/MatchHistoryScrubber.test.tsx`
+ * ("integrated" describe) and `hooks/useMatchHistoryScrubber.test.ts` — they do
+ * not need a browser, and driving a second early Fritz move through the UI to
+ * enable "Previous move" was chronically flaky (see docs/scoping /
+ * ci-e2e-flakes).
  */
 
 test.describe.configure({ timeout: 90_000 });
@@ -32,27 +40,36 @@ async function startFritzMatch(page: Page) {
 }
 
 /**
- * Get one move into the log so the scrubber appears — resilient to who opens.
- * Fritz opens automatically ~half the time; the other half it is the player's
- * turn, and a placement zone only exists once a hand tile is selected. Poll
- * both paths rather than assuming one (CI is slower than local, so a fixed
- * "give Fritz N seconds then force the player move" race is not safe).
+ * Get one tile placement into the log so the scrubber dock appears — resilient
+ * to who opens. Fritz opens automatically ~half the time; the other half it is
+ * the player's turn, and a placement zone only exists once a hand tile is
+ * selected. Poll both paths (CI is slower than local, so a fixed "give Fritz N
+ * seconds then force the player move" race is not safe).
  */
 async function ensureFirstMoveLogged(page: Page) {
   const dock = page.locator('[data-ui="match-history-scrubber"]');
-  // A playable hand tile's accessible name is exactly "Domino N-N"; an
-  // unplayable one is "Domino N-N, not playable" — the `$` anchor excludes it.
+  // Accessible-name match: "Domino N-N" is playable; "Domino N-N, not playable"
+  // and "…, opponent's turn" are excluded by the `$` anchor.
   const playable = page
     .getByRole('group', { name: 'Your hand' })
     .getByRole('button', { name: /^Domino \d-\d$/ });
+  // CSS fallback — the playable-tile highlight class, per driving-a-match-in-playwright.
+  const playableCss = page
+    .locator('.hand-container .domino-tile.highlight:not(.disabled):not(.unplayable)')
+    .first();
   const zone = page.locator('.placement-zone.active').first();
 
-  const deadline = Date.now() + 45_000;
+  const deadline = Date.now() + 55_000;
   while (Date.now() < deadline) {
     if (await dock.isVisible().catch(() => false)) return;
-    // Our turn? Select a playable tile, drop it on the first legal zone.
-    if (await playable.first().isVisible().catch(() => false)) {
-      await playable.first().click({ force: true }).catch(() => {});
+
+    const tile = (await playable.first().isVisible().catch(() => false))
+      ? playable.first()
+      : (await playableCss.isVisible().catch(() => false))
+        ? playableCss
+        : null;
+    if (tile) {
+      await tile.click({ force: true }).catch(() => {});
       if (await zone.isVisible({ timeout: 3_000 }).catch(() => false)) {
         await zone.click({ force: true }).catch(() => {});
         await page.waitForTimeout(1_000);
@@ -63,7 +80,7 @@ async function ensureFirstMoveLogged(page: Page) {
   await expect(dock).toBeVisible({ timeout: 5_000 });
 }
 
-test('scrubber steps through history view-only and returns to live', async ({ page }) => {
+test('scrubber dock appears once a move is logged, with a 44px step control', async ({ page }) => {
   await startFritzMatch(page);
   await ensureFirstMoveLogged(page);
 
@@ -71,21 +88,16 @@ test('scrubber steps through history view-only and returns to live', async ({ pa
   await expect(dock).toBeVisible();
   await expect(dock.getByText('Live')).toBeVisible();
 
+  // The "< / >" steppers must meet the 44px mobile tap-target floor (real CSS).
   const prev = dock.getByLabel('Previous move');
   const box = await prev.boundingBox();
   expect(box, 'previous-move control has a measurable box').not.toBeNull();
   expect(box!.width).toBeGreaterThanOrEqual(44);
   expect(box!.height).toBeGreaterThanOrEqual(44);
 
-  await prev.click();
-  // The readout renders position/total as discrete spans; the "Move N of M"
-  // string is the accessible label, not visible prose.
-  await expect(dock.getByLabel(/Move \d+ of \d+/)).toBeVisible();
-
-  // Hand is view-only while parked in history: every hand tile is disabled.
-  await expect(page.locator('.hand-area .domino-tile:not(.disabled)')).toHaveCount(0);
-  await expect(page.locator('.hand-area .domino-tile.disabled').first()).toBeVisible();
-
-  await dock.getByRole('button', { name: /Back to live/ }).click();
-  await expect(dock.getByText('Live')).toBeVisible();
+  const next = dock.getByLabel('Next move');
+  const nextBox = await next.boundingBox();
+  expect(nextBox).not.toBeNull();
+  expect(nextBox!.width).toBeGreaterThanOrEqual(44);
+  expect(nextBox!.height).toBeGreaterThanOrEqual(44);
 });

--- a/client/src/modules/replay/MatchHistoryScrubber.test.tsx
+++ b/client/src/modules/replay/MatchHistoryScrubber.test.tsx
@@ -1,7 +1,10 @@
+import { useState } from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { MatchHistoryScrubber } from './MatchHistoryScrubber.tsx';
+import { useMatchHistoryScrubber } from './hooks/useMatchHistoryScrubber.ts';
 import type { MatchHistoryScrubberState } from './hooks/useMatchHistoryScrubber.ts';
+import type { MoveEntry } from '../../game/moveLogger.ts';
 
 function state(over: Partial<MatchHistoryScrubberState> = {}): MatchHistoryScrubberState {
   return {
@@ -82,5 +85,110 @@ describe('MatchHistoryScrubber', () => {
       />,
     );
     expect(screen.getByLabelText('Back to live, 1 new move')).toBeTruthy();
+  });
+});
+
+// ─── Integrated: the real component driving the real cursor hook ──────────────
+// This replaces what `e2e/mid-match-scrubber.spec.ts` used to prove by clicking
+// through a live Play-vs-Fritz match (flaky — see docs). The step / back-to-live
+// mechanics are deterministic and need no browser; the e2e now only smoke-checks
+// that the dock mounts in a real match.
+
+function placement(moveNumber: number, handNumber = 1): MoveEntry {
+  return {
+    moveNumber,
+    handNumber,
+    player: moveNumber % 2 === 1 ? 'you' : 'opponent',
+    action: 'place',
+    tile: [moveNumber % 7, (moveNumber + 1) % 7],
+    position: 'left',
+    boardEnds: [0, 0],
+    handBefore: [],
+    validMoves: [],
+    pipDelta: 0,
+    pointsScored: 0,
+    boardState: [],
+    boardRenderState: null,
+    handSnapshot: [],
+    engineBestMove: null,
+  } as MoveEntry;
+}
+
+function Harness({ initialMoves }: { initialMoves: number }) {
+  const [moveLog, setMoveLog] = useState<MoveEntry[]>(() =>
+    Array.from({ length: initialMoves }, (_, i) => placement(i + 1)),
+  );
+  const scrubber = useMatchHistoryScrubber(moveLog);
+  return (
+    <div>
+      <button type="button" onClick={() => setMoveLog((l) => [...l, placement(l.length + 1)])}>
+        land a move
+      </button>
+      <MatchHistoryScrubber scrubber={scrubber} />
+    </div>
+  );
+}
+
+describe('MatchHistoryScrubber ↔ useMatchHistoryScrubber (integrated)', () => {
+  it('starts live, steps back into history, and returns to live', () => {
+    render(<Harness initialMoves={5} />);
+
+    // Live: "Live" shown, previous enabled (5 placements), next disabled.
+    expect(screen.getByText('Live')).toBeTruthy();
+    expect(screen.getByLabelText('Previous move').hasAttribute('disabled')).toBe(false);
+    expect(screen.getByLabelText('Next move').hasAttribute('disabled')).toBe(true);
+
+    // Step back once → parked on the move before live (position 4 of 5).
+    fireEvent.click(screen.getByLabelText('Previous move'));
+    expect(screen.getByLabelText('Move 4 of 5, hand 1')).toBeTruthy();
+    expect(screen.getByRole('button', { name: /Back to live/ })).toBeTruthy();
+    expect(screen.queryByText('Live', { selector: '.rh-scrubber-readout--live' })).toBeNull();
+
+    // Step back again → position 3 of 5. Forward → back to 4 of 5.
+    fireEvent.click(screen.getByLabelText('Previous move'));
+    expect(screen.getByLabelText('Move 3 of 5, hand 1')).toBeTruthy();
+    fireEvent.click(screen.getByLabelText('Next move'));
+    expect(screen.getByLabelText('Move 4 of 5, hand 1')).toBeTruthy();
+
+    // Back to live → "Live" again, no back-to-live control.
+    fireEvent.click(screen.getByRole('button', { name: /Back to live/ }));
+    expect(screen.getByText('Live', { selector: '.rh-scrubber-readout--live' })).toBeTruthy();
+    expect(screen.queryByRole('button', { name: /Back to live/ })).toBeNull();
+  });
+
+  it('counts moves landing while parked without snapping away from history', () => {
+    render(<Harness initialMoves={4} />);
+    fireEvent.click(screen.getByLabelText('Previous move')); // park on 3 of 4
+    expect(screen.getByLabelText('Move 3 of 4, hand 1')).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'land a move' }));
+    fireEvent.click(screen.getByRole('button', { name: 'land a move' }));
+
+    // Still parked on the same move; the back-to-live control now reports 3 behind
+    // (was 1 when parked, +2 landed).
+    expect(screen.getByLabelText('Move 3 of 6, hand 1')).toBeTruthy();
+    expect(screen.getByLabelText('Back to live, 3 new moves')).toBeTruthy();
+  });
+
+  it('drops back to live when the log resets under the cursor', () => {
+    function ResetHarness() {
+      const [moveLog, setMoveLog] = useState<MoveEntry[]>(() =>
+        Array.from({ length: 5 }, (_, i) => placement(i + 1)),
+      );
+      const scrubber = useMatchHistoryScrubber(moveLog);
+      return (
+        <div>
+          <button type="button" onClick={() => setMoveLog([])}>reset</button>
+          <MatchHistoryScrubber scrubber={scrubber} />
+        </div>
+      );
+    }
+    render(<ResetHarness />);
+    fireEvent.click(screen.getByLabelText('Previous move'));
+    expect(screen.getByLabelText(/Move 4 of 5/)).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'reset' }));
+    // Empty log → the whole control unmounts.
+    expect(screen.queryByLabelText('Previous move')).toBeNull();
   });
 });


### PR DESCRIPTION
## What

`mid-match-scrubber.spec.ts` used to drive a live Play-vs-Fritz match to a **second** early tile placement (so "Previous move" enables), then click through step-back / step-forward / back-to-live. Landing that second move through the UI — opening-tile rules, guided-overlay force-clicks, waiting on Fritz's reply — was **chronically flaky**: it failed the CI e2e job on the unrelated PRs #159 / #160 / #165 / #167, and four helper rewrites this session topped out at ~70% pass in a local loop.

Per the earlier recommendation: the mechanics are deterministic and don't need a browser.

## Change

**`client/src/modules/replay/MatchHistoryScrubber.test.tsx`** — new `"integrated"` describe (3 cases): the real `useMatchHistoryScrubber` wired to the real `<MatchHistoryScrubber>` via a small harness, driven through:
- live → step back → parked ("Move 4 of 5") → step back again → step forward → back to live
- moves landing while parked bump the "N behind" count without snapping away from history
- a log reset under the cursor unmounts the control

(Cursor edge cases — clamping, draws-skipped, log-shrink — were already in `hooks/useMatchHistoryScrubber.test.ts` (17 cases); the `viewingHistory` → board-swap / hand-view-only decision in `resolveHistoryScrubberView.test.ts`.)

**`client/e2e/mid-match-scrubber.spec.ts`** — now a **smoke test**: one move logged → the dock mounts, shows "Live", and both `< / >` steppers measure ≥44×44 with real CSS applied (the one thing that genuinely needs a browser). It needs only **one** placement, so it's not subject to the two-move race. The tile-drive poll has a CSS-class fallback (`.hand-container .domino-tile.highlight:not(.disabled):not(.unplayable)`) alongside the accessible-name selector.

## Verification

- e2e smoke: **12/12 green** in a local `--repeat-each=12` loop, ~10s each.
- `MatchHistoryScrubber.test.tsx`: 9/9. Replay module: 36/36.
- Full client `vitest`: 226 files / 1710 tests. `tsc -b` · `lint` (49/50) · `lint:hooks` · `check:architecture` 20/20 — all green.

`ci-e2e-flakes` memory updated with the root cause (`getByRole('group', {name:'Your hand'})` returning 0 on the opening move against `BotHandTray` — unexplained, no user impact, now moot for the test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)