### PR TITLE
fix(single-player): shift Journey art left with a pure percentage offset

### DIFF
--- a/client/src/screens/SinglePlayerModes.css
+++ b/client/src/screens/SinglePlayerModes.css
@@ -107,7 +107,7 @@
 
 .journey-card-container .sp-solo-mode-card__art {
   object-position: center top;
-  transform: scale(1.3) translate(calc(5% - 10px), 2%);
+  transform: scale(1.3) translate(-1%, 2%);
 }
 
 .journey-card-container {


### PR DESCRIPTION
Moved another 20px left per feedback (30px total), but a mixed \`calc(5% - 30px)\` translate breaks at narrow card widths — the fixed-px component is a much bigger fraction of a mobile card's smaller art-slot than a desktop one, and at ~390px it pushed the crop window off the source image entirely (character vanished). Switched to a pure percentage offset, \`translate(-1%, 2%)\`, which scales proportionally at every width.

Also root-caused the "cut off" screenshot: the character was sitting close enough to the card's right edge that the hard clip read as broken — the purple "lines" in that tight crop were the card's own rounded top/bottom border, not a rendering bug. The added offset gives it real room from that edge.

Verified with real browser windows at 3 widths — ~390px (forced single-column mobile via a temporary style override), ~1000px, ~1512px.

## Verification
- \`tsc -b\`: clean
- \`SinglePlayerHubScreen.test.tsx\`: still green
- \`lint\`: within budget
- \`lint:hooks\`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)