### PR TITLE
fix(single-player): stop cropping Journey's arm away from its own hand

### DIFF
--- a/client/src/screens/SinglePlayerModes.css
+++ b/client/src/screens/SinglePlayerModes.css
@@ -106,8 +106,8 @@
 }
 
 .journey-card-container .sp-solo-mode-card__art {
-  object-position: 60% 0%;
-  transform: scale(1.15) translate(0%, -3%);
+  object-position: center top;
+  transform: scale(1.9) translate(-10%, 3%);
 }
 
 .journey-card-container {

--- a/client/src/screens/SinglePlayerModes.css
+++ b/client/src/screens/SinglePlayerModes.css
@@ -106,8 +106,8 @@
 }
 
 .journey-card-container .sp-solo-mode-card__art {
-  object-position: center top;
-  transform: scale(1.35) translate(6%, -2%);
+  object-position: 60% 0%;
+  transform: scale(1.15) translate(0%, -3%);
 }
 
 .journey-card-container {


### PR DESCRIPTION
#193's "center top / scale 1.35" crop still didn't match Fritz/Ghost — feedback with a full-width screenshot showed why: it kept the head at top and the hand near the bottom, but cropped tight enough to leave a visible gap of empty background between them, since Journey's pointing arm reaches further from the body than Fritz's wave or Ghost's raised hands. Read as two disconnected pieces.

Traced against the actual source image before touching values again (not guessing): it's one continuous limb, just a wider diagonal span than the other two characters. Tried excluding the hand entirely first — worse, cropped into the face.

## Fix
Zoom out closer to natural scale instead of in: `object-position: 60% 0%; transform: scale(1.15) translate(0%, -3%);` — keeps the whole arm visible, head to hand, no gap. Reads as an intentional "pointing the way" pose now.

CSS-only.

## Verification
- `tsc -b`: clean
- `SinglePlayerHubScreen.test.tsx`: still green
- `lint`: within budget
- `lint:hooks`: clean
- Visually verified against a live dev server before and after

🤖 Generated with [Claude Code](https://claude.com/claude-code)