### PR TITLE
feat(stats): wire the Weekly Recap panel back to a real trigger

### DIFF
--- a/client/src/auth/useAppSessionUi.test.ts
+++ b/client/src/auth/useAppSessionUi.test.ts
@@ -74,7 +74,6 @@ describe('useAppSessionUi — initial state', () => {
     expect(result.current.authModalOpen).toBe(false);
     expect(result.current.usernameModalOpen).toBe(false);
     expect(result.current.signingOut).toBe(false);
-    expect(result.current.weeklyStatsOpen).toBe(false);
   });
 
   it('exposes setters for all modal state', () => {
@@ -85,7 +84,6 @@ describe('useAppSessionUi — initial state', () => {
     expect(typeof result.current.setAuthModalOpen).toBe('function');
     expect(typeof result.current.setUsernameModalOpen).toBe('function');
     expect(typeof result.current.setSigningOut).toBe('function');
-    expect(typeof result.current.setWeeklyStatsOpen).toBe('function');
     expect(typeof result.current.setOnboardingDismissed).toBe('function');
     expect(typeof result.current.setGhostOpponentName).toBe('function');
     expect(typeof result.current.setGhostOpponentUserId).toBe('function');

--- a/client/src/auth/useAppSessionUi.ts
+++ b/client/src/auth/useAppSessionUi.ts
@@ -32,8 +32,6 @@ export type UseAppSessionUiResult = {
   setUsernameModalOpen: React.Dispatch<React.SetStateAction<boolean>>;
   signingOut: boolean;
   setSigningOut: React.Dispatch<React.SetStateAction<boolean>>;
-  weeklyStatsOpen: boolean;
-  setWeeklyStatsOpen: React.Dispatch<React.SetStateAction<boolean>>;
   welcomeOpen: boolean;
   setWelcomeOpen: React.Dispatch<React.SetStateAction<boolean>>;
 };
@@ -48,10 +46,9 @@ export function useAppSessionUi(params: UseAppSessionUiParams): UseAppSessionUiR
   const [authModalOpen, setAuthModalOpen] = useState(false);
   const [usernameModalOpen, setUsernameModalOpen] = useState(false);
   const [signingOut, setSigningOut] = useState(false);
-  // welcomeOpen (set from the hasSeenWelcome flag below) and weeklyStatsOpen are
-  // exposed for a welcome / weekly-stats modal that has no UI consumer yet — they
-  // used to be routed through the unused `homeOverlays` route bundle (removed).
-  const [weeklyStatsOpen, setWeeklyStatsOpen] = useState(false);
+  // welcomeOpen is set from the hasSeenWelcome flag below but has no UI consumer
+  // yet (the first-visit welcome modal — a product decision). It used to be
+  // routed through the unused `homeOverlays` route bundle (removed in S8).
   const [welcomeOpen, setWelcomeOpen] = useState(false);
 
   const [onboardingDismissed, setOnboardingDismissed] = useState<boolean>(() => {
@@ -127,8 +124,6 @@ export function useAppSessionUi(params: UseAppSessionUiParams): UseAppSessionUiR
     setUsernameModalOpen,
     signingOut,
     setSigningOut,
-    weeklyStatsOpen,
-    setWeeklyStatsOpen,
     welcomeOpen,
     setWelcomeOpen,
   };

--- a/client/src/stats/StatsScreen.test.tsx
+++ b/client/src/stats/StatsScreen.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { act, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import type { User } from '@supabase/supabase-js';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createEmptyPlayerIdentityModel } from '../identity/playerIdentityNormalization';
@@ -10,6 +10,11 @@ const { identityState } = vi.hoisted(() => ({ identityState: { current: null as 
 vi.mock('../identity/usePlayerIdentityModel', () => ({ usePlayerIdentityModel: () => identityState.current }));
 // The page carries the site nav now rather than its own bare topbar.
 vi.mock('../components/GlobalNav', () => ({ GlobalNav: () => null }));
+// The recap panel is exercised in WeeklyStatsScreen.test.tsx; here we only
+// prove the trigger wiring.
+vi.mock('./WeeklyStatsScreen', () => ({
+  default: ({ open }: { open: boolean }) => (open ? <div role="dialog" aria-label="Weekly stats">recap</div> : null),
+}));
 
 function model(): PlayerIdentityModel {
   const base = createEmptyPlayerIdentityModel(100);
@@ -71,5 +76,12 @@ describe('StatsScreen normalized presentation', () => {
     // No longer a dialog: it is a route page with the site nav above it.
     expect(screen.queryByRole('dialog')).toBeNull();
     expect(screen.getByRole('main')).toHaveAttribute('aria-busy', 'true');
+  });
+
+  it('opens the Weekly Recap panel from its trigger', () => {
+    render(<StatsScreen {...props} />);
+    expect(screen.queryByRole('dialog', { name: 'Weekly stats' })).toBeNull();
+    fireEvent.click(screen.getByRole('button', { name: 'Weekly Recap' }));
+    expect(screen.getByRole('dialog', { name: 'Weekly stats' })).toBeTruthy();
   });
 });

--- a/client/src/stats/StatsScreen.tsx
+++ b/client/src/stats/StatsScreen.tsx
@@ -1,7 +1,10 @@
+import { useState } from 'react';
 import type { User } from '@supabase/supabase-js';
 import type { UserProfile } from '../auth/useAuth';
 import type { AppMode } from '../types';
 import { GlobalNav } from '../components/GlobalNav';
+import { Button } from '../components/primitives';
+import WeeklyStatsScreen from './WeeklyStatsScreen';
 import { usePlayerIdentityModel } from '../identity/usePlayerIdentityModel';
 import { DailyFritzPerformanceSection } from './components/DailyFritzPerformanceSection';
 import { FritzPerformanceSection } from './components/FritzPerformanceSection';
@@ -42,6 +45,7 @@ export default function StatsScreen({
   onOpenAuth,
   onSignOut,
 }: StatsScreenProps) {
+  const [weeklyRecapOpen, setWeeklyRecapOpen] = useState(false);
   const isUnsupportedPublicTarget = Boolean(targetUserId && targetUserId !== user?.id);
   const identityState = usePlayerIdentityModel({
     subjectUserId: targetUserId ?? user?.id ?? null,
@@ -96,6 +100,17 @@ export default function StatsScreen({
               {model && (
                 <>
                   <StatsIdentityHero username={username} competitive={model.competitive} />
+                  {model.subject.isCurrentUser && (
+                    <div className="rh-stats-actions">
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => setWeeklyRecapOpen(true)}
+                      >
+                        Weekly Recap
+                      </Button>
+                    </div>
+                  )}
                   <div className="rh-stats-grid">
                     <RankedPerformanceSection competitive={model.competitive} />
                     <FritzPerformanceSection fritz={model.fritz} />
@@ -113,6 +128,11 @@ export default function StatsScreen({
           )}
         </main>
       </div>
+      <WeeklyStatsScreen
+        open={weeklyRecapOpen}
+        onClose={() => setWeeklyRecapOpen(false)}
+        user={user}
+      />
     </div>
   );
 }

--- a/client/src/stats/WeeklyStatsScreen.test.tsx
+++ b/client/src/stats/WeeklyStatsScreen.test.tsx
@@ -1,0 +1,51 @@
+// @vitest-environment jsdom
+import { render, screen, waitFor } from '@testing-library/react';
+import type { User } from '@supabase/supabase-js';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import WeeklyStatsScreen from './WeeklyStatsScreen';
+import type { WeeklyRecap } from './statsApi';
+
+const { fetchWeeklyRecap } = vi.hoisted(() => ({ fetchWeeklyRecap: vi.fn() }));
+vi.mock('./statsApi', () => ({ fetchWeeklyRecap }));
+
+const user = { id: 'u1', email: 'maya@example.com' } as User;
+
+function recap(over: Partial<WeeklyRecap> = {}): WeeklyRecap {
+  return {
+    weekLabel: 'Sep 8 – Sep 14',
+    fritz: { gamesThisWeek: 3, ratingChangeThisWeek: 12, bestWinMarginThisWeek: 40 },
+    ghost: { gamesThisWeek: 1, ratingChangeThisWeek: -4, bestWinMarginThisWeek: 8 },
+    puzzle: { completionsThisWeek: 5, bestScoreToday: 1907 },
+    multiplayer: { gamesThisWeek: 2, wins: 1, losses: 1 },
+    ...over,
+  };
+}
+
+describe('WeeklyStatsScreen', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('does not fetch while closed', () => {
+    render(<WeeklyStatsScreen open={false} onClose={vi.fn()} user={user} />);
+    expect(fetchWeeklyRecap).not.toHaveBeenCalled();
+    // The overlay is present but hidden — no recap content, no loading state.
+    expect(screen.queryByText('Loading weekly recap...')).toBeNull();
+  });
+
+  it('fetches and renders the recap sections when opened', async () => {
+    fetchWeeklyRecap.mockResolvedValue({ data: recap(), error: null });
+    render(<WeeklyStatsScreen open onClose={vi.fn()} user={user} />);
+
+    await waitFor(() => expect(fetchWeeklyRecap).toHaveBeenCalledWith(user));
+    expect(await screen.findByText('Sep 8 – Sep 14')).toBeTruthy();
+    expect(screen.getByText('Fritz This Week')).toBeTruthy();
+    expect(screen.getByText('Multiplayer This Week')).toBeTruthy();
+    // A figure from the recap payload.
+    expect(screen.getByText('1907')).toBeTruthy();
+  });
+
+  it('shows an error state when the recap fetch fails', async () => {
+    fetchWeeklyRecap.mockResolvedValue({ data: null, error: 'Weekly recap unavailable right now.' });
+    render(<WeeklyStatsScreen open onClose={vi.fn()} user={user} />);
+    expect(await screen.findByText('Weekly recap unavailable right now.')).toBeTruthy();
+  });
+});

--- a/client/src/stats/statsScreen.css
+++ b/client/src/stats/statsScreen.css
@@ -181,6 +181,13 @@
 
 /* ── Mode cards ─────────────────────────────────────────────────── */
 
+.rh-stats-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-sm);
+  margin: calc(var(--space-sm) * -0.5) 0 var(--space-xs);
+}
+
 .rh-stats-grid {
   display: grid;
   grid-template-columns: 1fr;


### PR DESCRIPTION
## What

`WeeklyStatsScreen` is a maintained component — migrated to `useAsyncData` in #155, data from `fetchWeeklyRecap` → the live personal-stats-insights endpoint (same source `/stats` already uses). But **nothing has opened it** since the June 2026 App.tsx split dropped the old mode-select screen that held its trigger. `weeklyStatsOpen` state has sat dead in `useAppSessionUi` since S8 (#165) removed the `homeOverlays` bundle it was routed through.

Per the welcome-modal decision package: reviving it is cheap (data layer done) — only a trigger + render site were missing.

## Change

- **`/stats` gains a "Weekly Recap" button** (`Button variant="outline" size="sm"`, current-user only — `model.subject.isCurrentUser`, next to the identity hero) that opens `<WeeklyStatsScreen>` as its own overlay via local `StatsScreen` state. **No App.tsx plumbing.**
- **Removed** the now-genuinely-dead `weeklyStatsOpen` / `setWeeklyStatsOpen` from `useAppSessionUi` + its two test assertions. `welcomeOpen` stays — the first-visit welcome modal is a separate open product decision.
- New `WeeklyStatsScreen.test.tsx` (it had none): closed → no fetch; open → fetches + renders the recap sections + a payload figure; fetch error → error state.
- `StatsScreen.test.tsx`: the "Weekly Recap" trigger opens the panel.
- `statsScreen.css`: `.rh-stats-actions` row (tokens only).

`WeeklyStatsScreen`'s own markup/styles are unchanged — it's a self-contained `role="dialog"` overlay with its own backdrop + close button; the `.mode-inline-btn` class it uses is still defined (`home-hub.css`).

## Verification

- Full client `vitest`: 227 files / 1711 tests. `tsc -b` · `lint` (49/50) · `lint:hooks` · `lint:css` · `check:architecture` 20/20 — all green.
- `/stats` renders clean as a guest (no button — guard works); the signed-in trigger→open→fetch path is covered by tests (can't verify in-browser without QA credentials).

🤖 Generated with [Claude Code](https://claude.com/claude-code)