### PR TITLE
feat(welcome): first-visit welcome modal (Direction B)

### DIFF
--- a/client/e2e/daily-fritz-server-restore.spec.ts
+++ b/client/e2e/daily-fritz-server-restore.spec.ts
@@ -17,6 +17,8 @@ async function seedDailyFritzE2eAuth(context: BrowserContext, userId: string) {
     ({ userKey, bearerKey, userId: id, token }) => {
       window.localStorage.setItem(userKey, id);
       window.localStorage.setItem(bearerKey, token);
+      // Pre-dismiss the first-visit welcome modal (backdrop blocks the hub).
+      window.localStorage.setItem('hasSeenWelcome', '1');
     },
     {
       userKey: E2E_USER_ID_KEY,

--- a/client/e2e/daily-fritz-v2.spec.ts
+++ b/client/e2e/daily-fritz-v2.spec.ts
@@ -21,7 +21,7 @@ test.describe('Daily Fritz v2 official lifecycle',()=>{
   test.skip(!hasValidAuthState(authState),'A current authenticated Daily Fritz QA fixture is required');
   test('starts and resumes the exact official match snapshot',async({browser},testInfo)=>{
     test.setTimeout(90_000);
-    const context=await browser.newContext({storageState:authState,viewport:{width:1440,height:900}});const page=await context.newPage();const assertClean=runtimeGuard(page);
+    const context=await browser.newContext({storageState:authState,viewport:{width:1440,height:900}});await context.addInitScript(()=>window.localStorage.setItem('hasSeenWelcome','1'));const page=await context.newPage();const assertClean=runtimeGuard(page);
     try{
       await openDailyFritz(page);await page.screenshot({path:testInfo.outputPath('daily-fritz-pre-run.png'),fullPage:true});
       const action=page.locator('.df-pvf-start-btn');await expect(action).toBeEnabled();await action.click();

--- a/client/e2e/helpers/multiplayerMatch.ts
+++ b/client/e2e/helpers/multiplayerMatch.ts
@@ -50,6 +50,9 @@ export async function seedPlayerIdentity(context: BrowserContext, identity: E2EP
     ({ guestId, username, guestKey, nameKey }) => {
       window.localStorage.setItem(guestKey, guestId);
       window.localStorage.setItem(nameKey, username);
+      // Pre-dismiss the first-visit welcome modal — its backdrop would block
+      // every hub interaction in these self-built contexts.
+      window.localStorage.setItem('hasSeenWelcome', '1');
     },
     {
       guestId: identity.guestId,

--- a/client/e2e/spectator-mode.spec.ts
+++ b/client/e2e/spectator-mode.spec.ts
@@ -58,6 +58,9 @@ test.describe('Spectator Mode', () => {
   test('real Daily Fritz opt-in is discoverable and read-only over sockets', async ({ browser }, testInfo) => {
     const playerContext = await browser.newContext({ storageState: authState, viewport: { width: 1280, height: 720 } });
     const spectatorContext = await browser.newContext({ viewport: { width: 1440, height: 900 } });
+    for (const ctx of [playerContext, spectatorContext]) {
+      await ctx.addInitScript(() => window.localStorage.setItem('hasSeenWelcome', '1'));
+    }
     const player = await playerContext.newPage();
     const spectator = await spectatorContext.newPage();
     const assertPlayerClean = guardRuntime(player);

--- a/client/e2e/welcome-modal.spec.ts
+++ b/client/e2e/welcome-modal.spec.ts
@@ -1,0 +1,41 @@
+import { expect, test } from '@playwright/test';
+
+/**
+ * First-visit welcome modal (Direction B). Every other spec pre-dismisses it
+ * via the `hasSeenWelcome` flag seeded in playwright.config.ts; this one opts
+ * back out to exercise the real first-visit path.
+ */
+test.use({ storageState: { cookies: [], origins: [] } });
+
+test.describe('First-visit welcome modal', () => {
+  test('opens on first visit, routes a daily CTA, and stays dismissed', async ({ page }) => {
+    await page.goto('/');
+
+    const dialog = page.getByRole('dialog', { name: "Welcome. Here's today." });
+    await expect(dialog).toBeVisible({ timeout: 10_000 });
+    await expect(dialog.getByRole('button', { name: 'Play Daily Fritz' })).toBeVisible();
+    await expect(dialog.getByRole('button', { name: 'Play Daily Puzzles' })).toBeVisible();
+
+    await dialog.getByRole('button', { name: 'Play Daily Fritz' }).click();
+
+    await expect(page).toHaveURL(/\/daily-fritz$/);
+    await expect(dialog).toBeHidden();
+    expect(await page.evaluate(() => window.localStorage.getItem('hasSeenWelcome'))).toBe('1');
+
+    // Reload anywhere — the modal must not come back.
+    await page.goto('/');
+    await expect(page.getByRole('dialog', { name: "Welcome. Here's today." })).toBeHidden();
+  });
+
+  test('"Got it" dismisses without navigating', async ({ page }) => {
+    await page.goto('/');
+    const dialog = page.getByRole('dialog', { name: "Welcome. Here's today." });
+    await expect(dialog).toBeVisible({ timeout: 10_000 });
+
+    await dialog.getByRole('button', { name: 'Got it' }).click();
+
+    await expect(dialog).toBeHidden();
+    await expect(page).toHaveURL(/\/$/);
+    expect(await page.evaluate(() => window.localStorage.getItem('hasSeenWelcome'))).toBe('1');
+  });
+});

--- a/client/playwright.config.ts
+++ b/client/playwright.config.ts
@@ -14,6 +14,22 @@ const CLIENT_PORT = REACHABILITY ? 5233 : 5173;
 const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? `http://localhost:${CLIENT_PORT}`;
 const PHONE = { width: 390, height: 844 } as const;
 
+// The first-visit welcome modal (useAppSessionUi → welcomeOpen) renders a
+// full-screen backdrop that intercepts pointer events until dismissed. Every
+// spec that isn't specifically exercising it wants it pre-dismissed; seed the
+// `hasSeenWelcome` flag into the default context's storage. Specs that build
+// their own `browser.newContext()` seed it themselves (see
+// helpers/multiplayerMatch.ts). `welcome-modal.spec.ts` opts back out.
+const WELCOME_DISMISSED = {
+  cookies: [],
+  origins: [
+    {
+      origin: `http://localhost:${CLIENT_PORT}`,
+      localStorage: [{ name: 'hasSeenWelcome', value: '1' }],
+    },
+  ],
+};
+
 export default defineConfig({
   testDir: './e2e',
   // Aborts the run if the client dev server is serving stale config (issue
@@ -28,6 +44,7 @@ export default defineConfig({
     baseURL,
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
+    storageState: WELCOME_DISMISSED,
   },
   projects: [
     {

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -21,6 +21,7 @@ import { useSocketConnectionState } from './multiplayer/useSocketConnectionState
 import { useMultiplayerRoomSocialRuntimeBridge } from './multiplayer/useMultiplayerLobbyController';
 import { useMultiplayerLobbyHostProps } from './multiplayer/useMultiplayerLobbyHostProps';
 import { AuthModalsLayer, MultiplayerShellErrorFallback } from './AppOverlays';
+import { WelcomeModal } from './components/WelcomeModal';
 import { MultiplayerGameShell } from './multiplayer/MultiplayerGameShell';
 import { AppRoutesGamePropsHost } from './multiplayer/AppRoutesGamePropsHost';
 import type { MultiplayerShellDelegates } from './multiplayer/multiplayerGameShellTypes';
@@ -191,6 +192,8 @@ export default function App() {
     setUsernameModalOpen,
     signingOut,
     setSigningOut,
+    welcomeOpen,
+    setWelcomeOpen,
   } = useAppSessionUi({ authUser: authUser ? { id: authUser.id, email: authUser.email ?? '' } : null, authProfile, authLoading, justVerified, showToast });
 
   // Single tournament hook instance, shared by Hub/Bracket/Result screens.
@@ -810,7 +813,25 @@ export default function App() {
     [handleSignOut, setAppMode],
   );
 
+  const dismissWelcome = useCallback(() => {
+    try {
+      window.localStorage.setItem('hasSeenWelcome', '1');
+    } catch {
+      // private-mode / storage-disabled — the modal just reopens next visit
+    }
+    setWelcomeOpen(false);
+  }, [setWelcomeOpen]);
+
   const authModalsLayer = (
+    <>
+    <WelcomeModal
+      open={welcomeOpen}
+      onDismiss={dismissWelcome}
+      onNavigate={(mode) => {
+        dismissWelcome();
+        setAppMode(mode);
+      }}
+    />
     <AuthModalsLayer
       authModalOpen={authModalOpen}
       supabaseEnabled={supabaseEnabled}
@@ -836,6 +857,7 @@ export default function App() {
       onUsernameSignOut={handleSignOut}
       signingOut={signingOut}
     />
+    </>
   );
 
   const multiplayerLobbyHostProps = useMultiplayerLobbyHostProps({

--- a/client/src/components/WelcomeModal.css
+++ b/client/src/components/WelcomeModal.css
@@ -1,0 +1,73 @@
+.rh-welcome-lede {
+  margin: 0 0 20px;
+  font-family: var(--font-body);
+  font-size: 15px;
+  line-height: 1.5;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.rh-welcome-modes {
+  list-style: none;
+  margin: 0 0 22px;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.rh-welcome-modes li {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  padding: 12px 14px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: var(--radius-control);
+  background: rgba(10, 16, 28, 0.5);
+}
+
+.rh-welcome-mode-name {
+  font-family: var(--font-display);
+  font-size: 15px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.95);
+}
+
+.rh-welcome-mode-desc {
+  font-family: var(--font-body);
+  font-size: 13px;
+  line-height: 1.45;
+  color: rgba(255, 255, 255, 0.55);
+}
+
+.rh-welcome-cta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-bottom: 20px;
+}
+
+.rh-welcome-cta .rh-btn {
+  flex: 1 1 180px;
+}
+
+.rh-welcome-more {
+  margin: 0 0 18px;
+  padding-top: 16px;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  font-family: var(--font-body);
+  font-size: 12.5px;
+  line-height: 1.5;
+  color: rgba(255, 255, 255, 0.4);
+}
+
+.rh-welcome-more-label {
+  color: rgba(255, 255, 255, 0.6);
+  font-weight: 600;
+}
+
+.rh-welcome-dismiss {
+  display: flex;
+  justify-content: flex-end;
+}

--- a/client/src/components/WelcomeModal.test.tsx
+++ b/client/src/components/WelcomeModal.test.tsx
@@ -1,0 +1,39 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { WelcomeModal } from './WelcomeModal';
+
+const noop = () => {};
+
+describe('WelcomeModal', () => {
+  it('renders nothing when closed', () => {
+    render(<WelcomeModal open={false} onDismiss={noop} onNavigate={noop} />);
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('shows the Direction B lineup when open', () => {
+    render(<WelcomeModal open onDismiss={noop} onNavigate={noop} />);
+    expect(screen.getByRole('dialog', { name: "Welcome. Here's today." })).toBeInTheDocument();
+    expect(screen.getByText('Daily Fritz')).toBeInTheDocument();
+    expect(screen.getByText('Daily Puzzles')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Play Daily Fritz' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Play Daily Puzzles' })).toBeInTheDocument();
+  });
+
+  it('routes each daily CTA to its mode', () => {
+    const onNavigate = vi.fn();
+    render(<WelcomeModal open onDismiss={noop} onNavigate={onNavigate} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Play Daily Fritz' }));
+    expect(onNavigate).toHaveBeenCalledWith('dailyFritz');
+    fireEvent.click(screen.getByRole('button', { name: 'Play Daily Puzzles' }));
+    expect(onNavigate).toHaveBeenCalledWith('puzzleRush');
+  });
+
+  it('dismisses from "Got it" and from the close control', () => {
+    const onDismiss = vi.fn();
+    render(<WelcomeModal open onDismiss={onDismiss} onNavigate={noop} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Got it' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }));
+    expect(onDismiss).toHaveBeenCalledTimes(2);
+  });
+});

--- a/client/src/components/WelcomeModal.tsx
+++ b/client/src/components/WelcomeModal.tsx
@@ -1,0 +1,69 @@
+import { Button, Modal } from './primitives';
+import type { AppMode } from '../types';
+import './WelcomeModal.css';
+
+interface WelcomeModalProps {
+  open: boolean;
+  /** Dismiss without picking a mode (✕, backdrop, Escape, "Got it"). */
+  onDismiss: () => void;
+  /** Pick a daily challenge — the caller dismisses and navigates. */
+  onNavigate: (mode: AppMode) => void;
+}
+
+/**
+ * First-visit welcome — "Direction B" (start with today).
+ *
+ * The home screen already leads with the two daily cards; this leans in: a
+ * brand-new player's first action is one of today's challenges, and everything
+ * else is a one-line "when you want more" list pointing at the tabs.
+ *
+ * Wired to `useAppSessionUi`'s `welcomeOpen` / `hasSeenWelcome` — see App.tsx.
+ * Copy is `docs/scoping/welcome-modal-copy-drafts-2026-09-10.md` Direction B.
+ */
+export function WelcomeModal({ open, onDismiss, onNavigate }: WelcomeModalProps) {
+  return (
+    <Modal open={open} onClose={onDismiss} title="Welcome. Here's today." maxWidth={460}>
+      <p className="rh-welcome-lede">
+        Racehorse is built around two daily challenges — start with one, and your
+        streak begins.
+      </p>
+
+      <ul className="rh-welcome-modes">
+        <li>
+          <span className="rh-welcome-mode-name">Daily Fritz</span>
+          <span className="rh-welcome-mode-desc">Best-of-3 against the bot. ~5 minutes.</span>
+        </li>
+        <li>
+          <span className="rh-welcome-mode-name">Daily Puzzles</span>
+          <span className="rh-welcome-mode-desc">
+            Solve as many as you can before the clock runs out.
+          </span>
+        </li>
+      </ul>
+
+      <div className="rh-welcome-cta">
+        <Button variant="tier-elite" onClick={() => onNavigate('dailyFritz')}>
+          Play Daily Fritz
+        </Button>
+        <Button variant="tier-standard" onClick={() => onNavigate('puzzleRush')}>
+          Play Daily Puzzles
+        </Button>
+      </div>
+
+      <p className="rh-welcome-more">
+        <span className="rh-welcome-more-label">When you want more:</span> full
+        matches vs Fritz or a Ghost of your own game · live Multiplayer and
+        Tournaments · the Journey campaign · rules and coached games under Learn.
+        All from the tabs below.
+      </p>
+
+      <div className="rh-welcome-dismiss">
+        <Button variant="ghost" size="sm" onClick={onDismiss}>
+          Got it
+        </Button>
+      </div>
+    </Modal>
+  );
+}
+
+export default WelcomeModal;


### PR DESCRIPTION
## What

Wires the long-dormant `welcomeOpen` / `hasSeenWelcome` state in `useAppSessionUi` to a real first-visit modal. Approved **Direction B** ("start with today") from `docs/scoping/welcome-modal-copy-drafts-2026-09-10.md`.

A brand-new player's first action is one of the two daily challenges; everything else is one line of orientation pointing at the tabs.

## Changes

- `components/WelcomeModal.tsx` + scoped `WelcomeModal.css` — built on the `Modal` / `Button` primitives, tier-elite / tier-standard CTAs, tokens only.
- `App.tsx` — rendered inside `authModalsLayer`. Dismiss (✕ / backdrop / Escape / "Got it") writes `hasSeenWelcome` and closes; each daily CTA dismisses then `setAppMode('dailyFritz' | 'puzzleRush')`.
- `WelcomeModal.test.tsx` — closed renders nothing, open shows the lineup, CTAs route to the right mode, both dismiss paths fire `onDismiss`.

## Verification

- `tsc -b` clean
- `vitest run src/components` + `src/auth/useAppSessionUi.test.ts` green
- lint within budget (49/50 warnings; only pre-existing `max-lines` on `App.tsx`)

Screenshot to follow in the thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JSNbHAMoP1ap8CNpxEBxmC