### PR TITLE
fix(single-player): nudge Journey's art 10px left

### DIFF
--- a/client/src/screens/SinglePlayerModes.css
+++ b/client/src/screens/SinglePlayerModes.css
@@ -107,7 +107,7 @@
 
 .journey-card-container .sp-solo-mode-card__art {
   object-position: center top;
-  transform: scale(1.3) translate(5%, 2%);
+  transform: scale(1.3) translate(calc(5% - 10px), 2%);
 }
 
 .journey-card-container {


### PR DESCRIPTION
Small positioning nudge per feedback. `translate(calc(5% - 10px), 2%)` — kept the percentage base so it still scales with the card, just offset 10px further left.

🤖 Generated with [Claude Code](https://claude.com/claude-code)