### PR TITLE
fix(auth): close e2e-dev-auth / onAuthStateChange init race in useAuth

### DIFF
--- a/client/src/auth/useAuth.e2eAuthRace.test.tsx
+++ b/client/src/auth/useAuth.e2eAuthRace.test.tsx
@@ -1,0 +1,153 @@
+// @vitest-environment jsdom
+/**
+ * Regression test for the e2e-dev-auth / onAuthStateChange race.
+ *
+ * Before the fix: the dev-only e2e auth bypass (readE2eDevAuth) set
+ * user/accessToken/profile synchronously inside `init()`, then `init()`
+ * `return`ed — but the surrounding effect kept running past that point and
+ * unconditionally subscribed to `supabase.auth.onAuthStateChange`. Supabase
+ * fires that listener's callback with an `INITIAL_SESSION` event (session:
+ * null, since there's no real session) shortly after subscribing, and that
+ * callback's `syncSession('INITIAL_SESSION', null)` unconditionally reset
+ * user/profile/accessToken back to signed-out — a race whose outcome
+ * depended on ordering between two independently-scheduled microtask
+ * chains. Confirmed directly (not just read): a Playwright run against the
+ * real app flipped back to "Sign in to continue" moments after the e2e
+ * branch had set the user (client/e2e/ghost-play-to-completion.spec.ts's
+ * scoping work, 2026-09-11).
+ *
+ * The fix makes e2e-auth mode and the real-Supabase-session mode mutually
+ * exclusive branches of the same effect: when readE2eDevAuth() returns
+ * truthy, the effect returns immediately after setting state, before the
+ * real session bootstrap or the onAuthStateChange subscription are ever
+ * reached — so there is no listener left to race against.
+ *
+ * This test proves the fix at the mechanism level (the listener is never
+ * attached, so it structurally cannot fire) rather than just re-asserting
+ * "auth ends up correct", which a timing-dependent flake could still pass by
+ * luck.
+ */
+import { act, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { User } from '@supabase/supabase-js';
+
+const onAuthStateChangeSpy = vi.fn();
+const getSessionMock = vi.fn();
+
+vi.mock('../lib/supabase', () => ({
+  isSupabaseConfigured: true,
+  getSupabaseConfigError: () => null,
+  supabase: {
+    auth: {
+      getSession: (...args: unknown[]) => getSessionMock(...args),
+      onAuthStateChange: (...args: unknown[]) => {
+        onAuthStateChangeSpy(...args);
+        return { data: { subscription: { unsubscribe: vi.fn() } } };
+      },
+    },
+    from: () => ({
+      select: () => ({
+        eq: () => ({
+          maybeSingle: () => Promise.resolve({ data: null, error: null }),
+        }),
+      }),
+    }),
+  },
+}));
+
+vi.mock('../lib/analytics', () => ({
+  identifyUser: vi.fn(),
+  resetAnalytics: vi.fn(),
+  track: vi.fn(),
+}));
+
+const readE2eDevAuthMock = vi.fn();
+vi.mock('./e2eDevAuth', () => ({
+  readE2eDevAuth: () => readE2eDevAuthMock(),
+}));
+
+const { AuthProvider, useAuth } = await import('./useAuth');
+
+function Probe() {
+  const { user, loading } = useAuth();
+  return (
+    <div>
+      <span data-testid="user-id">{user?.id ?? 'none'}</span>
+      <span data-testid="loading">{String(loading)}</span>
+    </div>
+  );
+}
+
+function renderProbe() {
+  return render(
+    <AuthProvider>
+      <Probe />
+    </AuthProvider>,
+  );
+}
+
+describe('useAuth — e2e-dev-auth vs onAuthStateChange race', () => {
+  beforeEach(() => {
+    onAuthStateChangeSpy.mockClear();
+    getSessionMock.mockReset();
+    getSessionMock.mockResolvedValue({ data: { session: null } });
+    readE2eDevAuthMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('never subscribes to onAuthStateChange when e2e auth is active, so its INITIAL_SESSION event cannot fire and clobber the user', async () => {
+    const e2eUser = { id: 'e2e-user-1', aud: 'authenticated', role: 'authenticated' } as User;
+    readE2eDevAuthMock.mockReturnValue({ user: e2eUser, token: 'e2e-daily-fritz' });
+
+    renderProbe();
+
+    // Set synchronously by the e2e branch — no need to wait.
+    expect(screen.getByTestId('user-id').textContent).toBe('e2e-user-1');
+    expect(screen.getByTestId('loading').textContent).toBe('false');
+
+    // Give any stray microtasks / timers a chance to run. If the old code's
+    // onAuthStateChange subscription still existed, this is where its
+    // INITIAL_SESSION(null) callback would have fired and reset the user.
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    });
+
+    expect(onAuthStateChangeSpy).not.toHaveBeenCalled();
+    expect(getSessionMock).not.toHaveBeenCalled();
+    expect(screen.getByTestId('user-id').textContent).toBe('e2e-user-1');
+  });
+
+  it('still resolves a real signed-in user through onAuthStateChange when e2e auth is not active (normal path unchanged)', async () => {
+    readE2eDevAuthMock.mockReturnValue(null);
+    const realUser = { id: 'real-user-1', aud: 'authenticated', role: 'authenticated' } as User;
+
+    renderProbe();
+
+    await waitFor(() => expect(onAuthStateChangeSpy).toHaveBeenCalledTimes(1));
+    const [callback] = onAuthStateChangeSpy.mock.calls[0] as [(event: string, session: unknown) => Promise<void>];
+
+    await act(async () => {
+      await callback('INITIAL_SESSION', { user: realUser, access_token: 'tok' });
+    });
+
+    expect(screen.getByTestId('user-id').textContent).toBe('real-user-1');
+  });
+
+  it("a null INITIAL_SESSION on the real path still signs the user out (that clobber is correct when it's the only session source)", async () => {
+    readE2eDevAuthMock.mockReturnValue(null);
+
+    renderProbe();
+
+    await waitFor(() => expect(onAuthStateChangeSpy).toHaveBeenCalledTimes(1));
+    const [callback] = onAuthStateChangeSpy.mock.calls[0] as [(event: string, session: unknown) => Promise<void>];
+
+    await act(async () => {
+      await callback('INITIAL_SESSION', null);
+    });
+
+    expect(screen.getByTestId('user-id').textContent).toBe('none');
+  });
+});

--- a/client/src/auth/useAuth.ts
+++ b/client/src/auth/useAuth.ts
@@ -324,6 +324,37 @@ function useAuthInternal() {
 
   useEffect(() => {
     let active = true;
+
+    // Dev-only e2e auth bypass is a *complete* replacement for the real
+    // Supabase session, not a value to seed and then let live auth events
+    // reconcile against. Checking it here — before the real-session wiring
+    // below even exists — and returning early is what makes that true: the
+    // real getSession() bootstrap never runs and, critically,
+    // onAuthStateChange never subscribes, so its first INITIAL_SESSION
+    // event (session: null, since there's no real Supabase session) can't
+    // race the synchronous setUser/setAccessToken/setProfile calls above and
+    // silently revert them to signed-out. This used to be an early `return`
+    // inside `init()` below, several lines before the (still-unconditional)
+    // onAuthStateChange subscription — the subscription didn't know init()
+    // had already fully handled auth, so it always attached, and its first
+    // event settled the race non-deterministically (confirmed directly: a
+    // Playwright run showed a real UI flip back to "signed out" moments
+    // after the e2e branch had set the user).
+    const e2eAuth = readE2eDevAuth();
+    if (e2eAuth) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- dev-only e2e bypass: synchronously replaces the real session-bootstrap effect entirely (see comment above), not a value layered onto external-system sync
+      setUser(e2eAuth.user);
+      setAccessToken(e2eAuth.token);
+      setProfile({
+        id: e2eAuth.user.id,
+        username: 'e2e_daily_fritz',
+      });
+      setLoading(false);
+      return () => {
+        active = false;
+      };
+    }
+
     /**
      * Set once a live auth event has delivered a real signed-in user. The
      * bootstrap `getSession()` call can stay pending long after it timed out,
@@ -379,20 +410,10 @@ function useAuthInternal() {
     };
 
     const init = async () => {
-      const e2eAuth = readE2eDevAuth();
-      if (e2eAuth) {
-        if (active) {
-          setUser(e2eAuth.user);
-          setAccessToken(e2eAuth.token);
-          setProfile({
-            id: e2eAuth.user.id,
-            username: 'e2e_daily_fritz',
-          });
-          setLoading(false);
-        }
-        return;
-      }
-
+      // e2eAuth is handled above, before this effect body even reaches here
+      // — the whole real-session branch (this function, the
+      // onAuthStateChange subscription, the visibilitychange listener) is
+      // skipped entirely in that case.
       if (!supabase) {
         if (active) {
           setUser(null);


### PR DESCRIPTION
## What
`useAuth.ts`'s init effect had a race between the dev-only e2e auth bypass (`readE2eDevAuth()`) and Supabase's `onAuthStateChange` listener. The e2e branch set `user`/`accessToken`/`profile` synchronously inside an early `return` in `init()` (an async function called fire-and-forget via `void init()`), but the enclosing effect unconditionally kept running past that call and subscribed to `onAuthStateChange` anyway. That listener's first event fires as `INITIAL_SESSION` with `session: null` (no real Supabase session exists in e2e mode) — and its callback unconditionally reset `user`/`profile`/`accessToken` back to signed-out. The outcome (auth sticks vs. reverts) depended on the ordering of two independently-scheduled microtask chains.

Confirmed directly, not just by reading the code: a Playwright run against `ghost-play-to-completion.spec.ts` showed the UI flip back to "Sign in to continue" moments after the e2e branch had set the user, while an earlier `puzzle-rush-play-to-completion.spec.ts` run on the same code stayed authenticated — same bypass, same session, different outcome.

## Fix
Move the `readE2eDevAuth()` check to the very top of the effect, before the real-session bootstrap, the `onAuthStateChange` subscription, or the `visibilitychange` listener are ever reached. When it's truthy, the effect sets state and returns immediately — the real-session wiring is never entered at all, so there's no listener left to race against. e2e-auth mode and real-Supabase-session mode are now structurally mutually exclusive branches of the same effect.

## Testing
Adds `useAuth.e2eAuthRace.test.tsx` — the first test coverage for this 898-line file.
- Core test proves the fix at the mechanism level: `onAuthStateChange` is never subscribed when e2e auth is active, so its `INITIAL_SESSION` event structurally cannot fire and clobber state — not just "auth ends up correct," which a timing-dependent flake could pass by luck.
- **Mutation-tested**: reverting the fix (removing the early return, letting the effect fall through) makes that exact assertion fail with `expected vi.fn() to not be called at all, but actually been called 1 times`, confirming the test has teeth.
- Two more tests cover the unaffected normal (non-e2e) path: a real `INITIAL_SESSION` with a session signs the user in; one with `session: null` still signs out (that clobber is correct there — it's the only session source on the real path).

## Full local bar
- `tsc -b`: clean
- `vitest run` (full client suite): 233 files / 1732 tests passing
- `lint`: clean (0 errors)
- `lint:hooks`: clean — one scoped `eslint-disable-next-line react-hooks/set-state-in-effect` with rationale, matching existing precedent in `useAppSessionUi.ts` / `useHomeCommandCenter.ts` / `usePlayerIdentityModel.ts` for effects that intentionally replace rather than layer onto external-system sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)