### PR TITLE
refactor(board): extract useBoardPointerControls (D2, PR 3 of 3 — decomposition complete)

### DIFF
--- a/client/src/components/Board.tsx
+++ b/client/src/components/Board.tsx
@@ -2,9 +2,7 @@
 import {
   forwardRef,
   memo,
-  useCallback,
   useImperativeHandle,
-  useRef,
   useState,
   type ForwardedRef,
 } from 'react';
@@ -14,13 +12,10 @@ import type { Tile, BoardState, PlacementPosition, Move } from '../types';
 import { tileEquals } from '../game/tileUtils';
 import { isDouble } from '../game/openEndsGeometry';
 import { useRenderProfiler } from '../debug/renderProfiler';
-import {
-  recordDailyFritzBoardMetric,
-  traceCameraDebug,
-  traceDailyFritzBoardEvent,
-} from './boardDiagnostics';
+import { recordDailyFritzBoardMetric, traceDailyFritzBoardEvent } from './boardDiagnostics';
 import { useBoardRenderLayout } from './board/useBoardRenderLayout';
 import { useBoardCamera } from './board/useBoardCamera';
+import { useBoardPointerControls } from './board/useBoardPointerControls';
 
 // ─── Board Component ─────────────────────────────────────────
 
@@ -103,8 +98,6 @@ function BoardComponent(
   // as the original single-component code; useBoardCamera owns the effects
   // that decide the camera, not the state itself.
   const [camera, setCamera] = useState({ x: 0, y: 0, scale: 1 });
-  const [isDragging, setIsDragging] = useState(false);
-  const dragStart = useRef({ x: 0, y: 0, camX: 0, camY: 0 });
   const showTargetDebug =
     typeof window !== 'undefined' && window.localStorage.getItem('BOARD_TARGET_DEBUG') === '1';
 
@@ -150,100 +143,24 @@ function BoardComponent(
   const centerY =
     staticView && staticFitMainline ? 0 : (layout.minY + layout.maxY) / 2;
 
-  // Mouse wheel zoom
-  const handleWheel = useCallback((e: React.WheelEvent) => {
-    e.preventDefault();
-    const delta = e.deltaY > 0 ? 0.9 : 1.1;
-    markManualCamera();
-    setCamera((cam) => ({
-      ...cam,
-      scale: (() => {
-        const nextScale = Math.min(2.4, Math.max(minCameraScale, cam.scale * delta));
-        traceCameraDebug('[camera-debug] setCamera', {
-          reason: 'wheel',
-          x: Number(cam.x.toFixed(2)),
-          y: Number(cam.y.toFixed(2)),
-          scale: Number(nextScale.toFixed(3)),
-        });
-        return nextScale;
-      })(),
-    }));
-  }, [markManualCamera, minCameraScale]);
-
-  // Pan handlers
-  const handleMouseDown = useCallback(
-    (e: React.MouseEvent) => {
-      if (e.button !== 0) return;
-      if ((e.target as HTMLElement)?.closest('.placement-zone')) {
-        return;
-      }
-      markManualCamera();
-      setIsDragging(true);
-      dragStart.current = {
-        x: e.clientX,
-        y: e.clientY,
-        camX: camera.x,
-        camY: camera.y,
-      };
-    },
-    [camera.x, camera.y, markManualCamera],
-  );
-
-  const handleMouseMove = useCallback(
-    (e: React.MouseEvent) => {
-      if (!isDragging) return;
-      const dx = e.clientX - dragStart.current.x;
-      const dy = e.clientY - dragStart.current.y;
-      setCamera((cam) => ({
-        ...cam,
-        x: (() => {
-          const nextX = dragStart.current.camX + dx;
-          const nextY = dragStart.current.camY + dy;
-          traceCameraDebug('[camera-debug] setCamera', {
-            reason: 'drag',
-            x: Number(nextX.toFixed(2)),
-            y: Number(nextY.toFixed(2)),
-            scale: Number(cam.scale.toFixed(3)),
-          });
-          return nextX;
-        })(),
-        y: dragStart.current.camY + dy,
-      }));
-    },
-    [isDragging],
-  );
-
-  const handleMouseUp = useCallback(() => {
-    setIsDragging(false);
-  }, []);
-
-  // Double-click to reset
-  const handleDoubleClick = useCallback(() => {
-    manualCameraRef.current = false;
-    fitCameraToContainer('double-click-reset', undefined, undefined, true);
-  }, [fitCameraToContainer, manualCameraRef]);
-
-  const applyZoomStep = useCallback((factor: number) => {
-    markManualCamera();
-    setCamera((cam) => ({
-      ...cam,
-      scale: (() => {
-        const nextScale = Math.min(2.4, Math.max(minCameraScale, cam.scale * factor));
-        traceCameraDebug('[camera-debug] setCamera', {
-          reason: 'manual-zoom',
-          x: Number(cam.x.toFixed(2)),
-          y: Number(cam.y.toFixed(2)),
-          scale: Number(nextScale.toFixed(3)),
-        });
-        return nextScale;
-      })(),
-    }));
-  }, [markManualCamera, minCameraScale]);
-
-  const resetCameraToFit = useCallback(() => {
-    manualCameraRef.current = false;
-    fitCameraToContainerRef.current('manual-reset', undefined, undefined, true);
-  }, [fitCameraToContainerRef, manualCameraRef]);
+  const {
+    isDragging,
+    handleWheel,
+    handleMouseDown,
+    handleMouseMove,
+    handleMouseUp,
+    handleDoubleClick,
+    applyZoomStep,
+    resetCameraToFit,
+  } = useBoardPointerControls({
+    camera,
+    setCamera,
+    minCameraScale,
+    manualCameraRef,
+    markManualCamera,
+    fitCameraToContainer,
+    fitCameraToContainerRef,
+  });
 
   useImperativeHandle(
     ref,

--- a/client/src/components/board/useBoardPointerControls.ts
+++ b/client/src/components/board/useBoardPointerControls.ts
@@ -1,0 +1,155 @@
+// client/src/components/board/useBoardPointerControls.ts
+//
+// Extracted verbatim from Board.tsx (D2 Tier-1, final hook — see
+// docs/scoping/D2-board-tsx-decomposition-scoping.md). Wheel-zoom, drag-pan,
+// double-click-to-fit, and the zoom-tray's applyZoomStep/resetCameraToFit —
+// every pointer interaction that mutates the camera. Genuinely last of the
+// three D2 hooks: its signature depends on useBoardCamera's output (the
+// camera setter, markManualCamera, fitCameraToContainer), which is why the
+// implementation order ended up reversed from the scoping doc's PR-3/PR-4
+// documentation order (see useBoardCamera.ts's header for the full story).
+import { useCallback, useRef, useState } from 'react';
+import { traceCameraDebug } from '../boardDiagnostics';
+import type { BoardCameraState } from './useBoardCamera';
+
+export interface UseBoardPointerControlsParams {
+  camera: BoardCameraState;
+  setCamera: React.Dispatch<React.SetStateAction<BoardCameraState>>;
+  minCameraScale: number;
+  manualCameraRef: React.MutableRefObject<boolean>;
+  markManualCamera: () => void;
+  fitCameraToContainer: (reason: string, width?: number, height?: number, force?: boolean) => void;
+  fitCameraToContainerRef: React.MutableRefObject<
+    (reason: string, width?: number, height?: number, force?: boolean) => void
+  >;
+}
+
+export interface UseBoardPointerControlsResult {
+  isDragging: boolean;
+  handleWheel: (e: React.WheelEvent) => void;
+  handleMouseDown: (e: React.MouseEvent) => void;
+  handleMouseMove: (e: React.MouseEvent) => void;
+  handleMouseUp: () => void;
+  handleDoubleClick: () => void;
+  applyZoomStep: (factor: number) => void;
+  resetCameraToFit: () => void;
+}
+
+export function useBoardPointerControls({
+  camera,
+  setCamera,
+  minCameraScale,
+  manualCameraRef,
+  markManualCamera,
+  fitCameraToContainer,
+  fitCameraToContainerRef,
+}: UseBoardPointerControlsParams): UseBoardPointerControlsResult {
+  const [isDragging, setIsDragging] = useState(false);
+  const dragStart = useRef({ x: 0, y: 0, camX: 0, camY: 0 });
+
+  // Mouse wheel zoom
+  const handleWheel = useCallback((e: React.WheelEvent) => {
+    e.preventDefault();
+    const delta = e.deltaY > 0 ? 0.9 : 1.1;
+    markManualCamera();
+    setCamera((cam) => ({
+      ...cam,
+      scale: (() => {
+        const nextScale = Math.min(2.4, Math.max(minCameraScale, cam.scale * delta));
+        traceCameraDebug('[camera-debug] setCamera', {
+          reason: 'wheel',
+          x: Number(cam.x.toFixed(2)),
+          y: Number(cam.y.toFixed(2)),
+          scale: Number(nextScale.toFixed(3)),
+        });
+        return nextScale;
+      })(),
+    }));
+  }, [markManualCamera, minCameraScale, setCamera]);
+
+  // Pan handlers
+  const handleMouseDown = useCallback(
+    (e: React.MouseEvent) => {
+      if (e.button !== 0) return;
+      if ((e.target as HTMLElement)?.closest('.placement-zone')) {
+        return;
+      }
+      markManualCamera();
+      setIsDragging(true);
+      dragStart.current = {
+        x: e.clientX,
+        y: e.clientY,
+        camX: camera.x,
+        camY: camera.y,
+      };
+    },
+    [camera.x, camera.y, markManualCamera],
+  );
+
+  const handleMouseMove = useCallback(
+    (e: React.MouseEvent) => {
+      if (!isDragging) return;
+      const dx = e.clientX - dragStart.current.x;
+      const dy = e.clientY - dragStart.current.y;
+      setCamera((cam) => ({
+        ...cam,
+        x: (() => {
+          const nextX = dragStart.current.camX + dx;
+          const nextY = dragStart.current.camY + dy;
+          traceCameraDebug('[camera-debug] setCamera', {
+            reason: 'drag',
+            x: Number(nextX.toFixed(2)),
+            y: Number(nextY.toFixed(2)),
+            scale: Number(cam.scale.toFixed(3)),
+          });
+          return nextX;
+        })(),
+        y: dragStart.current.camY + dy,
+      }));
+    },
+    [isDragging, setCamera],
+  );
+
+  const handleMouseUp = useCallback(() => {
+    setIsDragging(false);
+  }, []);
+
+  // Double-click to reset
+  const handleDoubleClick = useCallback(() => {
+    manualCameraRef.current = false;
+    fitCameraToContainer('double-click-reset', undefined, undefined, true);
+  }, [fitCameraToContainer, manualCameraRef]);
+
+  const applyZoomStep = useCallback((factor: number) => {
+    markManualCamera();
+    setCamera((cam) => ({
+      ...cam,
+      scale: (() => {
+        const nextScale = Math.min(2.4, Math.max(minCameraScale, cam.scale * factor));
+        traceCameraDebug('[camera-debug] setCamera', {
+          reason: 'manual-zoom',
+          x: Number(cam.x.toFixed(2)),
+          y: Number(cam.y.toFixed(2)),
+          scale: Number(nextScale.toFixed(3)),
+        });
+        return nextScale;
+      })(),
+    }));
+  }, [markManualCamera, minCameraScale, setCamera]);
+
+  const resetCameraToFit = useCallback(() => {
+    manualCameraRef.current = false;
+    fitCameraToContainerRef.current('manual-reset', undefined, undefined, true);
+  }, [fitCameraToContainerRef, manualCameraRef]);
+
+  return {
+    isDragging,
+    handleWheel,
+    handleMouseDown,
+    handleMouseMove,
+    handleMouseUp,
+    handleDoubleClick,
+    applyZoomStep,
+    resetCameraToFit,
+  };
+}


### PR DESCRIPTION
## What

`D2-board-tsx-decomposition-scoping.md` Tier-1, final hook. Wheel-zoom, drag-pan, double-click-to-fit, and the zoom-tray's `applyZoomStep`/`resetCameraToFit` move verbatim into `client/src/components/board/useBoardPointerControls.ts`, alongside the `isDragging`/`dragStart` state they own.

Genuinely last of the three (as corrected in #178) — its params (`camera`, `setCamera`, `minCameraScale`, `manualCameraRef`, `markManualCamera`, `fitCameraToContainer`/Ref) are `useBoardCamera`'s outputs.

## D2 hook decomposition — complete

| Step | PR | What |
|---|---|---|
| Tier-0 | #173 | Pure geometry → `board/boardLayout.ts` |
| Pre-req e2e | #176 | `board-camera.spec.ts` — the safety net this whole sequence gated on |
| Hook 1 | #177 | `useBoardRenderLayout` — layout derivation |
| Hook 2 | #178 | `useBoardCamera` — camera state + fit effects |
| Hook 3 | **this PR** | `useBoardPointerControls` — wheel/pan/zoom/double-click |

`Board.tsx`: **1266 → 396 lines** across the sequence. The component now composes three independently-testable hooks + render; the static-vs-live `fitMode`/`staticView` branching that used to be smeared through one 690-line function body is now scoped to the hook that actually owns it (`useBoardCamera`).

## Verification

- `tsc -b` clean
- Full client vitest: **230/230 files, 1726/1726 tests**
- Lint: 48/50 warnings (unchanged from #178). `lint:hooks` (`--max-warnings 0`) clean.
- **`board-camera.spec.ts` loop-tested 10/10 clean** against the *complete* 3-hook decomposition — the pan/zoom/double-click paths this hook owns are exactly what the spec's framing/pan/zoom-tray/double-click-refit assertions exercise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JSNbHAMoP1ap8CNpxEBxmC