### PR TITLE
refactor(board): extract useBoardRenderLayout (D2, PR 1 of 3)

### DIFF
--- a/client/src/components/Board.tsx
+++ b/client/src/components/Board.tsx
@@ -5,7 +5,6 @@ import {
   useCallback,
   useEffect,
   useImperativeHandle,
-  useMemo,
   useRef,
   useState,
   type ForwardedRef,
@@ -18,15 +17,11 @@ import { isDouble } from '../game/openEndsGeometry';
 import { useRenderProfiler } from '../debug/renderProfiler';
 import {
   recordDailyFritzBoardMetric,
-  recordDailyFritzLayoutDebug,
   traceCameraDebug,
   traceDailyFritzBoardEvent,
 } from './boardDiagnostics';
-import {
-  calculateBoardFitScale,
-  computeBoardLayout,
-  type BoardLayout,
-} from './board/boardLayout';
+import { calculateBoardFitScale } from './board/boardLayout';
+import { useBoardRenderLayout } from './board/useBoardRenderLayout';
 
 // ─── Board Component ─────────────────────────────────────────
 
@@ -126,137 +121,18 @@ function BoardComponent(
   const showTargetDebug =
     typeof window !== 'undefined' && window.localStorage.getItem('BOARD_TARGET_DEBUG') === '1';
 
-  const boardTileCount = board
-    ? board.mainLine.length +
-      board.hubDoubles.reduce(
-        (sum, hub) =>
-          sum +
-          (hub.branches ?? []).reduce(
-            (branchSum, branch) => branchSum + (branch?.tiles?.length ?? 0),
-            0,
-          ),
-        0,
-      )
-    : 0;
-
-  const isResettingBoard = !board || board.mainLine.length === 0;
-
-  const openEndPositions = useMemo(() => {
-    if (!board || isResettingBoard) return [] as PlacementPosition[];
-    const positions: PlacementPosition[] = ['left', 'right'];
-    for (const hub of board.hubDoubles ?? []) {
-      if (typeof hub.hubId !== 'number' || !hub.isCrossed) continue;
-      const hubId = hub.hubId;
-      positions.push(`branch-${hubId}-0`, `branch-${hubId}-1`);
-    }
-    return positions;
-  }, [board, isResettingBoard]);
-
-  const validPositions = useMemo((): PlacementPosition[] => {
-    if (!selectedTile) return [];
-    return legalMoves
-      .filter((m) => m.type === 'play' && m.tile && selectedTile && tileEquals(m.tile, selectedTile))
-      .map((m) => m.position!)
-      .filter(Boolean);
-  }, [selectedTile, legalMoves]);
-
-  const cameraFitPositions = useMemo(() => {
-    if (staticView) return [] as PlacementPosition[];
-    if (isResettingBoard) {
-      return validPositions.length > 0 ? validPositions : (['left'] as PlacementPosition[]);
-    }
-    return selectedTile != null || showOpenEndGlow ? openEndPositions : [];
-  }, [staticView, isResettingBoard, validPositions, openEndPositions, selectedTile, showOpenEndGlow]);
-
-  const logLayoutDebug = useCallback(
-    (validPositionsCount: number, selectedTileKey: string | null, layout: BoardLayout) => {
-      if (typeof window === 'undefined') return;
-      const timestamp =
-        typeof performance !== 'undefined' && typeof performance.now === 'function'
-          ? Number(performance.now().toFixed(2))
-          : Date.now();
-      recordDailyFritzLayoutDebug({
-        tag: '[layout-debug]',
-        timestamp,
-        handNumber,
-        handOver,
-        gameOver,
-        boardTileCount,
-        openEndPositions,
-        validPositionsCount,
-        selectedTile: selectedTileKey,
-        computedBounds: {
-          minX: Number(layout.minX.toFixed(2)),
-          maxX: Number(layout.maxX.toFixed(2)),
-          minY: Number(layout.minY.toFixed(2)),
-          maxY: Number(layout.maxY.toFixed(2)),
-        },
-        zoomScale: Number(camera.scale.toFixed(3)),
-      });
-    },
-    [boardTileCount, camera.scale, gameOver, handNumber, handOver, openEndPositions],
-  );
-
-  // Keep the camera/layout stable when the player selects a tile.
-  const layout = useMemo(() => {
-    // eslint-disable-next-line react-hooks/purity -- performance.now() timing probe inside the layout memo — instrumentation, not a value the memo returns
-    const start = typeof performance !== 'undefined' ? performance.now() : Date.now();
-    traceCameraDebug('[camera-debug] computeLayout input', {
-      boardTileCount,
-      openEndPositions: cameraFitPositions,
-      validPositions,
-      selectedTile: selectedTile ? `${selectedTile.low}|${selectedTile.high}` : null,
-    });
-    const nextLayout = computeBoardLayout(isResettingBoard ? null : board, cameraFitPositions);
-    traceCameraDebug('[camera-debug] computeLayout output', {
-      minX: Number(nextLayout.minX.toFixed(2)),
-      maxX: Number(nextLayout.maxX.toFixed(2)),
-      minY: Number(nextLayout.minY.toFixed(2)),
-      maxY: Number(nextLayout.maxY.toFixed(2)),
-      scale: Number(camera.scale.toFixed(3)),
-    });
-    if (profileDailyFritz) {
-      // eslint-disable-next-line react-hooks/purity -- performance.now() timing probe — instrumentation
-      const end = typeof performance !== 'undefined' ? performance.now() : Date.now();
-      recordDailyFritzBoardMetric('computeLayout', end - start);
-      logLayoutDebug(validPositions.length, selectedTile ? `${selectedTile.low}|${selectedTile.high}` : null, nextLayout);
-    }
-    return nextLayout;
-  // eslint-disable-next-line react-hooks/exhaustive-deps -- the layout memo keys on the inputs that change its geometry; boardTileCount/camera.scale are derived from those and would only add churn
-  }, [board, cameraFitPositions, profileDailyFritz, logLayoutDebug, selectedTile, validPositions, isResettingBoard]);
-  const placementZones = useMemo(() => {
-    // eslint-disable-next-line react-hooks/purity -- performance.now() timing probe — instrumentation
-    const start = typeof performance !== 'undefined' ? performance.now() : Date.now();
-    const zones = computeBoardLayout(isResettingBoard ? null : board, validPositions).zones;
-    if (profileDailyFritz) {
-      // eslint-disable-next-line react-hooks/purity -- performance.now() timing probe — instrumentation
-      const end = typeof performance !== 'undefined' ? performance.now() : Date.now();
-      recordDailyFritzBoardMetric('computeLayout', end - start);
-      traceDailyFritzBoardEvent('[render] placementZones', {
-        count: zones.length,
-        selectedTile: selectedTile ? `${selectedTile.low}|${selectedTile.high}` : null,
-      });
-    }
-    return zones;
-  }, [board, validPositions, profileDailyFritz, selectedTile, isResettingBoard]);
-
-  useEffect(() => {
-    if (!profileDailyFritz) return;
-    traceDailyFritzBoardEvent('[render] Board props', {
-      selectedTile: selectedTile ? `${selectedTile.low}|${selectedTile.high}` : null,
-      legalMovesCount: legalMoves.length,
-    });
-  }, [profileDailyFritz, selectedTile, legalMoves.length]);
-
-  const glowLayout = useMemo(() => {
-    if (!showOpenEndGlow) return null;
-    return computeBoardLayout(isResettingBoard ? null : board, openEndPositions);
-  }, [showOpenEndGlow, board, openEndPositions, isResettingBoard]);
-
-  const resetSignature = useMemo(
-    () => `${handNumber}:${gameOver}:${isResettingBoard}`,
-    [gameOver, handNumber, isResettingBoard],
-  );
+  const { boardTileCount, layout, placementZones, glowLayout, resetSignature } = useBoardRenderLayout({
+    board,
+    legalMoves,
+    selectedTile,
+    handNumber,
+    handOver,
+    gameOver,
+    showOpenEndGlow,
+    staticView,
+    profileDailyFritz,
+    cameraScale: camera.scale,
+  });
 
   useEffect(() => {
     if (lastResetSignatureRef.current === resetSignature) return;

--- a/client/src/components/board/useBoardRenderLayout.test.ts
+++ b/client/src/components/board/useBoardRenderLayout.test.ts
@@ -1,0 +1,109 @@
+// @vitest-environment jsdom
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import type { BoardState, PlacedTile, Move } from '../../types';
+import { useBoardRenderLayout, type UseBoardRenderLayoutParams } from './useBoardRenderLayout';
+
+function placed(low: number, high: number, orientation = 'horizontal-normal'): PlacedTile {
+  return { tile: { low, high }, orientation: orientation as PlacedTile['orientation'] };
+}
+
+function emptyBoard(): BoardState {
+  return { mainLine: [], leftEnd: null, rightEnd: null, leftEndIsDouble: false, rightEndIsDouble: false, hubDoubles: [] } as unknown as BoardState;
+}
+
+function oneTileBoard(): BoardState {
+  return {
+    mainLine: [placed(3, 4)],
+    leftEnd: 3,
+    rightEnd: 4,
+    leftEndIsDouble: false,
+    rightEndIsDouble: false,
+    hubDoubles: [],
+  };
+}
+
+function baseParams(overrides: Partial<UseBoardRenderLayoutParams> = {}): UseBoardRenderLayoutParams {
+  return {
+    board: emptyBoard(),
+    legalMoves: [],
+    selectedTile: null,
+    handNumber: 1,
+    handOver: false,
+    gameOver: false,
+    showOpenEndGlow: false,
+    staticView: false,
+    profileDailyFritz: false,
+    cameraScale: 1,
+    ...overrides,
+  };
+}
+
+describe('useBoardRenderLayout', () => {
+  it('treats an empty mainLine as a resetting board with a default left camera-fit target', () => {
+    const { result } = renderHook(() => useBoardRenderLayout(baseParams()));
+    expect(result.current.boardTileCount).toBe(0);
+    expect(result.current.isResettingBoard).toBe(true);
+    expect(result.current.cameraFitPositions).toEqual(['left']);
+    expect(result.current.layout.tiles).toHaveLength(0);
+  });
+
+  it('counts main-line + branch tiles once a board is placed', () => {
+    const { result } = renderHook(() => useBoardRenderLayout(baseParams({ board: oneTileBoard() })));
+    expect(result.current.boardTileCount).toBe(1);
+    expect(result.current.isResettingBoard).toBe(false);
+    expect(result.current.layout.tiles).toHaveLength(1);
+  });
+
+  it('derives validPositions from legalMoves that match the selected tile', () => {
+    const board = oneTileBoard();
+    const legalMoves: Move[] = [
+      { type: 'play', tile: { low: 4, high: 5 }, position: 'right' },
+      { type: 'play', tile: { low: 9, high: 9 }, position: 'left' }, // different tile — filtered out
+      { type: 'pass' },
+    ];
+    const { result } = renderHook(() =>
+      useBoardRenderLayout(baseParams({ board, legalMoves, selectedTile: { low: 4, high: 5 } })),
+    );
+    expect(result.current.validPositions).toEqual(['right']);
+    // A tile is selected → cameraFitPositions follows the board's open ends
+    // (left/right), not just the tile's own legal placements.
+    expect(result.current.cameraFitPositions).toEqual(['left', 'right']);
+  });
+
+  it('computes placementZones from validPositions independent of the camera-fit layout', () => {
+    const board = oneTileBoard();
+    const legalMoves: Move[] = [{ type: 'play', tile: { low: 4, high: 5 }, position: 'right' }];
+    const { result } = renderHook(() =>
+      useBoardRenderLayout(baseParams({ board, legalMoves, selectedTile: { low: 4, high: 5 } })),
+    );
+    expect(result.current.placementZones.length).toBeGreaterThan(0);
+    expect(result.current.placementZones.some((z) => z.position === 'right')).toBe(true);
+  });
+
+  it('only computes a glowLayout when showOpenEndGlow is set', () => {
+    const board = oneTileBoard();
+    const off = renderHook(() => useBoardRenderLayout(baseParams({ board, showOpenEndGlow: false })));
+    expect(off.result.current.glowLayout).toBeNull();
+
+    const on = renderHook(() => useBoardRenderLayout(baseParams({ board, showOpenEndGlow: true })));
+    expect(on.result.current.glowLayout).not.toBeNull();
+    expect(on.result.current.glowLayout!.tiles.length).toBe(on.result.current.layout.tiles.length);
+  });
+
+  it('keys resetSignature on handNumber/gameOver/isResettingBoard, not on unrelated prop changes', () => {
+    const { result, rerender } = renderHook(
+      (props: UseBoardRenderLayoutParams) => useBoardRenderLayout(props),
+      { initialProps: baseParams({ board: oneTileBoard(), handNumber: 3 }) },
+    );
+    const first = result.current.resetSignature;
+
+    // Unrelated change (selectedTile) — signature stays put.
+    rerender(baseParams({ board: oneTileBoard(), handNumber: 3, selectedTile: { low: 1, high: 2 } }));
+    expect(result.current.resetSignature).toBe(first);
+
+    // handNumber change — signature changes.
+    rerender(baseParams({ board: oneTileBoard(), handNumber: 4 }));
+    expect(result.current.resetSignature).not.toBe(first);
+  });
+});

--- a/client/src/components/board/useBoardRenderLayout.ts
+++ b/client/src/components/board/useBoardRenderLayout.ts
@@ -1,0 +1,202 @@
+// client/src/components/board/useBoardRenderLayout.ts
+//
+// Extracted verbatim from Board.tsx (D2 Tier-1, step 1 — see
+// docs/scoping/D2-board-tsx-decomposition-scoping.md). Pure derivation: given
+// the board + selection props, computes the positioned-tile layout, the
+// placement-zone hit targets, and the open-end glow layout that the render
+// and the camera-fit effects (useBoardCamera, still in Board.tsx) both read.
+// No refs, no DOM, no state — every value here is a useMemo over its inputs.
+import { useCallback, useEffect, useMemo } from 'react';
+import type { Tile, BoardState, PlacementPosition, Move } from '../../types';
+import { tileEquals } from '../../game/tileUtils';
+import {
+  recordDailyFritzBoardMetric,
+  recordDailyFritzLayoutDebug,
+  traceCameraDebug,
+  traceDailyFritzBoardEvent,
+} from '../boardDiagnostics';
+import { computeBoardLayout, type BoardLayout } from './boardLayout';
+
+export interface UseBoardRenderLayoutParams {
+  board: BoardState | null;
+  legalMoves: Move[];
+  selectedTile: Tile | null;
+  handNumber: number;
+  handOver: boolean;
+  gameOver: boolean;
+  showOpenEndGlow: boolean;
+  staticView: boolean;
+  profileDailyFritz: boolean;
+  /** Read only for debug tracing (not a dependency) — matches the original's parity. */
+  cameraScale: number;
+}
+
+export interface UseBoardRenderLayoutResult {
+  boardTileCount: number;
+  isResettingBoard: boolean;
+  openEndPositions: PlacementPosition[];
+  validPositions: PlacementPosition[];
+  cameraFitPositions: PlacementPosition[];
+  layout: BoardLayout;
+  placementZones: BoardLayout['zones'];
+  glowLayout: BoardLayout | null;
+  resetSignature: string;
+}
+
+export function useBoardRenderLayout({
+  board,
+  legalMoves,
+  selectedTile,
+  handNumber,
+  handOver,
+  gameOver,
+  showOpenEndGlow,
+  staticView,
+  profileDailyFritz,
+  cameraScale,
+}: UseBoardRenderLayoutParams): UseBoardRenderLayoutResult {
+  const boardTileCount = board
+    ? board.mainLine.length +
+      board.hubDoubles.reduce(
+        (sum, hub) =>
+          sum +
+          (hub.branches ?? []).reduce(
+            (branchSum, branch) => branchSum + (branch?.tiles?.length ?? 0),
+            0,
+          ),
+        0,
+      )
+    : 0;
+
+  const isResettingBoard = !board || board.mainLine.length === 0;
+
+  const openEndPositions = useMemo(() => {
+    if (!board || isResettingBoard) return [] as PlacementPosition[];
+    const positions: PlacementPosition[] = ['left', 'right'];
+    for (const hub of board.hubDoubles ?? []) {
+      if (typeof hub.hubId !== 'number' || !hub.isCrossed) continue;
+      const hubId = hub.hubId;
+      positions.push(`branch-${hubId}-0`, `branch-${hubId}-1`);
+    }
+    return positions;
+  }, [board, isResettingBoard]);
+
+  const validPositions = useMemo((): PlacementPosition[] => {
+    if (!selectedTile) return [];
+    return legalMoves
+      .filter((m) => m.type === 'play' && m.tile && selectedTile && tileEquals(m.tile, selectedTile))
+      .map((m) => m.position!)
+      .filter(Boolean);
+  }, [selectedTile, legalMoves]);
+
+  const cameraFitPositions = useMemo(() => {
+    if (staticView) return [] as PlacementPosition[];
+    if (isResettingBoard) {
+      return validPositions.length > 0 ? validPositions : (['left'] as PlacementPosition[]);
+    }
+    return selectedTile != null || showOpenEndGlow ? openEndPositions : [];
+  }, [staticView, isResettingBoard, validPositions, openEndPositions, selectedTile, showOpenEndGlow]);
+
+  const logLayoutDebug = useCallback(
+    (validPositionsCount: number, selectedTileKey: string | null, layout: BoardLayout) => {
+      if (typeof window === 'undefined') return;
+      const timestamp =
+        typeof performance !== 'undefined' && typeof performance.now === 'function'
+          ? Number(performance.now().toFixed(2))
+          : Date.now();
+      recordDailyFritzLayoutDebug({
+        tag: '[layout-debug]',
+        timestamp,
+        handNumber,
+        handOver,
+        gameOver,
+        boardTileCount,
+        openEndPositions,
+        validPositionsCount,
+        selectedTile: selectedTileKey,
+        computedBounds: {
+          minX: Number(layout.minX.toFixed(2)),
+          maxX: Number(layout.maxX.toFixed(2)),
+          minY: Number(layout.minY.toFixed(2)),
+          maxY: Number(layout.maxY.toFixed(2)),
+        },
+        zoomScale: Number(cameraScale.toFixed(3)),
+      });
+    },
+    [boardTileCount, cameraScale, gameOver, handNumber, handOver, openEndPositions],
+  );
+
+  // Keep the camera/layout stable when the player selects a tile.
+  const layout = useMemo(() => {
+    // eslint-disable-next-line react-hooks/purity -- performance.now() timing probe inside the layout memo — instrumentation, not a value the memo returns
+    const start = typeof performance !== 'undefined' ? performance.now() : Date.now();
+    traceCameraDebug('[camera-debug] computeLayout input', {
+      boardTileCount,
+      openEndPositions: cameraFitPositions,
+      validPositions,
+      selectedTile: selectedTile ? `${selectedTile.low}|${selectedTile.high}` : null,
+    });
+    const nextLayout = computeBoardLayout(isResettingBoard ? null : board, cameraFitPositions);
+    traceCameraDebug('[camera-debug] computeLayout output', {
+      minX: Number(nextLayout.minX.toFixed(2)),
+      maxX: Number(nextLayout.maxX.toFixed(2)),
+      minY: Number(nextLayout.minY.toFixed(2)),
+      maxY: Number(nextLayout.maxY.toFixed(2)),
+      scale: Number(cameraScale.toFixed(3)),
+    });
+    if (profileDailyFritz) {
+      // eslint-disable-next-line react-hooks/purity -- performance.now() timing probe — instrumentation
+      const end = typeof performance !== 'undefined' ? performance.now() : Date.now();
+      recordDailyFritzBoardMetric('computeLayout', end - start);
+      logLayoutDebug(validPositions.length, selectedTile ? `${selectedTile.low}|${selectedTile.high}` : null, nextLayout);
+    }
+    return nextLayout;
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- the layout memo keys on the inputs that change its geometry; boardTileCount/cameraScale are derived from those and would only add churn
+  }, [board, cameraFitPositions, profileDailyFritz, logLayoutDebug, selectedTile, validPositions, isResettingBoard]);
+
+  const placementZones = useMemo(() => {
+    // eslint-disable-next-line react-hooks/purity -- performance.now() timing probe — instrumentation
+    const start = typeof performance !== 'undefined' ? performance.now() : Date.now();
+    const zones = computeBoardLayout(isResettingBoard ? null : board, validPositions).zones;
+    if (profileDailyFritz) {
+      // eslint-disable-next-line react-hooks/purity -- performance.now() timing probe — instrumentation
+      const end = typeof performance !== 'undefined' ? performance.now() : Date.now();
+      recordDailyFritzBoardMetric('computeLayout', end - start);
+      traceDailyFritzBoardEvent('[render] placementZones', {
+        count: zones.length,
+        selectedTile: selectedTile ? `${selectedTile.low}|${selectedTile.high}` : null,
+      });
+    }
+    return zones;
+  }, [board, validPositions, profileDailyFritz, selectedTile, isResettingBoard]);
+
+  useEffect(() => {
+    if (!profileDailyFritz) return;
+    traceDailyFritzBoardEvent('[render] Board props', {
+      selectedTile: selectedTile ? `${selectedTile.low}|${selectedTile.high}` : null,
+      legalMovesCount: legalMoves.length,
+    });
+  }, [profileDailyFritz, selectedTile, legalMoves.length]);
+
+  const glowLayout = useMemo(() => {
+    if (!showOpenEndGlow) return null;
+    return computeBoardLayout(isResettingBoard ? null : board, openEndPositions);
+  }, [showOpenEndGlow, board, openEndPositions, isResettingBoard]);
+
+  const resetSignature = useMemo(
+    () => `${handNumber}:${gameOver}:${isResettingBoard}`,
+    [gameOver, handNumber, isResettingBoard],
+  );
+
+  return {
+    boardTileCount,
+    isResettingBoard,
+    openEndPositions,
+    validPositions,
+    cameraFitPositions,
+    layout,
+    placementZones,
+    glowLayout,
+    resetSignature,
+  };
+}


### PR DESCRIPTION
## What

`D2-board-tsx-decomposition-scoping.md` Tier-1 step 2 (PR 2 in its sequence — Tier-0 geometry move shipped as #173). The pure layout-derivation cluster moves verbatim out of `Board.tsx` into `client/src/components/board/useBoardRenderLayout.ts`:

- `boardTileCount`, `isResettingBoard`
- `openEndPositions`, `validPositions`, `cameraFitPositions` (3 memos)
- `layout`, `placementZones`, `glowLayout` (the `computeBoardLayout` calls + `profileDailyFritz` debug tracing)
- `resetSignature`

No behaviour change — every memo body, dependency array, and debug-trace call is unchanged. `camera.scale` is passed in as a plain value (not a ref) to preserve the original's non-reactive "read at render time, not a dependency" debug-trace behavior.

`Board.tsx`: 797 → 673 lines.

## Verification

- `tsc -b` clean
- Full client vitest: **230/230 files, 1726/1726 tests**
- New `useBoardRenderLayout.test.ts` — 6 cases covering reset-state defaults, tile counting, `validPositions`/`cameraFitPositions` derivation, `placementZones`, `glowLayout` gating, `resetSignature` keying
- **`board-camera.spec.ts` (#176, the D2 pre-req) loop-tested 10/10 clean** against this extraction — confirms the camera-fit behaviour it exists to protect is unaffected
- Lint: no new warnings (49/50 budget, unchanged)

## Next

`useBoardPointerControls`, then `useBoardCamera` (the hard one, per the scoping doc) — each its own PR, gated on `board-camera.spec.ts` staying green before/after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JSNbHAMoP1ap8CNpxEBxmC