### PR TITLE
fix(single-player): retune Journey card art crop to match Fritz/Ghost

### DIFF
--- a/client/src/screens/SinglePlayerModes.css
+++ b/client/src/screens/SinglePlayerModes.css
@@ -106,8 +106,8 @@
 }
 
 .journey-card-container .sp-solo-mode-card__art {
-  object-position: 50% 4%;
-  transform: scale(1.22) translate(4%, 2%);
+  object-position: center top;
+  transform: scale(1.35) translate(6%, -2%);
 }
 
 .journey-card-container {


### PR DESCRIPTION
Feedback with a side-by-side screenshot: Journey's character art read as a different style/placement than Fritz/Ghost. Turned out to be a crop problem, not a pose problem worth regenerating the image over — the previous crop left the helmet low in frame with more of the arm/hand visible, while Fritz/Ghost both keep the head filling the same vertical band with the gesture staying clear of the CTA button.

## Fix
`object-position: center top; transform: scale(1.35) translate(6%, -2%);` — same convention Ghost/Lab already use. Tuned against a live dev server through 3 iterations (documented in the commit message): full helmet now visible, matching vertical proportions to the other two cards, hand only lightly grazes the button edge (same as Fritz's own hand near its Play button, not a new problem).

CSS-only change.

## Verification
- `tsc -b`: clean
- `SinglePlayerHubScreen.test.tsx`: still green
- `lint`: within budget
- `lint:hooks`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)