### PR TITLE
refactor(multiplayer): useMultiplayerRoomCallbacks reads runtime slices, not raw refs (D5 migration, PR 2)

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -333,7 +333,7 @@ export default function App() {
     multiplayerRuntimeRef.current = createMultiplayerRuntime(runtimeBootstrapRef.current);
   }
   const multiplayerRuntime = multiplayerRuntimeRef.current;
-  const { sessionRef, dispatchSession } = multiplayerRuntime.session;
+  const { sessionRef } = multiplayerRuntime.session;
 
   const shellDelegateActions = useMultiplayerShellDelegates(shellDelegatesRef);
   const {
@@ -553,30 +553,17 @@ export default function App() {
     emitCreateRoom,
     applyJoinedRoomResponse,
     handleMatchmakingAutoJoin,
-  // eslint-disable-next-line react-hooks/refs -- ref object shared into a hook/provider — its .current is read only inside that consumer's effects/callbacks; the rule cannot see across the call boundary (D-2)
+    /* eslint-disable react-hooks/refs -- runtime object shared into a hook — its ref-slice .current fields are read only inside that consumer's effects/callbacks; the rule cannot see across the call boundary (D-2) */
   } = useMultiplayerRoomCallbacks({
-    pendingCreateResolversRef,
-    maxSequenceRef,
+    runtime: multiplayerRuntime,
     maxEventSequenceRef,
     roomMatchIdRef,
     roomOperationEpochRef,
-    resyncBufferedUpdateRef,
     shellDelegatesRef,
-    autoJoinAttemptedRef,
     appModeRef,
-    joinedRoomResponseRef,
-    roomPlayersRef,
-    roomIdentityRef,
-    youRef,
-    socketRef,
-    // eslint-disable-next-line react-hooks/refs -- ref object shared into a hook/provider — its .current is read only inside that consumer's effects/callbacks; the rule cannot see across the call boundary (D-2)
-    sessionRef,
     applyRoomEventMetaRef,
     schedulePlayerReadyRef,
-    applyJoinedRoomResponseRef,
     trySchedulePlayerReadyRef,
-    // eslint-disable-next-line react-hooks/refs -- ref object shared into a hook/provider — its .current is read only inside that consumer's effects/callbacks; the rule cannot see across the call boundary (D-2)
-    dispatchSession,
     dispatchRecovery,
     setJoinedRoom,
     setRoomCode,
@@ -604,6 +591,7 @@ export default function App() {
     applyTournamentMetadataFromJoin,
     tournament,
   });
+  /* eslint-enable react-hooks/refs */
 
   // eslint-disable-next-line react-hooks/refs -- keeps a ref synced to the latest render value for async consumers; moving the write to an effect would defer it past paint
   resetMultiplayerRoomStateRef.current = resetMultiplayerRoomState;

--- a/client/src/multiplayer/useMultiplayerRoomCallbacks.ts
+++ b/client/src/multiplayer/useMultiplayerRoomCallbacks.ts
@@ -36,9 +36,9 @@ import { useJoinAckCoordinator } from './useJoinAckCoordinator';
 import type { JoinAckSnapshotResult } from './joinAckCoordinator';
 import { logger } from '../utils/logger';
 import type { MatchFoundPayload } from '../matchmaking/types';
-import type { SessionEvent, SessionSnapshot } from './session/sessionTypes';
 import type { MultiplayerShellDelegates } from './multiplayerGameShellTypes';
 import type { TournamentMatchContext } from '../match/session/tournament/tournamentMatchSessionTypes';
+import type { MultiplayerRuntime } from './runtime/runtimeTypes';
 
 type HandEndedPayload = {
   handNumber: number;
@@ -53,29 +53,34 @@ type HandEndedPayload = {
 // ─── Params ──────────────────────────────────────────────────
 
 export type UseMultiplayerRoomCallbacksParams = {
-  // Refs
-  pendingCreateResolversRef: MutableRefObject<Array<(code: string | null) => void>>;
-  maxSequenceRef: MutableRefObject<number>;
+  /**
+   * D5 runtime migration (2026-09-10, following #183's useMultiplayerResync
+   * conversion): pendingCreateResolversRef/autoJoinAttemptedRef,
+   * maxSequenceRef/roomPlayersRef/roomIdentityRef/youRef/joinedRoomResponseRef,
+   * resyncBufferedUpdateRef/applyJoinedRoomResponseRef, socketRef, and
+   * sessionRef/dispatchSession now come from the composed runtime's slices
+   * (.controller.joinFlight / .room / .recovery / .socket / .session)
+   * instead of ten individual App.tsx ref params — same ref objects by
+   * identity, proven in
+   * useMultiplayerRoomCallbacksRuntimeSliceIdentity.test.ts.
+   *
+   * maxEventSequenceRef, roomMatchIdRef, roomOperationEpochRef,
+   * shellDelegatesRef, appModeRef, applyRoomEventMetaRef,
+   * schedulePlayerReadyRef, and trySchedulePlayerReadyRef stay individual
+   * params — none has a runtime slice today (confirmed gaps, not
+   * introduced here — see D5-runtime-migration-scoping-2026-09-10.md §2).
+   */
+  runtime: MultiplayerRuntime;
   maxEventSequenceRef: MutableRefObject<number>;
   roomMatchIdRef: MutableRefObject<string | null>;
   roomOperationEpochRef: MutableRefObject<number>;
-  resyncBufferedUpdateRef: MutableRefObject<import('./protocol').StateUpdatePayload | null>;
   shellDelegatesRef: MutableRefObject<MultiplayerShellDelegates | null>;
-  autoJoinAttemptedRef: MutableRefObject<boolean>;
   appModeRef: MutableRefObject<AppMode>;
-  joinedRoomResponseRef: MutableRefObject<RoomAckResponse | null>;
-  roomPlayersRef: MutableRefObject<RoomPlayer[]>;
-  roomIdentityRef: MutableRefObject<{ username: string; userId: string | null; authToken: string | null } | null>;
-  youRef: MutableRefObject<string>;
-  socketRef: MutableRefObject<Socket | null>;
-  sessionRef: MutableRefObject<SessionSnapshot>;
   // Ref write-backs (4 refs that need every-render assignment)
   applyRoomEventMetaRef: MutableRefObject<(meta?: RoomEventMeta | null) => void>;
   schedulePlayerReadyRef: MutableRefObject<() => Promise<void>>;
-  applyJoinedRoomResponseRef: MutableRefObject<(resp: RoomAckResponse) => void>;
   trySchedulePlayerReadyRef: MutableRefObject<() => void>;
   // Dispatch / session
-  dispatchSession: (event: SessionEvent) => void;
   dispatchRecovery: (event: RecoveryEvent) => void;
   // State setters
   setJoinedRoom: (roomCode: string | null) => void;
@@ -138,26 +143,15 @@ export function useMultiplayerRoomCallbacks(
   params: UseMultiplayerRoomCallbacksParams,
 ): UseMultiplayerRoomCallbacksResult {
   const {
-    pendingCreateResolversRef,
-    maxSequenceRef,
+    runtime,
     maxEventSequenceRef,
     roomMatchIdRef,
     roomOperationEpochRef,
-    resyncBufferedUpdateRef,
     shellDelegatesRef,
-    autoJoinAttemptedRef,
     appModeRef,
-    joinedRoomResponseRef,
-    roomPlayersRef,
-    roomIdentityRef,
-    youRef,
-    socketRef,
-    sessionRef,
     applyRoomEventMetaRef,
     schedulePlayerReadyRef,
-    applyJoinedRoomResponseRef,
     trySchedulePlayerReadyRef,
-    dispatchSession,
     dispatchRecovery,
     setJoinedRoom,
     setRoomCode,
@@ -185,6 +179,15 @@ export function useMultiplayerRoomCallbacks(
     applyTournamentMetadataFromJoin,
     tournament,
   } = params;
+  const { socketRef } = runtime.socket;
+  const { sessionRef, dispatchSession } = runtime.session;
+  const { pendingCreateResolversRef, autoJoinAttemptedRef } = runtime.controller.joinFlight;
+  const { maxSequenceRef, roomPlayersRef, roomIdentityRef, youRef } = runtime.room;
+  // room.joinedRoomResponseRef is typed `unknown` at the runtime-slice layer
+  // (it stays decoupled from RoomAckResponse there); this hook only ever
+  // reads it as the same RoomAckResponse | null shape it always did.
+  const joinedRoomResponseRef = runtime.room.joinedRoomResponseRef as MutableRefObject<RoomAckResponse | null>;
+  const { resyncBufferedUpdateRef, applyJoinedRoomResponseRef } = runtime.recovery;
 
   const getInviteLink = useCallback((code: string) => {
     if (typeof window === 'undefined') return '';

--- a/client/src/multiplayer/useMultiplayerRoomCallbacksRuntimeSliceIdentity.test.ts
+++ b/client/src/multiplayer/useMultiplayerRoomCallbacksRuntimeSliceIdentity.test.ts
@@ -1,0 +1,122 @@
+// @vitest-environment jsdom
+/**
+ * D5 runtime migration — manual identity check for useMultiplayerRoomCallbacks'
+ * conversion to runtime slices, per D5-runtime-migration-scoping-2026-09-10.md
+ * §4's note: "a manual identity check ... per converted hook is worth adding."
+ * Same approach as useMultiplayerResyncRuntimeSliceIdentity.test.ts (#183).
+ *
+ * Builds its fixture as a plain object literal shaped like the runtime slices
+ * this hook actually reads, rather than constructing anything through the
+ * runtime's own composition functions — check:architecture's INV-01 restricts
+ * every one of those (the singleton root and the individual slice factories
+ * alike) to their own module plus App.tsx / runtimeBehaviorTests.ts, tests
+ * included, and text-scans multiplayer/use* files for even a bare mention of
+ * the restricted name. A hand-built literal constructs nothing, so it doesn't
+ * trip that rule, while still proving what matters here: the hook's
+ * unchanged internal logic reads/writes through whatever ref objects the
+ * runtime param hands it, not a copy.
+ *
+ * resetClientGameSession is the target — it's the one callback that touches
+ * every migrated slice in one call (room.maxSequenceRef, recovery's buffered
+ * update ref, session's dispatch) plus two of the confirmed orphan refs, so
+ * one behavioral test exercises the whole conversion at once.
+ */
+import { renderHook, act } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { Socket } from 'socket.io-client';
+import { useMultiplayerRoomCallbacks, type UseMultiplayerRoomCallbacksParams } from './useMultiplayerRoomCallbacks';
+import type { MultiplayerRuntime } from './runtime/runtimeTypes';
+
+function makeFakeRuntime() {
+  const socketRef = { current: null as Socket | null };
+  const sessionRef = { current: { phase: 'idle' as const, context: {} } };
+  const dispatchSession = vi.fn();
+  const pendingCreateResolversRef = { current: [] as Array<(code: string | null) => void> };
+  const autoJoinAttemptedRef = { current: false };
+  const maxSequenceRef = { current: 7 };
+  const roomPlayersRef = { current: [] as unknown[] };
+  const roomIdentityRef = { current: null as { username: string; userId: string | null; authToken: string | null } | null };
+  const youRef = { current: '' };
+  const joinedRoomResponseRef = { current: null as unknown };
+  const resyncBufferedUpdateRef = { current: { some: 'buffered-update' } as unknown };
+  const applyJoinedRoomResponseRef = { current: vi.fn() };
+
+  const runtime = {
+    socket: { socketRef },
+    session: { sessionRef, dispatchSession },
+    controller: { joinFlight: { pendingCreateResolversRef, autoJoinAttemptedRef } },
+    room: { maxSequenceRef, roomPlayersRef, roomIdentityRef, youRef, joinedRoomResponseRef },
+    recovery: { resyncBufferedUpdateRef, applyJoinedRoomResponseRef },
+    gameplay: {},
+    registrars: {},
+    projection: {},
+    tournamentAttach: {},
+    destroy: () => undefined,
+    // Deliberate partial mock — only the slices useMultiplayerRoomCallbacks reads are real.
+  } as unknown as MultiplayerRuntime;
+
+  return { runtime, maxSequenceRef, resyncBufferedUpdateRef, dispatchSession };
+}
+
+function makeBaseParams(
+  runtime: MultiplayerRuntime,
+): UseMultiplayerRoomCallbacksParams {
+  return {
+    runtime,
+    maxEventSequenceRef: { current: 3 },
+    roomMatchIdRef: { current: 'match-1' },
+    roomOperationEpochRef: { current: 0 },
+    shellDelegatesRef: { current: null },
+    appModeRef: { current: 'multiplayer' },
+    applyRoomEventMetaRef: { current: () => undefined },
+    schedulePlayerReadyRef: { current: async () => undefined },
+    trySchedulePlayerReadyRef: { current: () => undefined },
+    dispatchRecovery: () => undefined,
+    setJoinedRoom: () => undefined,
+    setRoomCode: () => undefined,
+    setYou: () => undefined,
+    setPlayers: () => undefined,
+    setTournamentMatch: () => undefined,
+    setError: () => undefined,
+    setOverlayPayload: () => undefined,
+    setAppMode: () => undefined,
+    showToast: () => undefined,
+    shellSetState: () => undefined,
+    shellSetLegalMoves: () => undefined,
+    shellSetCanDraw: () => undefined,
+    shellSetSelectedTile: () => undefined,
+    shellSetHandReveal: () => undefined,
+    shellSetRematchRequested: () => undefined,
+    shellSetRematchReadyIds: () => undefined,
+    shellSetActionError: () => undefined,
+    authProfile: null,
+    authUser: null,
+    multiplayerIdentityUserId: null,
+    multiplayerAuthToken: null,
+    normalizeRoomCode: (v) => (typeof v === 'string' ? v.toUpperCase() : ''),
+    clearTournamentAttachRefs: () => undefined,
+    applyTournamentMetadataFromJoin: () => undefined,
+    tournament: { clearPendingMatch: () => undefined, clearRecoveryMatch: () => undefined },
+  };
+}
+
+describe('useMultiplayerRoomCallbacks runtime-slice ref identity', () => {
+  it('resetClientGameSession writes through the exact runtime-slice ref objects, not copies', () => {
+    const fake = makeFakeRuntime();
+    const { result } = renderHook(() => useMultiplayerRoomCallbacks(makeBaseParams(fake.runtime)));
+
+    expect(fake.maxSequenceRef.current).toBe(7);
+    expect(fake.resyncBufferedUpdateRef.current).not.toBeNull();
+
+    act(() => {
+      result.current.resetClientGameSession();
+    });
+
+    // These assertions read the *original* fixture-held ref objects, not
+    // anything routed back through the hook — proving the hook mutated the
+    // same objects the runtime param handed it.
+    expect(fake.maxSequenceRef.current).toBe(-1);
+    expect(fake.resyncBufferedUpdateRef.current).toBeNull();
+    expect(fake.dispatchSession).toHaveBeenCalledWith({ type: 'SESSION_RESET_GAME' });
+  });
+});


### PR DESCRIPTION
## ⚠️ Protected-directory change

`client/src/multiplayer/` is CLAUDE.md-protected ("socket lifecycle code; do not restructure"). Flagged explicitly, same bar as any other change there.

## What

`D5-runtime-migration-scoping-2026-09-10.md` §3 step 4 — the "real size" conversion, following #183's `useMultiplayerResync`. The orphan-ref approach here matches the proposal you reviewed and approved before this PR started.

10 individual bootstrap refs collapse to one `runtime: MultiplayerRuntime` param: `pendingCreateResolversRef`/`autoJoinAttemptedRef` (`controller.joinFlight`), `maxSequenceRef`/`roomPlayersRef`/`roomIdentityRef`/`youRef`/`joinedRoomResponseRef` (`room`), `resyncBufferedUpdateRef`/`applyJoinedRoomResponseRef` (`recovery`), `socketRef` (`socket`), `sessionRef`/`dispatchSession` (`session`) — same ref objects by identity, hook's internal logic unchanged below the destructuring line.

**One wrinkle:** `runtime.room.joinedRoomResponseRef` is typed `unknown` at the runtime-slice layer (deliberately decoupled from `RoomAckResponse` there). Cast back to the hook's original `MutableRefObject<RoomAckResponse | null>` at the destructuring site — same object, narrower local type.

**`maxEventSequenceRef`, `roomMatchIdRef`, `roomOperationEpochRef`, `shellDelegatesRef`, `appModeRef`, `applyRoomEventMetaRef`, `schedulePlayerReadyRef`, `trySchedulePlayerReadyRef` stay individual params** — confirmed single-consumer (App.tsx + this one hook, nothing else) with no runtime slice today. No protected-module additions.

## Manual identity check

`useMultiplayerRoomCallbacksRuntimeSliceIdentity.test.ts`: `resetClientGameSession` is the one callback that touches every migrated slice in a single call (`room.maxSequenceRef`, recovery's buffered-update ref, session's dispatch) plus two orphans — one behavioral test exercises the whole conversion. Built as a plain object literal, not via the runtime's own composition functions — `check:architecture`'s INV-01 text-scans `multiplayer/use*` files and restricts every `create*Runtime` factory (singleton included) to its own module + `App.tsx` + `runtimeBehaviorTests.ts`. Learned this the hard way on #183; ran `check:architecture` first this time.

## Verification

- `tsc -b` clean
- Full client vitest: **232/232 files, 1729/1729 tests**
- `check:architecture` **CERTIFIED 20/20**
- Lint 48/50 (unchanged), `lint:hooks` (`--max-warnings 0`) clean — needed a block `eslint-disable`/`enable` around the call instead of a per-line comment; the rule's reported line for this multi-line call expression moved between attempts and didn't track a single prop reliably
- `check:multiplayer-arch` / `check:multiplayer-cycles` both clean
- **`multiplayer-in-match-reconnect.spec.ts` (5 scenarios) + `multiplayer-chaos.spec.ts` (6 scenarios) — 11/11 clean**, one run, fresh servers (ports verified clear before starting)
- MP Private Authority Soak: CI-only (needs the live Supabase service key this session doesn't have), same as every protected-dir PR tonight

## D5 migration status after this PR

All items from `D5-runtime-migration-scoping-2026-09-10.md` §3 are now resolved: the three register-handlers hooks needed no PR (investigated, don't touch the bootstrap), `useMultiplayerResync` shipped (#183), dead `useAppSessionRuntime()` deleted (#184), and this closes `useMultiplayerRoomCallbacks` — the last one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JSNbHAMoP1ap8CNpxEBxmC