### PR TITLE
feat(journey): author lessons 4-6 — blocked-hand tiebreak, endgame hand-shape, defensive holding

### DIFF
--- a/client/src/journey/journeyAuthoredLessonRegistry.ts
+++ b/client/src/journey/journeyAuthoredLessonRegistry.ts
@@ -2,8 +2,18 @@ import type { JourneyAuthoredLessonBundle } from './journeyAuthoredLessonBundle.
 import { OPEN_END_DISCIPLINE_BUNDLE } from './lessons/openEndDiscipline/openEndDisciplineBundle.ts';
 import { COUNTING_WHATS_LEFT_BUNDLE } from './lessons/countingWhatsLeft/countingWhatsLeftBundle.ts';
 import { DOUBLES_ARENT_FREE_BUNDLE } from './lessons/doublesArentFree/doublesArentFreeBundle.ts';
+import { BLOCKED_HAND_TIEBREAK_BUNDLE } from './lessons/blockedHandTiebreak/blockedHandTiebreakBundle.ts';
+import { ENDGAME_HAND_SHAPE_BUNDLE } from './lessons/endgameHandShape/endgameHandShapeBundle.ts';
+import { DEFENSIVE_HOLDING_BUNDLE } from './lessons/defensiveHolding/defensiveHoldingBundle.ts';
 
-export const PRODUCTION_AUTHORED_LESSON_BUNDLES: ReadonlyArray<JourneyAuthoredLessonBundle> = [OPEN_END_DISCIPLINE_BUNDLE, COUNTING_WHATS_LEFT_BUNDLE, DOUBLES_ARENT_FREE_BUNDLE];
+export const PRODUCTION_AUTHORED_LESSON_BUNDLES: ReadonlyArray<JourneyAuthoredLessonBundle> = [
+  OPEN_END_DISCIPLINE_BUNDLE,
+  COUNTING_WHATS_LEFT_BUNDLE,
+  DOUBLES_ARENT_FREE_BUNDLE,
+  BLOCKED_HAND_TIEBREAK_BUNDLE,
+  ENDGAME_HAND_SHAPE_BUNDLE,
+  DEFENSIVE_HOLDING_BUNDLE,
+];
 const BUNDLES_BY_CONTENT_ID = new Map(PRODUCTION_AUTHORED_LESSON_BUNDLES.map((bundle) => [String(bundle.contentId), bundle]));
 
 if (BUNDLES_BY_CONTENT_ID.size !== PRODUCTION_AUTHORED_LESSON_BUNDLES.length) throw new Error('Duplicate authored Journey lesson bundle content IDs.');

--- a/client/src/journey/journeyContentResolver.test.ts
+++ b/client/src/journey/journeyContentResolver.test.ts
@@ -76,11 +76,11 @@ function makeLesson(id: string, nodeId: string, prerequisites: string[] = []): J
 }
 
 describe('Journey content resolver coverage', () => {
-  it('keeps the three production premium migration boundaries explicit', () => {
+  it('keeps the six production premium migration boundaries explicit', () => {
     expect(PRODUCTION_JOURNEY_CONTENT_REGISTRY.descriptors).toHaveLength(108);
-    expect(PRODUCTION_JOURNEY_CONTENT_REGISTRY.descriptors.filter((descriptor) => descriptor.migrationClass === 'legacy')).toHaveLength(105);
-    expect(PRODUCTION_JOURNEY_CONTENT_REGISTRY.descriptors.filter((descriptor) => descriptor.migrationClass === 'premium')).toHaveLength(3);
-    expect(PRODUCTION_PREMIUM_LESSON_DEFINITIONS).toHaveLength(3);
+    expect(PRODUCTION_JOURNEY_CONTENT_REGISTRY.descriptors.filter((descriptor) => descriptor.migrationClass === 'legacy')).toHaveLength(102);
+    expect(PRODUCTION_JOURNEY_CONTENT_REGISTRY.descriptors.filter((descriptor) => descriptor.migrationClass === 'premium')).toHaveLength(6);
+    expect(PRODUCTION_PREMIUM_LESSON_DEFINITIONS).toHaveLength(6);
     expect(PRODUCTION_PREMIUM_LESSON_DEFINITIONS[0].nodeId).toBe('ch1-n07');
     expect(PRODUCTION_PREMIUM_LESSON_DEFINITIONS[0].id).not.toBe('ch1-n07');
   });
@@ -99,14 +99,14 @@ describe('Journey content resolver coverage', () => {
     expect(summary.trials.fullMatchCount + summary.trials.shortRaceCount).toBe(41);
     expect(summary.puzzleAnswerDistribution.totalPuzzles).toBe(48);
     expect(summary.normalizedContent).toMatchObject({
-      supported: 90,
+      supported: 93,
       legacyFallback: 0,
-      placeholder: 18,
+      placeholder: 15,
       unsupported: 0,
       coreJourneyRuleset: 108,
     });
     expect(summary.normalizedContent.capabilities).toMatchObject({
-      briefing_acknowledgement: 18,
+      briefing_acknowledgement: 15,
       static_decision: 45,
       interactive_board_decision: 1,
       bot_match: 35,
@@ -332,7 +332,7 @@ describe('future Journey lesson contract validation', () => {
 
   it('exposes isolated production and registry lookup collections', () => {
     expect(getJourneyLessonDefinition('premium:lesson-a')).toBeNull();
-    expect(getAllJourneyLessonDefinitions()).toHaveLength(3);
+    expect(getAllJourneyLessonDefinitions()).toHaveLength(6);
     expect(getAllJourneyLessonDefinitions()[0].id).toBe('journey:ch1:open-end-discipline');
     const registry = buildJourneyContentRegistry({ canonicalChapters: JOURNEY_CHAPTER_DEFINITIONS, premiumLessonDefinitions: [makeLesson('premium:lookup', 'ch1-n02')] });
     const definitions = getAllJourneyLessonDefinitionsFromRegistry(registry);

--- a/client/src/journey/journeyContentResolver.ts
+++ b/client/src/journey/journeyContentResolver.ts
@@ -24,6 +24,12 @@ import { COUNTING_WHATS_LEFT_LESSON_DEFINITION } from './lessons/countingWhatsLe
 import { validateCountingWhatsLeftContent } from './lessons/countingWhatsLeft/countingWhatsLeftValidation.ts';
 import { DOUBLES_ARENT_FREE_LESSON_DEFINITION } from './lessons/doublesArentFree/doublesArentFreeLesson.ts';
 import { validateDoublesArentFreeContent } from './lessons/doublesArentFree/doublesArentFreeValidation.ts';
+import { BLOCKED_HAND_TIEBREAK_LESSON_DEFINITION } from './lessons/blockedHandTiebreak/blockedHandTiebreakLesson.ts';
+import { validateBlockedHandTiebreakContent } from './lessons/blockedHandTiebreak/blockedHandTiebreakValidation.ts';
+import { ENDGAME_HAND_SHAPE_LESSON_DEFINITION } from './lessons/endgameHandShape/endgameHandShapeLesson.ts';
+import { validateEndgameHandShapeContent } from './lessons/endgameHandShape/endgameHandShapeValidation.ts';
+import { DEFENSIVE_HOLDING_LESSON_DEFINITION } from './lessons/defensiveHolding/defensiveHoldingLesson.ts';
+import { validateDefensiveHoldingContent } from './lessons/defensiveHolding/defensiveHoldingValidation.ts';
 
 export type JourneyContentRegistryBuildInput = {
   canonicalChapters: JourneyChapterDefinition[];
@@ -224,6 +230,9 @@ export function buildJourneyContentRegistry(input: JourneyContentRegistryBuildIn
     }
     if (definition.id === COUNTING_WHATS_LEFT_LESSON_DEFINITION.id) errors.push(...validateCountingWhatsLeftContent(definition));
     if (definition.id === DOUBLES_ARENT_FREE_LESSON_DEFINITION.id) errors.push(...validateDoublesArentFreeContent(definition));
+    if (definition.id === BLOCKED_HAND_TIEBREAK_LESSON_DEFINITION.id) errors.push(...validateBlockedHandTiebreakContent(definition));
+    if (definition.id === ENDGAME_HAND_SHAPE_LESSON_DEFINITION.id) errors.push(...validateEndgameHandShapeContent(definition));
+    if (definition.id === DEFENSIVE_HOLDING_LESSON_DEFINITION.id) errors.push(...validateDefensiveHoldingContent(definition));
   }
   if (errors.length > 0) throw new Error(['Invalid Journey content registry:', ...[...new Set(errors)].sort()].join('\n'));
   const premiumByNode = new Map(premiumDefinitions.map((definition) => [String(definition.nodeId), definition]));
@@ -256,7 +265,14 @@ export function buildJourneyContentRegistry(input: JourneyContentRegistryBuildIn
   };
 }
 
-export const PRODUCTION_PREMIUM_LESSON_DEFINITIONS: JourneyLessonDefinition[] = [OPEN_END_DISCIPLINE_LESSON_DEFINITION, COUNTING_WHATS_LEFT_LESSON_DEFINITION, DOUBLES_ARENT_FREE_LESSON_DEFINITION];
+export const PRODUCTION_PREMIUM_LESSON_DEFINITIONS: JourneyLessonDefinition[] = [
+  OPEN_END_DISCIPLINE_LESSON_DEFINITION,
+  COUNTING_WHATS_LEFT_LESSON_DEFINITION,
+  DOUBLES_ARENT_FREE_LESSON_DEFINITION,
+  BLOCKED_HAND_TIEBREAK_LESSON_DEFINITION,
+  ENDGAME_HAND_SHAPE_LESSON_DEFINITION,
+  DEFENSIVE_HOLDING_LESSON_DEFINITION,
+];
 export const PRODUCTION_JOURNEY_CONTENT_REGISTRY = buildJourneyContentRegistry({
   canonicalChapters: JOURNEY_CHAPTER_DEFINITIONS,
   premiumLessonDefinitions: PRODUCTION_PREMIUM_LESSON_DEFINITIONS,

--- a/client/src/journey/journeyPremiumRuntimeRegistry.ts
+++ b/client/src/journey/journeyPremiumRuntimeRegistry.ts
@@ -11,6 +11,9 @@ export const PRODUCTION_JOURNEY_PREMIUM_HOSTS: ReadonlyArray<JourneyPremiumHostR
   { contentId: 'journey:ch1:open-end-discipline' as JourneyContentId, hostKind: 'authored_board_lesson' },
   { contentId: 'journey:ch1:counting-whats-left' as JourneyContentId, hostKind: 'authored_board_lesson' },
   { contentId: 'journey:ch1:doubles-arent-free' as JourneyContentId, hostKind: 'authored_board_lesson' },
+  { contentId: 'journey:ch2:blocked-hand-tiebreak' as JourneyContentId, hostKind: 'authored_board_lesson' },
+  { contentId: 'journey:ch3:endgame-hand-shape' as JourneyContentId, hostKind: 'authored_board_lesson' },
+  { contentId: 'journey:ch4:defensive-holding' as JourneyContentId, hostKind: 'authored_board_lesson' },
 ];
 
 const HOSTS_BY_CONTENT_ID = new Map(PRODUCTION_JOURNEY_PREMIUM_HOSTS.map((host) => [String(host.contentId), host]));

--- a/client/src/journey/lessons/blockedHandTiebreak/blockedHandTiebreak.test.ts
+++ b/client/src/journey/lessons/blockedHandTiebreak/blockedHandTiebreak.test.ts
@@ -1,0 +1,50 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest';
+import { analyzeJourneyAuthoredMove } from '../../journeyAuthoredLessonBundle.ts';
+import { BLOCKED_HAND_TIEBREAK_LESSON_DEFINITION } from './blockedHandTiebreakLesson.ts';
+import { BLOCKED_HAND_TIEBREAK_SCENARIOS } from './blockedHandTiebreakScenarios.ts';
+import { evaluateBlockedHandTiebreakResponse } from './blockedHandTiebreakEvaluator.ts';
+import { validateBlockedHandTiebreakContent } from './blockedHandTiebreakValidation.ts';
+
+describe('Reading the Blocked-Hand Tiebreak', () => {
+  it('validates every authored scenario and the practice/proof variant minimums', () => {
+    expect(validateBlockedHandTiebreakContent(BLOCKED_HAND_TIEBREAK_LESSON_DEFINITION)).toEqual([]);
+    expect(BLOCKED_HAND_TIEBREAK_SCENARIOS.filter((s) => s.variantSetId === 'variants:blocked-hand-tiebreak-practice')).toHaveLength(3);
+    expect(BLOCKED_HAND_TIEBREAK_SCENARIOS.filter((s) => s.variantSetId === 'variants:blocked-hand-tiebreak-proof')).toHaveLength(2);
+  });
+
+  it('derives a strictly lower remaining pip total for the accepted action than the tempting one, for every scenario', () => {
+    for (const scenario of BLOCKED_HAND_TIEBREAK_SCENARIOS) {
+      const accepted = analyzeJourneyAuthoredMove(scenario, scenario.acceptedActions[0]);
+      const tempting = analyzeJourneyAuthoredMove(scenario, scenario.temptingActions[0]);
+      const acceptedPips = accepted.remainingHand.reduce((sum, t) => sum + t.low + t.high, 0);
+      const temptingPips = tempting.remainingHand.reduce((sum, t) => sum + t.low + t.high, 0);
+      expect(acceptedPips).toBeLessThan(temptingPips);
+    }
+  });
+
+  it('passes a proof scenario when the accepted (lower-pip) action is chosen', () => {
+    const scenario = BLOCKED_HAND_TIEBREAK_SCENARIOS.find((entry) => entry.id === 'scenario:tiebreak-proof-1')!;
+    const result = evaluateBlockedHandTiebreakResponse(scenario, { kind: 'move', action: scenario.acceptedActions[0] });
+    expect(result.result).toBe('passed');
+  });
+
+  it('fails a proof scenario when the tempting (higher-pip) action is chosen', () => {
+    const scenario = BLOCKED_HAND_TIEBREAK_SCENARIOS.find((entry) => entry.id === 'scenario:tiebreak-proof-1')!;
+    const result = evaluateBlockedHandTiebreakResponse(scenario, { kind: 'move', action: scenario.temptingActions[0] });
+    expect(result.result).toBe('failed');
+    expect(result.feedbackOutcomeKey).toBe('ignored_pip_math');
+  });
+
+  it('rejects an illegal authored response before controller submission', () => {
+    const scenario = BLOCKED_HAND_TIEBREAK_SCENARIOS.find((entry) => entry.id === 'scenario:tiebreak-guided')!;
+    const result = evaluateBlockedHandTiebreakResponse(scenario, { kind: 'move', action: { tile: { low: 6, high: 6 }, position: 'left' } });
+    expect(result.kind).toBe('illegal');
+    expect(result.result).toBeUndefined();
+  });
+
+  it('keeps demonstration steps discrete', () => {
+    const demo = BLOCKED_HAND_TIEBREAK_SCENARIOS.find((entry) => entry.id === 'scenario:tiebreak-demo')!;
+    expect(demo.demonstrationSteps?.map((step) => step.id)).toEqual(['tiebreak-demo-position', 'tiebreak-demo-tempting', 'tiebreak-demo-accepted']);
+  });
+});

--- a/client/src/journey/lessons/blockedHandTiebreak/blockedHandTiebreakBundle.ts
+++ b/client/src/journey/lessons/blockedHandTiebreak/blockedHandTiebreakBundle.ts
@@ -1,0 +1,20 @@
+import type { JourneyAuthoredLessonBundle } from '../../journeyAuthoredLessonBundle.ts';
+import { BLOCKED_HAND_TIEBREAK_LESSON_DEFINITION } from './blockedHandTiebreakLesson.ts';
+import { BLOCKED_HAND_TIEBREAK_FEEDBACK } from './blockedHandTiebreakFeedback.ts';
+import { evaluateBlockedHandTiebreakResponse } from './blockedHandTiebreakEvaluator.ts';
+import { BLOCKED_HAND_TIEBREAK_SCENARIOS } from './blockedHandTiebreakScenarios.ts';
+
+export const BLOCKED_HAND_TIEBREAK_BUNDLE: JourneyAuthoredLessonBundle = {
+  contentId: BLOCKED_HAND_TIEBREAK_LESSON_DEFINITION.id,
+  definition: BLOCKED_HAND_TIEBREAK_LESSON_DEFINITION,
+  scenarios: Object.fromEntries(BLOCKED_HAND_TIEBREAK_SCENARIOS.map((scenario) => [scenario.id, scenario])),
+  feedback: BLOCKED_HAND_TIEBREAK_FEEDBACK,
+  presentation: {
+    tableTitle: 'Fritz’s Table',
+    lessonTitle: 'Reading the Blocked-Hand Tiebreak',
+    framingLine: 'When nobody can play, the hand doesn’t end in a tie. It ends by pip count.',
+    framingInstruction: 'Before you play, check what each legal move leaves behind — not just what it scores.',
+    completionLine: 'You stopped judging a play only by what it scores. You checked what it leaves you holding.',
+  },
+  evaluateResponse: evaluateBlockedHandTiebreakResponse,
+};

--- a/client/src/journey/lessons/blockedHandTiebreak/blockedHandTiebreakEvaluator.ts
+++ b/client/src/journey/lessons/blockedHandTiebreak/blockedHandTiebreakEvaluator.ts
@@ -1,0 +1,29 @@
+import { analyzeJourneyAuthoredMove, type JourneyAuthoredScenario, type JourneyScenarioEvaluation, type JourneyScenarioResponse } from '../../journeyAuthoredLessonBundle.ts';
+import type { BlockedHandTiebreakScenario } from './blockedHandTiebreakScenarios.ts';
+
+function actionKey(action: { tile: { low: number; high: number }; position: string }): string { return `${action.tile.low}-${action.tile.high}@${action.position}`; }
+function sameAction(a: { tile: { low: number; high: number }; position: string }, b: { tile: { low: number; high: number }; position: string }): boolean { return actionKey(a) === actionKey(b); }
+
+export function evaluateBlockedHandTiebreakResponse(scenarioInput: JourneyAuthoredScenario, response: JourneyScenarioResponse): JourneyScenarioEvaluation {
+  const scenario = scenarioInput as BlockedHandTiebreakScenario;
+  if (response.kind !== 'move') throw new Error(`Reading the Blocked-Hand Tiebreak expects move responses, received ${response.kind}.`);
+  const consequence = analyzeJourneyAuthoredMove(scenario, response.action);
+  const before = [scenario.board.leftEnd, scenario.board.rightEnd];
+  if (!consequence.legal) {
+    return { kind: 'illegal', feedbackOutcomeKey: 'illegal_action', decisionSummary: { total: 1, correct: 0, incorrect: 1 }, mistakeCategoryIds: ['mistake:illegal-action'], nextBoard: null, openEndsBefore: before, openEndsAfter: before, consequence };
+  }
+  const accepted = scenario.acceptedActions.some((action) => sameAction(action, response.action));
+  const acceptedResult = scenario.kind === 'proof' ? 'passed' : 'completed';
+  const feedbackOutcomeKey = scenario.feedbackByAction[actionKey(response.action)] ?? (accepted ? 'valid_alternative' : 'ignored_pip_math');
+  return {
+    kind: 'evaluated',
+    result: accepted ? acceptedResult : 'failed',
+    feedbackOutcomeKey,
+    decisionSummary: { total: 1, correct: accepted ? 1 : 0, incorrect: accepted ? 0 : 1 },
+    mistakeCategoryIds: accepted ? [] : ['mistake:ignored-pip-total'],
+    nextBoard: consequence.resultingBoard,
+    openEndsBefore: before,
+    openEndsAfter: consequence.resultingOpenEnds,
+    consequence,
+  };
+}

--- a/client/src/journey/lessons/blockedHandTiebreak/blockedHandTiebreakFeedback.ts
+++ b/client/src/journey/lessons/blockedHandTiebreak/blockedHandTiebreakFeedback.ts
@@ -1,0 +1,12 @@
+import type { JourneyFeedbackId } from '../../journeyContentContract.ts';
+import type { JourneyFeedbackAsset } from '../../journeyAuthoredLessonBundle.ts';
+
+export const BLOCKED_HAND_TIEBREAK_FEEDBACK_ID = 'journey:feedback:blocked-hand-tiebreak' as JourneyFeedbackId;
+export const BLOCKED_HAND_TIEBREAK_FEEDBACK: Record<string, JourneyFeedbackAsset> = {
+  kept_hand_light: { key: 'kept_hand_light', heading: 'You kept your hand light.', explanation: 'When blockedHandRule pays the lowest pip total, the tile you play matters less than the tiles you keep. This line left you carrying fewer pips.', fritzRemark: 'If the hand blocks, that total is the whole game.', retryExpected: false },
+  loaded_up_on_pips: { key: 'loaded_up_on_pips', heading: 'That line left you heavy.', explanation: 'Both tiles were legal, but this one left more pips sitting in your hand. If the hand blocks before you go out, that total decides the winner.', fritzRemark: null, retryExpected: true },
+  recognized_tiebreak_math: { key: 'recognized_tiebreak_math', heading: 'You read the tiebreak.', explanation: 'You compared what each legal play left behind, not just what it scored. That is the actual skill here.', fritzRemark: 'The board rarely tells you a block is coming until it already has.', retryExpected: false },
+  ignored_pip_math: { key: 'ignored_pip_math', heading: 'The pip math went the other way.', explanation: 'This play was legal, but the alternative left a lower total. In a race decided by a block, that gap is the whole margin.', fritzRemark: null, retryExpected: true },
+  valid_alternative: { key: 'valid_alternative', heading: 'That line is defensible.', explanation: 'More than one legal move can protect your pip total about equally well.', fritzRemark: null, retryExpected: false },
+  illegal_action: { key: 'illegal_action', heading: 'That placement is not legal.', explanation: 'Choose a tile and open end that match the board.', fritzRemark: null, retryExpected: true },
+};

--- a/client/src/journey/lessons/blockedHandTiebreak/blockedHandTiebreakLesson.ts
+++ b/client/src/journey/lessons/blockedHandTiebreak/blockedHandTiebreakLesson.ts
@@ -1,0 +1,29 @@
+import type { JourneyContentId, JourneyLessonDefinition, JourneyNodeId, JourneySkillId } from '../../journeyContentContract.ts';
+import { CORE_JOURNEY_RULESET_ID } from '../../journeyContentContract.ts';
+import { BLOCKED_HAND_TIEBREAK_FEEDBACK_ID } from './blockedHandTiebreakFeedback.ts';
+
+export const BLOCKED_HAND_TIEBREAK_CONTENT_ID = 'journey:ch2:blocked-hand-tiebreak' as JourneyContentId;
+export const BLOCKED_HAND_TIEBREAK_NODE_ID = 'ch2-n07' as JourneyNodeId;
+export const BLOCKED_HAND_TIEBREAK_SKILL_ID = 'skill:blocked-hand-tiebreak' as JourneySkillId;
+export const BLOCKED_HAND_TIEBREAK_PRACTICE_VARIANT_SET_ID = 'variants:blocked-hand-tiebreak-practice';
+export const BLOCKED_HAND_TIEBREAK_PROOF_VARIANT_SET_ID = 'variants:blocked-hand-tiebreak-proof';
+const feedback = { kind: 'outcome_bundle', id: BLOCKED_HAND_TIEBREAK_FEEDBACK_ID } as const;
+
+export const BLOCKED_HAND_TIEBREAK_LESSON_DEFINITION: JourneyLessonDefinition = {
+  id: BLOCKED_HAND_TIEBREAK_CONTENT_ID,
+  nodeId: BLOCKED_HAND_TIEBREAK_NODE_ID,
+  chapterId: 'ch2-high-line',
+  skillId: BLOCKED_HAND_TIEBREAK_SKILL_ID,
+  contentVersion: 1,
+  ruleset: { kind: 'core_journey', id: CORE_JOURNEY_RULESET_ID },
+  prerequisites: ['journey:ch1:doubles-arent-free' as JourneyContentId],
+  presentation: { tableContextId: 'table:fritz', rivalContextId: null },
+  stages: [
+    { id: 'welcome', kind: 'frame', copyRef: 'blocked-hand-tiebreak:welcome', evidenceRole: 'none' },
+    { id: 'tiebreak-demo', kind: 'board_demo', scenarioRef: 'scenario:tiebreak-demo', evidenceRole: 'none' },
+    { id: 'guided-decision', kind: 'guided_practice', scenarioRef: 'scenario:tiebreak-guided', feedbackRef: feedback, retry: { kind: 'same_scenario' }, evidenceRole: 'none', failurePolicy: 'retry_required' },
+    { id: 'independent-practice', kind: 'independent_practice', scenarioRef: 'scenario:tiebreak-practice-1', feedbackRef: feedback, retry: { kind: 'fresh_variant', variantSetId: BLOCKED_HAND_TIEBREAK_PRACTICE_VARIANT_SET_ID }, evidenceRole: 'practice', failurePolicy: 'retry_required' },
+    { id: 'proof', kind: 'mastery', scenarioRef: 'scenario:tiebreak-proof-1', feedbackRef: feedback, retry: { kind: 'fresh_variant', variantSetId: BLOCKED_HAND_TIEBREAK_PROOF_VARIANT_SET_ID }, evidenceRole: 'proof', failurePolicy: 'retry_required' },
+  ],
+  completion: { kind: 'required_stages', stageIds: ['independent-practice', 'proof'], owner: 'journey_lesson_controller' },
+};

--- a/client/src/journey/lessons/blockedHandTiebreak/blockedHandTiebreakScenarios.ts
+++ b/client/src/journey/lessons/blockedHandTiebreak/blockedHandTiebreakScenarios.ts
@@ -1,0 +1,102 @@
+import type { BoardState, Tile } from '../../../types.ts';
+import type { JourneyAuthoredMoveAction, JourneyAuthoredScenario, JourneyBoardDemonstrationStep } from '../../journeyAuthoredLessonBundle.ts';
+import { previewPlayMove } from '../../../modules/match/runtime/botEngine.ts';
+import { createJourneyScenarioState } from '../../journeyAuthoredLessonBundle.ts';
+import { CORE_JOURNEY_RULESET_ID } from '../../journeyContentContract.ts';
+import { BLOCKED_HAND_TIEBREAK_PRACTICE_VARIANT_SET_ID, BLOCKED_HAND_TIEBREAK_PROOF_VARIANT_SET_ID } from './blockedHandTiebreakLesson.ts';
+
+export type BlockedHandTiebreakScenario = JourneyAuthoredScenario & {
+  pipTotalFacts: { acceptedRemainingPips: number; temptingRemainingPips: number };
+};
+
+const tile = (low: number, high: number): Tile => ({ low, high });
+const core = { kind: 'core_journey' as const, id: CORE_JOURNEY_RULESET_ID };
+
+function singleTileBoard(a: number, b: number): BoardState {
+  return { mainLine: [{ tile: tile(a, b), orientation: 'horizontal-normal' }], leftEnd: a, rightEnd: b, leftEndIsDouble: false, rightEndIsDouble: false, hubDoubles: [] };
+}
+
+function pipSum(hand: Tile[]): number {
+  return hand.reduce((sum, t) => sum + t.low + t.high, 0);
+}
+
+function actionKey(action: JourneyAuthoredMoveAction): string {
+  return `${action.tile.low}-${action.tile.high}@${action.position}`;
+}
+
+function remainingAfter(board: BoardState, hand: Tile[], action: JourneyAuthoredMoveAction): number {
+  const state = createJourneyScenarioState({ id: 'tmp', variantSetId: null, kind: 'demo', ruleset: core, board, playerHand: hand, interaction: { kind: 'move' }, acceptedActions: [], temptingActions: [], feedbackByAction: {} });
+  const preview = previewPlayMove(state, 'you', { type: 'play', tile: action.tile, position: action.position });
+  if (!preview) throw new Error(`blocked-hand-tiebreak: ${actionKey(action)} is not a legal preview against this board`);
+  return pipSum(preview.nextHand);
+}
+
+function scenario(
+  id: string,
+  kind: BlockedHandTiebreakScenario['kind'],
+  variantSetId: string | null,
+  board: BoardState,
+  hand: Tile[],
+  accepted: JourneyAuthoredMoveAction,
+  tempting: JourneyAuthoredMoveAction,
+  acceptedFeedback: string,
+  temptingFeedback: string,
+): BlockedHandTiebreakScenario {
+  const acceptedRemainingPips = remainingAfter(board, hand, accepted);
+  const temptingRemainingPips = remainingAfter(board, hand, tempting);
+  if (acceptedRemainingPips >= temptingRemainingPips) {
+    throw new Error(`${id}: accepted action must leave a lower remaining pip total than the tempting one (${acceptedRemainingPips} vs ${temptingRemainingPips})`);
+  }
+  return {
+    id, variantSetId, kind, ruleset: core, board, playerHand: hand, interaction: { kind: 'move' },
+    acceptedActions: [accepted], temptingActions: [tempting],
+    feedbackByAction: { [actionKey(accepted)]: acceptedFeedback, [actionKey(tempting)]: temptingFeedback },
+    pipTotalFacts: { acceptedRemainingPips, temptingRemainingPips },
+  };
+}
+
+const demoBoard = singleTileBoard(4, 2);
+const demoHand = [tile(2, 3), tile(4, 6), tile(5, 5)];
+const demoAccepted = { tile: tile(4, 6), position: 'left' as const };
+const demoTempting = { tile: tile(2, 3), position: 'right' as const };
+
+const demoSteps: JourneyBoardDemonstrationStep[] = [
+  { id: 'tiebreak-demo-position', kind: 'position', caption: 'Both tiles are legal here.', boardDescription: 'You hold 2-3, 4-6, and the double 5-5. Either 2-3 or 4-6 can be played right now.', board: demoBoard, highlightedEnds: [4, 2] },
+  { id: 'tiebreak-demo-tempting', kind: 'preview_move', caption: 'Play the low tile first.', boardDescription: 'Playing 2-3 feels tidy, but it leaves 4-6 and the 5-5 double sitting in your hand — 20 pips of exposure if the hand blocks.', board: previewPlayMove(createJourneyScenarioState({ id: 'demo', variantSetId: null, kind: 'demo', ruleset: core, board: demoBoard, playerHand: demoHand, interaction: { kind: 'move' }, acceptedActions: [], temptingActions: [], feedbackByAction: {} }), 'you', { type: 'play', tile: demoTempting.tile, position: demoTempting.position })!.nextBoard, action: demoTempting, highlightedEnds: [4, 2] },
+  { id: 'tiebreak-demo-accepted', kind: 'preview_move', caption: 'Compare playing 4-6 instead.', boardDescription: 'This leaves 2-3 and the 5-5 double — 15 pips. Same legality, five fewer pips sitting in your hand if the hand blocks.', board: previewPlayMove(createJourneyScenarioState({ id: 'demo', variantSetId: null, kind: 'demo', ruleset: core, board: demoBoard, playerHand: demoHand, interaction: { kind: 'move' }, acceptedActions: [], temptingActions: [], feedbackByAction: {} }), 'you', { type: 'play', tile: demoAccepted.tile, position: demoAccepted.position })!.nextBoard, action: demoAccepted, highlightedEnds: [4, 2] },
+];
+
+export const BLOCKED_HAND_TIEBREAK_SCENARIOS: BlockedHandTiebreakScenario[] = [
+  { ...scenario('scenario:tiebreak-demo', 'demo', null, demoBoard, demoHand, demoAccepted, demoTempting, 'kept_hand_light', 'loaded_up_on_pips'), demonstrationSteps: demoSteps },
+  scenario('scenario:tiebreak-guided', 'guided', null, demoBoard, demoHand, demoAccepted, demoTempting, 'kept_hand_light', 'loaded_up_on_pips'),
+  scenario(
+    'scenario:tiebreak-practice-1', 'independent', BLOCKED_HAND_TIEBREAK_PRACTICE_VARIANT_SET_ID,
+    singleTileBoard(6, 1), [tile(1, 4), tile(6, 3), tile(5, 5)],
+    { tile: tile(6, 3), position: 'left' }, { tile: tile(1, 4), position: 'right' },
+    'recognized_tiebreak_math', 'ignored_pip_math',
+  ),
+  scenario(
+    'scenario:tiebreak-practice-2', 'independent', BLOCKED_HAND_TIEBREAK_PRACTICE_VARIANT_SET_ID,
+    singleTileBoard(3, 0), [tile(0, 5), tile(3, 1), tile(6, 6)],
+    { tile: tile(0, 5), position: 'right' }, { tile: tile(3, 1), position: 'left' },
+    'recognized_tiebreak_math', 'ignored_pip_math',
+  ),
+  scenario(
+    'scenario:tiebreak-practice-3', 'independent', BLOCKED_HAND_TIEBREAK_PRACTICE_VARIANT_SET_ID,
+    singleTileBoard(2, 5), [tile(5, 1), tile(2, 6), tile(4, 4)],
+    { tile: tile(2, 6), position: 'left' }, { tile: tile(5, 1), position: 'right' },
+    'recognized_tiebreak_math', 'ignored_pip_math',
+  ),
+  scenario(
+    'scenario:tiebreak-proof-1', 'proof', BLOCKED_HAND_TIEBREAK_PROOF_VARIANT_SET_ID,
+    singleTileBoard(1, 3), [tile(3, 6), tile(1, 0), tile(5, 5)],
+    { tile: tile(3, 6), position: 'right' }, { tile: tile(1, 0), position: 'left' },
+    'recognized_tiebreak_math', 'ignored_pip_math',
+  ),
+  scenario(
+    'scenario:tiebreak-proof-2', 'proof', BLOCKED_HAND_TIEBREAK_PROOF_VARIANT_SET_ID,
+    singleTileBoard(4, 0), [tile(0, 2), tile(4, 5), tile(6, 6)],
+    { tile: tile(4, 5), position: 'left' }, { tile: tile(0, 2), position: 'right' },
+    'recognized_tiebreak_math', 'ignored_pip_math',
+  ),
+];

--- a/client/src/journey/lessons/blockedHandTiebreak/blockedHandTiebreakValidation.ts
+++ b/client/src/journey/lessons/blockedHandTiebreak/blockedHandTiebreakValidation.ts
@@ -1,0 +1,35 @@
+import { getLegalMoves } from '../../../modules/match/runtime/botEngine.ts';
+import { createJourneyScenarioState } from '../../journeyAuthoredLessonBundle.ts';
+import { BLOCKED_HAND_TIEBREAK_CONTENT_ID, BLOCKED_HAND_TIEBREAK_PRACTICE_VARIANT_SET_ID, BLOCKED_HAND_TIEBREAK_PROOF_VARIANT_SET_ID } from './blockedHandTiebreakLesson.ts';
+import { BLOCKED_HAND_TIEBREAK_FEEDBACK } from './blockedHandTiebreakFeedback.ts';
+import { BLOCKED_HAND_TIEBREAK_SCENARIOS } from './blockedHandTiebreakScenarios.ts';
+
+export function validateBlockedHandTiebreakContent(definition: { id: string; nodeId: string }): string[] {
+  const errors: string[] = [];
+  const ids = new Set<string>();
+  for (const scenario of BLOCKED_HAND_TIEBREAK_SCENARIOS) {
+    if (ids.has(scenario.id)) errors.push(`duplicate scenario ${scenario.id}`);
+    ids.add(scenario.id);
+    const legal = getLegalMoves(createJourneyScenarioState(scenario), 'you');
+    const legalAction = (action: { tile: { low: number; high: number }; position: string }) =>
+      legal.some((move) => move.type === 'play' && move.tile && move.position === action.position && move.tile.low === action.tile.low && move.tile.high === action.tile.high);
+    for (const action of [...scenario.acceptedActions, ...scenario.temptingActions]) {
+      if (!legalAction(action)) errors.push(`${scenario.id}: illegal authored action ${action.tile.low}-${action.tile.high}@${action.position}`);
+      const key = `${action.tile.low}-${action.tile.high}@${action.position}`;
+      if (!scenario.feedbackByAction[key] || !BLOCKED_HAND_TIEBREAK_FEEDBACK[scenario.feedbackByAction[key]]) errors.push(`${scenario.id}: missing feedback for ${key}`);
+    }
+    if (scenario.pipTotalFacts.acceptedRemainingPips >= scenario.pipTotalFacts.temptingRemainingPips) {
+      errors.push(`${scenario.id}: accepted action must leave a strictly lower remaining pip total`);
+    }
+    for (const step of scenario.demonstrationSteps ?? []) {
+      if (!step.caption.trim() || !step.boardDescription.trim()) errors.push(`${scenario.id}: demonstration copy is empty`);
+      if (step.kind === 'preview_move' && !legalAction(step.action)) errors.push(`${scenario.id}: illegal demonstration preview ${step.id}`);
+    }
+  }
+  const practice = BLOCKED_HAND_TIEBREAK_SCENARIOS.filter((s) => s.variantSetId === BLOCKED_HAND_TIEBREAK_PRACTICE_VARIANT_SET_ID);
+  const proof = BLOCKED_HAND_TIEBREAK_SCENARIOS.filter((s) => s.variantSetId === BLOCKED_HAND_TIEBREAK_PROOF_VARIANT_SET_ID);
+  if (practice.length < 3) errors.push('blocked-hand-tiebreak practice needs at least three variants');
+  if (proof.length < 2) errors.push('blocked-hand-tiebreak proof needs at least two variants');
+  if (definition.id !== BLOCKED_HAND_TIEBREAK_CONTENT_ID || definition.nodeId !== 'ch2-n07') errors.push('blocked-hand-tiebreak definition identity mismatch');
+  return errors.sort();
+}

--- a/client/src/journey/lessons/defensiveHolding/defensiveHolding.test.ts
+++ b/client/src/journey/lessons/defensiveHolding/defensiveHolding.test.ts
@@ -1,0 +1,56 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest';
+import { getCoreJourneyTileSet, getUnseenTileCountForPip } from '../../journeyCounting.ts';
+import { DEFENSIVE_HOLDING_LESSON_DEFINITION } from './defensiveHoldingLesson.ts';
+import { DEFENSIVE_HOLDING_SCENARIOS } from './defensiveHoldingScenarios.ts';
+import { evaluateDefensiveHoldingResponse } from './defensiveHoldingEvaluator.ts';
+import { validateDefensiveHoldingContent } from './defensiveHoldingValidation.ts';
+
+function otherPip(tile: { low: number; high: number }, matched: number): number {
+  return tile.low === matched ? tile.high : tile.low;
+}
+
+describe('Defensive Holding', () => {
+  it('validates every authored scenario and the practice/proof variant minimums', () => {
+    expect(validateDefensiveHoldingContent(DEFENSIVE_HOLDING_LESSON_DEFINITION)).toEqual([]);
+    expect(DEFENSIVE_HOLDING_SCENARIOS.filter((s) => s.variantSetId === 'variants:defensive-holding-practice')).toHaveLength(3);
+    expect(DEFENSIVE_HOLDING_SCENARIOS.filter((s) => s.variantSetId === 'variants:defensive-holding-proof')).toHaveLength(2);
+  });
+
+  it('exposes a strictly safer (lower unseen-count) pip for the accepted action than the tempting one, for every scenario', () => {
+    for (const scenario of DEFENSIVE_HOLDING_SCENARIOS) {
+      const accepted = scenario.acceptedActions[0];
+      const tempting = scenario.temptingActions[0];
+      const acceptedMatchedEnd = accepted.position === 'left' ? scenario.board.leftEnd : scenario.board.rightEnd;
+      const temptingMatchedEnd = tempting.position === 'left' ? scenario.board.leftEnd : scenario.board.rightEnd;
+      const acceptedUnseen = getUnseenTileCountForPip({ tileSet: getCoreJourneyTileSet(), board: scenario.board, playerHand: scenario.playerHand, pip: otherPip(accepted.tile, acceptedMatchedEnd) });
+      const temptingUnseen = getUnseenTileCountForPip({ tileSet: getCoreJourneyTileSet(), board: scenario.board, playerHand: scenario.playerHand, pip: otherPip(tempting.tile, temptingMatchedEnd) });
+      expect(acceptedUnseen).toBeLessThan(temptingUnseen);
+    }
+  });
+
+  it('passes a proof scenario when the accepted (safer) action is chosen', () => {
+    const scenario = DEFENSIVE_HOLDING_SCENARIOS.find((entry) => entry.id === 'scenario:holding-proof-1')!;
+    const result = evaluateDefensiveHoldingResponse(scenario, { kind: 'move', action: scenario.acceptedActions[0] });
+    expect(result.result).toBe('passed');
+  });
+
+  it('fails a proof scenario when the tempting (dangerous) action is chosen', () => {
+    const scenario = DEFENSIVE_HOLDING_SCENARIOS.find((entry) => entry.id === 'scenario:holding-proof-1')!;
+    const result = evaluateDefensiveHoldingResponse(scenario, { kind: 'move', action: scenario.temptingActions[0] });
+    expect(result.result).toBe('failed');
+    expect(result.feedbackOutcomeKey).toBe('ignored_the_count');
+  });
+
+  it('rejects an illegal authored response before controller submission', () => {
+    const scenario = DEFENSIVE_HOLDING_SCENARIOS.find((entry) => entry.id === 'scenario:holding-guided')!;
+    const result = evaluateDefensiveHoldingResponse(scenario, { kind: 'move', action: { tile: { low: 6, high: 6 }, position: 'left' } });
+    expect(result.kind).toBe('illegal');
+    expect(result.result).toBeUndefined();
+  });
+
+  it('keeps demonstration steps discrete', () => {
+    const demo = DEFENSIVE_HOLDING_SCENARIOS.find((entry) => entry.id === 'scenario:holding-demo')!;
+    expect(demo.demonstrationSteps?.map((step) => step.id)).toEqual(['holding-demo-position', 'holding-demo-tempting', 'holding-demo-accepted']);
+  });
+});

--- a/client/src/journey/lessons/defensiveHolding/defensiveHoldingBundle.ts
+++ b/client/src/journey/lessons/defensiveHolding/defensiveHoldingBundle.ts
@@ -1,0 +1,20 @@
+import type { JourneyAuthoredLessonBundle } from '../../journeyAuthoredLessonBundle.ts';
+import { DEFENSIVE_HOLDING_LESSON_DEFINITION } from './defensiveHoldingLesson.ts';
+import { DEFENSIVE_HOLDING_FEEDBACK } from './defensiveHoldingFeedback.ts';
+import { evaluateDefensiveHoldingResponse } from './defensiveHoldingEvaluator.ts';
+import { DEFENSIVE_HOLDING_SCENARIOS } from './defensiveHoldingScenarios.ts';
+
+export const DEFENSIVE_HOLDING_BUNDLE: JourneyAuthoredLessonBundle = {
+  contentId: DEFENSIVE_HOLDING_LESSON_DEFINITION.id,
+  definition: DEFENSIVE_HOLDING_LESSON_DEFINITION,
+  scenarios: Object.fromEntries(DEFENSIVE_HOLDING_SCENARIOS.map((scenario) => [scenario.id, scenario])),
+  feedback: DEFENSIVE_HOLDING_FEEDBACK,
+  presentation: {
+    tableTitle: 'Fritz’s Table',
+    lessonTitle: 'Defensive Holding',
+    framingLine: 'The end you leave open matters as much as the tile you played to leave it.',
+    framingInstruction: 'Before you play, count which end is actually the harder one for Fritz to answer.',
+    completionLine: 'You stopped exposing the crowded end out of habit. You checked which one was actually guarded.',
+  },
+  evaluateResponse: evaluateDefensiveHoldingResponse,
+};

--- a/client/src/journey/lessons/defensiveHolding/defensiveHoldingEvaluator.ts
+++ b/client/src/journey/lessons/defensiveHolding/defensiveHoldingEvaluator.ts
@@ -1,0 +1,29 @@
+import { analyzeJourneyAuthoredMove, type JourneyAuthoredScenario, type JourneyScenarioEvaluation, type JourneyScenarioResponse } from '../../journeyAuthoredLessonBundle.ts';
+import type { DefensiveHoldingScenario } from './defensiveHoldingScenarios.ts';
+
+function actionKey(action: { tile: { low: number; high: number }; position: string }): string { return `${action.tile.low}-${action.tile.high}@${action.position}`; }
+function sameAction(a: { tile: { low: number; high: number }; position: string }, b: { tile: { low: number; high: number }; position: string }): boolean { return actionKey(a) === actionKey(b); }
+
+export function evaluateDefensiveHoldingResponse(scenarioInput: JourneyAuthoredScenario, response: JourneyScenarioResponse): JourneyScenarioEvaluation {
+  const scenario = scenarioInput as DefensiveHoldingScenario;
+  if (response.kind !== 'move') throw new Error(`Defensive Holding expects move responses, received ${response.kind}.`);
+  const consequence = analyzeJourneyAuthoredMove(scenario, response.action);
+  const before = [scenario.board.leftEnd, scenario.board.rightEnd];
+  if (!consequence.legal) {
+    return { kind: 'illegal', feedbackOutcomeKey: 'illegal_action', decisionSummary: { total: 1, correct: 0, incorrect: 1 }, mistakeCategoryIds: ['mistake:illegal-action'], nextBoard: null, openEndsBefore: before, openEndsAfter: before, consequence };
+  }
+  const accepted = scenario.acceptedActions.some((action) => sameAction(action, response.action));
+  const acceptedResult = scenario.kind === 'proof' ? 'passed' : 'completed';
+  const feedbackOutcomeKey = scenario.feedbackByAction[actionKey(response.action)] ?? (accepted ? 'valid_alternative' : 'ignored_the_count');
+  return {
+    kind: 'evaluated',
+    result: accepted ? acceptedResult : 'failed',
+    feedbackOutcomeKey,
+    decisionSummary: { total: 1, correct: accepted ? 1 : 0, incorrect: accepted ? 0 : 1 },
+    mistakeCategoryIds: accepted ? [] : ['mistake:exposed-dangerous-end'],
+    nextBoard: consequence.resultingBoard,
+    openEndsBefore: before,
+    openEndsAfter: consequence.resultingOpenEnds,
+    consequence,
+  };
+}

--- a/client/src/journey/lessons/defensiveHolding/defensiveHoldingFeedback.ts
+++ b/client/src/journey/lessons/defensiveHolding/defensiveHoldingFeedback.ts
@@ -1,0 +1,12 @@
+import type { JourneyFeedbackId } from '../../journeyContentContract.ts';
+import type { JourneyFeedbackAsset } from '../../journeyAuthoredLessonBundle.ts';
+
+export const DEFENSIVE_HOLDING_FEEDBACK_ID = 'journey:feedback:defensive-holding' as JourneyFeedbackId;
+export const DEFENSIVE_HOLDING_FEEDBACK: Record<string, JourneyFeedbackAsset> = {
+  exposed_the_safer_end: { key: 'exposed_the_safer_end', heading: 'You exposed the safer end.', explanation: 'Fewer tiles carrying that pip are still unseen. Fritz is less likely to hold a matching reply.', fritzRemark: 'Denial starts with what you leave open, not just what you play.', retryExpected: false },
+  exposed_the_dangerous_end: { key: 'exposed_the_dangerous_end', heading: 'That end was still crowded.', explanation: 'This play was legal, but it left an end value with more unseen tiles. Fritz has better odds of holding a reply there than at the alternative.', fritzRemark: null, retryExpected: true },
+  read_the_denial: { key: 'read_the_denial', heading: 'You read the denial.', explanation: 'You checked which of your legal plays left the harder end for Fritz to answer, not just which one felt natural.', fritzRemark: null, retryExpected: false },
+  ignored_the_count: { key: 'ignored_the_count', heading: 'You skipped the count.', explanation: 'One of your legal plays left a genuinely safer end. This one did not.', fritzRemark: null, retryExpected: true },
+  valid_alternative: { key: 'valid_alternative', heading: 'That line is defensible.', explanation: 'More than one legal move can leave a similarly guarded position.', fritzRemark: null, retryExpected: false },
+  illegal_action: { key: 'illegal_action', heading: 'That placement is not legal.', explanation: 'Choose a tile and open end that match the board.', fritzRemark: null, retryExpected: true },
+};

--- a/client/src/journey/lessons/defensiveHolding/defensiveHoldingLesson.ts
+++ b/client/src/journey/lessons/defensiveHolding/defensiveHoldingLesson.ts
@@ -1,0 +1,29 @@
+import type { JourneyContentId, JourneyLessonDefinition, JourneyNodeId, JourneySkillId } from '../../journeyContentContract.ts';
+import { CORE_JOURNEY_RULESET_ID } from '../../journeyContentContract.ts';
+import { DEFENSIVE_HOLDING_FEEDBACK_ID } from './defensiveHoldingFeedback.ts';
+
+export const DEFENSIVE_HOLDING_CONTENT_ID = 'journey:ch4:defensive-holding' as JourneyContentId;
+export const DEFENSIVE_HOLDING_NODE_ID = 'ch4-n07' as JourneyNodeId;
+export const DEFENSIVE_HOLDING_SKILL_ID = 'skill:defensive-holding' as JourneySkillId;
+export const DEFENSIVE_HOLDING_PRACTICE_VARIANT_SET_ID = 'variants:defensive-holding-practice';
+export const DEFENSIVE_HOLDING_PROOF_VARIANT_SET_ID = 'variants:defensive-holding-proof';
+const feedback = { kind: 'outcome_bundle', id: DEFENSIVE_HOLDING_FEEDBACK_ID } as const;
+
+export const DEFENSIVE_HOLDING_LESSON_DEFINITION: JourneyLessonDefinition = {
+  id: DEFENSIVE_HOLDING_CONTENT_ID,
+  nodeId: DEFENSIVE_HOLDING_NODE_ID,
+  chapterId: 'ch4-pressure-circuit',
+  skillId: DEFENSIVE_HOLDING_SKILL_ID,
+  contentVersion: 1,
+  ruleset: { kind: 'core_journey', id: CORE_JOURNEY_RULESET_ID },
+  prerequisites: ['journey:ch3:endgame-hand-shape' as JourneyContentId],
+  presentation: { tableContextId: 'table:fritz', rivalContextId: null },
+  stages: [
+    { id: 'welcome', kind: 'frame', copyRef: 'defensive-holding:welcome', evidenceRole: 'none' },
+    { id: 'holding-demo', kind: 'board_demo', scenarioRef: 'scenario:holding-demo', evidenceRole: 'none' },
+    { id: 'guided-decision', kind: 'guided_practice', scenarioRef: 'scenario:holding-guided', feedbackRef: feedback, retry: { kind: 'same_scenario' }, evidenceRole: 'none', failurePolicy: 'retry_required' },
+    { id: 'independent-practice', kind: 'independent_practice', scenarioRef: 'scenario:holding-practice-1', feedbackRef: feedback, retry: { kind: 'fresh_variant', variantSetId: DEFENSIVE_HOLDING_PRACTICE_VARIANT_SET_ID }, evidenceRole: 'practice', failurePolicy: 'retry_required' },
+    { id: 'proof', kind: 'mastery', scenarioRef: 'scenario:holding-proof-1', feedbackRef: feedback, retry: { kind: 'fresh_variant', variantSetId: DEFENSIVE_HOLDING_PROOF_VARIANT_SET_ID }, evidenceRole: 'proof', failurePolicy: 'retry_required' },
+  ],
+  completion: { kind: 'required_stages', stageIds: ['independent-practice', 'proof'], owner: 'journey_lesson_controller' },
+};

--- a/client/src/journey/lessons/defensiveHolding/defensiveHoldingScenarios.ts
+++ b/client/src/journey/lessons/defensiveHolding/defensiveHoldingScenarios.ts
@@ -1,0 +1,107 @@
+import type { BoardState, Tile } from '../../../types.ts';
+import type { JourneyAuthoredMoveAction, JourneyAuthoredScenario, JourneyBoardDemonstrationStep } from '../../journeyAuthoredLessonBundle.ts';
+import { createJourneyScenarioState } from '../../journeyAuthoredLessonBundle.ts';
+import { previewPlayMove } from '../../../modules/match/runtime/botEngine.ts';
+import { getCoreJourneyTileSet, getUnseenTileCountForPip } from '../../journeyCounting.ts';
+import { CORE_JOURNEY_RULESET_ID } from '../../journeyContentContract.ts';
+import { DEFENSIVE_HOLDING_PRACTICE_VARIANT_SET_ID, DEFENSIVE_HOLDING_PROOF_VARIANT_SET_ID } from './defensiveHoldingLesson.ts';
+
+export type DefensiveHoldingScenario = JourneyAuthoredScenario & {
+  denialFacts: { acceptedUnseenCount: number; temptingUnseenCount: number };
+};
+
+const tile = (low: number, high: number): Tile => ({ low, high });
+const core = { kind: 'core_journey' as const, id: CORE_JOURNEY_RULESET_ID };
+
+function singleTileBoard(a: number, b: number): BoardState {
+  return { mainLine: [{ tile: tile(a, b), orientation: 'horizontal-normal' }], leftEnd: a, rightEnd: b, leftEndIsDouble: false, rightEndIsDouble: false, hubDoubles: [] };
+}
+
+function actionKey(action: JourneyAuthoredMoveAction): string {
+  return `${action.tile.low}-${action.tile.high}@${action.position}`;
+}
+
+function otherPip(t: Tile, matched: number): number {
+  return t.low === matched ? t.high : t.low;
+}
+
+function baseScenario(board: BoardState, hand: Tile[]): JourneyAuthoredScenario {
+  return { id: 'tmp', variantSetId: null, kind: 'demo', ruleset: core, board, playerHand: hand, interaction: { kind: 'move' }, acceptedActions: [], temptingActions: [], feedbackByAction: {} };
+}
+
+function unseenAfterAction(board: BoardState, hand: Tile[], action: JourneyAuthoredMoveAction): number {
+  const matchedEnd = action.position === 'left' ? board.leftEnd : board.rightEnd;
+  const exposedPip = otherPip(action.tile, matchedEnd);
+  return getUnseenTileCountForPip({ tileSet: getCoreJourneyTileSet(), board, playerHand: hand, pip: exposedPip });
+}
+
+function scenario(
+  id: string,
+  kind: DefensiveHoldingScenario['kind'],
+  variantSetId: string | null,
+  board: BoardState,
+  hand: Tile[],
+  accepted: JourneyAuthoredMoveAction,
+  tempting: JourneyAuthoredMoveAction,
+  acceptedFeedback: string,
+  temptingFeedback: string,
+): DefensiveHoldingScenario {
+  const acceptedUnseenCount = unseenAfterAction(board, hand, accepted);
+  const temptingUnseenCount = unseenAfterAction(board, hand, tempting);
+  if (acceptedUnseenCount >= temptingUnseenCount) {
+    throw new Error(`${id}: accepted action must expose a pip with a strictly lower unseen count than the tempting one (${acceptedUnseenCount} vs ${temptingUnseenCount})`);
+  }
+  return {
+    id, variantSetId, kind, ruleset: core, board, playerHand: hand, interaction: { kind: 'move' },
+    acceptedActions: [accepted], temptingActions: [tempting],
+    feedbackByAction: { [actionKey(accepted)]: acceptedFeedback, [actionKey(tempting)]: temptingFeedback },
+    denialFacts: { acceptedUnseenCount, temptingUnseenCount },
+  };
+}
+
+const demoBoard = singleTileBoard(2, 4);
+const demoHand = [tile(2, 6), tile(4, 1), tile(1, 3)];
+const demoAccepted = { tile: tile(4, 1), position: 'right' as const };
+const demoTempting = { tile: tile(2, 6), position: 'left' as const };
+const demoBase = baseScenario(demoBoard, demoHand);
+
+const demoSteps: JourneyBoardDemonstrationStep[] = [
+  { id: 'holding-demo-position', kind: 'position', caption: 'Two legal replies.', boardDescription: 'You hold 2-6, 4-1, and 1-3. Both 2-6 and 4-1 are legal right now.', board: demoBoard, highlightedEnds: [2, 4] },
+  { id: 'holding-demo-tempting', kind: 'preview_move', caption: 'Play the 2-end tile.', boardDescription: 'Playing 2-6 exposes a 6. Fewer of your own tiles account for 6s, so more of them are still unseen — Fritz is more likely to have a reply.', board: previewPlayMove(createJourneyScenarioState(demoBase), 'you', { type: 'play', tile: demoTempting.tile, position: demoTempting.position })!.nextBoard, action: demoTempting, highlightedEnds: [2, 4] },
+  { id: 'holding-demo-accepted', kind: 'preview_move', caption: 'Compare playing 4-1 instead.', boardDescription: 'Playing 4-1 exposes a 1. You already hold another 1 yourself, so fewer 1-tiles remain unseen — this end is harder for Fritz to answer.', board: previewPlayMove(createJourneyScenarioState(demoBase), 'you', { type: 'play', tile: demoAccepted.tile, position: demoAccepted.position })!.nextBoard, action: demoAccepted, highlightedEnds: [2, 4] },
+];
+
+export const DEFENSIVE_HOLDING_SCENARIOS: DefensiveHoldingScenario[] = [
+  { ...scenario('scenario:holding-demo', 'demo', null, demoBoard, demoHand, demoAccepted, demoTempting, 'exposed_the_safer_end', 'exposed_the_dangerous_end'), demonstrationSteps: demoSteps },
+  scenario('scenario:holding-guided', 'guided', null, demoBoard, demoHand, demoAccepted, demoTempting, 'exposed_the_safer_end', 'exposed_the_dangerous_end'),
+  scenario(
+    'scenario:holding-practice-1', 'independent', DEFENSIVE_HOLDING_PRACTICE_VARIANT_SET_ID,
+    singleTileBoard(1, 5), [tile(1, 4), tile(5, 3), tile(4, 0)],
+    { tile: tile(1, 4), position: 'left' }, { tile: tile(5, 3), position: 'right' },
+    'read_the_denial', 'ignored_the_count',
+  ),
+  scenario(
+    'scenario:holding-practice-2', 'independent', DEFENSIVE_HOLDING_PRACTICE_VARIANT_SET_ID,
+    singleTileBoard(0, 6), [tile(0, 2), tile(6, 4), tile(2, 5)],
+    { tile: tile(0, 2), position: 'left' }, { tile: tile(6, 4), position: 'right' },
+    'read_the_denial', 'ignored_the_count',
+  ),
+  scenario(
+    'scenario:holding-practice-3', 'independent', DEFENSIVE_HOLDING_PRACTICE_VARIANT_SET_ID,
+    singleTileBoard(3, 6), [tile(3, 0), tile(6, 5), tile(0, 2)],
+    { tile: tile(3, 0), position: 'left' }, { tile: tile(6, 5), position: 'right' },
+    'read_the_denial', 'ignored_the_count',
+  ),
+  scenario(
+    'scenario:holding-proof-1', 'proof', DEFENSIVE_HOLDING_PROOF_VARIANT_SET_ID,
+    singleTileBoard(3, 1), [tile(3, 2), tile(1, 6), tile(2, 4)],
+    { tile: tile(3, 2), position: 'left' }, { tile: tile(1, 6), position: 'right' },
+    'read_the_denial', 'ignored_the_count',
+  ),
+  scenario(
+    'scenario:holding-proof-2', 'proof', DEFENSIVE_HOLDING_PROOF_VARIANT_SET_ID,
+    singleTileBoard(6, 2), [tile(6, 5), tile(2, 0), tile(5, 3)],
+    { tile: tile(6, 5), position: 'left' }, { tile: tile(2, 0), position: 'right' },
+    'read_the_denial', 'ignored_the_count',
+  ),
+];

--- a/client/src/journey/lessons/defensiveHolding/defensiveHoldingValidation.ts
+++ b/client/src/journey/lessons/defensiveHolding/defensiveHoldingValidation.ts
@@ -1,0 +1,37 @@
+import { getLegalMoves } from '../../../modules/match/runtime/botEngine.ts';
+import { createJourneyScenarioState } from '../../journeyAuthoredLessonBundle.ts';
+import { getCoreJourneyTileSet, validateKnownTiles } from '../../journeyCounting.ts';
+import { DEFENSIVE_HOLDING_CONTENT_ID, DEFENSIVE_HOLDING_PRACTICE_VARIANT_SET_ID, DEFENSIVE_HOLDING_PROOF_VARIANT_SET_ID } from './defensiveHoldingLesson.ts';
+import { DEFENSIVE_HOLDING_FEEDBACK } from './defensiveHoldingFeedback.ts';
+import { DEFENSIVE_HOLDING_SCENARIOS } from './defensiveHoldingScenarios.ts';
+
+export function validateDefensiveHoldingContent(definition: { id: string; nodeId: string }): string[] {
+  const errors: string[] = [];
+  const ids = new Set<string>();
+  for (const scenario of DEFENSIVE_HOLDING_SCENARIOS) {
+    if (ids.has(scenario.id)) errors.push(`duplicate scenario ${scenario.id}`);
+    ids.add(scenario.id);
+    try { validateKnownTiles(getCoreJourneyTileSet(), scenario.board, scenario.playerHand); } catch (error) { errors.push(`${scenario.id}: ${error instanceof Error ? error.message : 'invalid known tiles'}`); }
+    const legal = getLegalMoves(createJourneyScenarioState(scenario), 'you');
+    const legalAction = (action: { tile: { low: number; high: number }; position: string }) =>
+      legal.some((move) => move.type === 'play' && move.tile && move.position === action.position && move.tile.low === action.tile.low && move.tile.high === action.tile.high);
+    for (const action of [...scenario.acceptedActions, ...scenario.temptingActions]) {
+      if (!legalAction(action)) errors.push(`${scenario.id}: illegal authored action ${action.tile.low}-${action.tile.high}@${action.position}`);
+      const key = `${action.tile.low}-${action.tile.high}@${action.position}`;
+      if (!scenario.feedbackByAction[key] || !DEFENSIVE_HOLDING_FEEDBACK[scenario.feedbackByAction[key]]) errors.push(`${scenario.id}: missing feedback for ${key}`);
+    }
+    if (scenario.denialFacts.acceptedUnseenCount >= scenario.denialFacts.temptingUnseenCount) {
+      errors.push(`${scenario.id}: accepted action must expose a strictly safer (lower unseen count) end`);
+    }
+    for (const step of scenario.demonstrationSteps ?? []) {
+      if (!step.caption.trim() || !step.boardDescription.trim()) errors.push(`${scenario.id}: demonstration copy is empty`);
+      if (step.kind === 'preview_move' && !legalAction(step.action)) errors.push(`${scenario.id}: illegal demonstration preview ${step.id}`);
+    }
+  }
+  const practice = DEFENSIVE_HOLDING_SCENARIOS.filter((s) => s.variantSetId === DEFENSIVE_HOLDING_PRACTICE_VARIANT_SET_ID);
+  const proof = DEFENSIVE_HOLDING_SCENARIOS.filter((s) => s.variantSetId === DEFENSIVE_HOLDING_PROOF_VARIANT_SET_ID);
+  if (practice.length < 3) errors.push('defensive-holding practice needs at least three variants');
+  if (proof.length < 2) errors.push('defensive-holding proof needs at least two variants');
+  if (definition.id !== DEFENSIVE_HOLDING_CONTENT_ID || definition.nodeId !== 'ch4-n07') errors.push('defensive-holding definition identity mismatch');
+  return errors.sort();
+}

--- a/client/src/journey/lessons/endgameHandShape/endgameHandShape.test.ts
+++ b/client/src/journey/lessons/endgameHandShape/endgameHandShape.test.ts
@@ -1,0 +1,48 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest';
+import { analyzeJourneyAuthoredMove } from '../../journeyAuthoredLessonBundle.ts';
+import { ENDGAME_HAND_SHAPE_LESSON_DEFINITION } from './endgameHandShapeLesson.ts';
+import { ENDGAME_HAND_SHAPE_SCENARIOS } from './endgameHandShapeScenarios.ts';
+import { evaluateEndgameHandShapeResponse } from './endgameHandShapeEvaluator.ts';
+import { validateEndgameHandShapeContent } from './endgameHandShapeValidation.ts';
+
+describe('Endgame Hand Shape', () => {
+  it('validates every authored scenario and the practice/proof variant minimums', () => {
+    expect(validateEndgameHandShapeContent(ENDGAME_HAND_SHAPE_LESSON_DEFINITION)).toEqual([]);
+    expect(ENDGAME_HAND_SHAPE_SCENARIOS.filter((s) => s.variantSetId === 'variants:endgame-hand-shape-practice')).toHaveLength(3);
+    expect(ENDGAME_HAND_SHAPE_SCENARIOS.filter((s) => s.variantSetId === 'variants:endgame-hand-shape-proof')).toHaveLength(2);
+  });
+
+  it('derives strictly more remaining legal actions for the accepted action than the tempting one, for every scenario', () => {
+    for (const scenario of ENDGAME_HAND_SHAPE_SCENARIOS) {
+      const accepted = analyzeJourneyAuthoredMove(scenario, scenario.acceptedActions[0]);
+      const tempting = analyzeJourneyAuthoredMove(scenario, scenario.temptingActions[0]);
+      expect(accepted.remainingLegalActionCount).toBeGreaterThan(tempting.remainingLegalActionCount);
+    }
+  });
+
+  it('passes a proof scenario when the accepted (hand-preserving) action is chosen', () => {
+    const scenario = ENDGAME_HAND_SHAPE_SCENARIOS.find((entry) => entry.id === 'scenario:shape-proof-1')!;
+    const result = evaluateEndgameHandShapeResponse(scenario, { kind: 'move', action: scenario.acceptedActions[0] });
+    expect(result.result).toBe('passed');
+  });
+
+  it('fails a proof scenario when the tempting (hand-stranding) action is chosen', () => {
+    const scenario = ENDGAME_HAND_SHAPE_SCENARIOS.find((entry) => entry.id === 'scenario:shape-proof-1')!;
+    const result = evaluateEndgameHandShapeResponse(scenario, { kind: 'move', action: scenario.temptingActions[0] });
+    expect(result.result).toBe('failed');
+    expect(result.feedbackOutcomeKey).toBe('ignored_shape_math');
+  });
+
+  it('rejects an illegal authored response before controller submission', () => {
+    const scenario = ENDGAME_HAND_SHAPE_SCENARIOS.find((entry) => entry.id === 'scenario:shape-guided')!;
+    const result = evaluateEndgameHandShapeResponse(scenario, { kind: 'move', action: { tile: { low: 6, high: 6 }, position: 'left' } });
+    expect(result.kind).toBe('illegal');
+    expect(result.result).toBeUndefined();
+  });
+
+  it('keeps demonstration steps discrete', () => {
+    const demo = ENDGAME_HAND_SHAPE_SCENARIOS.find((entry) => entry.id === 'scenario:shape-demo')!;
+    expect(demo.demonstrationSteps?.map((step) => step.id)).toEqual(['shape-demo-position', 'shape-demo-tempting', 'shape-demo-accepted']);
+  });
+});

--- a/client/src/journey/lessons/endgameHandShape/endgameHandShapeBundle.ts
+++ b/client/src/journey/lessons/endgameHandShape/endgameHandShapeBundle.ts
@@ -1,0 +1,20 @@
+import type { JourneyAuthoredLessonBundle } from '../../journeyAuthoredLessonBundle.ts';
+import { ENDGAME_HAND_SHAPE_LESSON_DEFINITION } from './endgameHandShapeLesson.ts';
+import { ENDGAME_HAND_SHAPE_FEEDBACK } from './endgameHandShapeFeedback.ts';
+import { evaluateEndgameHandShapeResponse } from './endgameHandShapeEvaluator.ts';
+import { ENDGAME_HAND_SHAPE_SCENARIOS } from './endgameHandShapeScenarios.ts';
+
+export const ENDGAME_HAND_SHAPE_BUNDLE: JourneyAuthoredLessonBundle = {
+  contentId: ENDGAME_HAND_SHAPE_LESSON_DEFINITION.id,
+  definition: ENDGAME_HAND_SHAPE_LESSON_DEFINITION,
+  scenarios: Object.fromEntries(ENDGAME_HAND_SHAPE_SCENARIOS.map((scenario) => [scenario.id, scenario])),
+  feedback: ENDGAME_HAND_SHAPE_FEEDBACK,
+  presentation: {
+    tableTitle: 'Fritz’s Table',
+    lessonTitle: 'Endgame Hand Shape',
+    framingLine: 'Late in a hand, the tile you play matters less than the tiles it leaves behind.',
+    framingInstruction: 'Before you commit, check whether your remaining tiles still have somewhere to go.',
+    completionLine: 'You stopped playing the first legal tile you saw. You checked what stayed alive after it.',
+  },
+  evaluateResponse: evaluateEndgameHandShapeResponse,
+};

--- a/client/src/journey/lessons/endgameHandShape/endgameHandShapeEvaluator.ts
+++ b/client/src/journey/lessons/endgameHandShape/endgameHandShapeEvaluator.ts
@@ -1,0 +1,29 @@
+import { analyzeJourneyAuthoredMove, type JourneyAuthoredScenario, type JourneyScenarioEvaluation, type JourneyScenarioResponse } from '../../journeyAuthoredLessonBundle.ts';
+import type { EndgameHandShapeScenario } from './endgameHandShapeScenarios.ts';
+
+function actionKey(action: { tile: { low: number; high: number }; position: string }): string { return `${action.tile.low}-${action.tile.high}@${action.position}`; }
+function sameAction(a: { tile: { low: number; high: number }; position: string }, b: { tile: { low: number; high: number }; position: string }): boolean { return actionKey(a) === actionKey(b); }
+
+export function evaluateEndgameHandShapeResponse(scenarioInput: JourneyAuthoredScenario, response: JourneyScenarioResponse): JourneyScenarioEvaluation {
+  const scenario = scenarioInput as EndgameHandShapeScenario;
+  if (response.kind !== 'move') throw new Error(`Endgame Hand Shape expects move responses, received ${response.kind}.`);
+  const consequence = analyzeJourneyAuthoredMove(scenario, response.action);
+  const before = [scenario.board.leftEnd, scenario.board.rightEnd];
+  if (!consequence.legal) {
+    return { kind: 'illegal', feedbackOutcomeKey: 'illegal_action', decisionSummary: { total: 1, correct: 0, incorrect: 1 }, mistakeCategoryIds: ['mistake:illegal-action'], nextBoard: null, openEndsBefore: before, openEndsAfter: before, consequence };
+  }
+  const accepted = scenario.acceptedActions.some((action) => sameAction(action, response.action));
+  const acceptedResult = scenario.kind === 'proof' ? 'passed' : 'completed';
+  const feedbackOutcomeKey = scenario.feedbackByAction[actionKey(response.action)] ?? (accepted ? 'valid_alternative' : 'ignored_shape_math');
+  return {
+    kind: 'evaluated',
+    result: accepted ? acceptedResult : 'failed',
+    feedbackOutcomeKey,
+    decisionSummary: { total: 1, correct: accepted ? 1 : 0, incorrect: accepted ? 0 : 1 },
+    mistakeCategoryIds: accepted ? [] : ['mistake:stranded-a-tile'],
+    nextBoard: consequence.resultingBoard,
+    openEndsBefore: before,
+    openEndsAfter: consequence.resultingOpenEnds,
+    consequence,
+  };
+}

--- a/client/src/journey/lessons/endgameHandShape/endgameHandShapeFeedback.ts
+++ b/client/src/journey/lessons/endgameHandShape/endgameHandShapeFeedback.ts
@@ -1,0 +1,12 @@
+import type { JourneyFeedbackId } from '../../journeyContentContract.ts';
+import type { JourneyFeedbackAsset } from '../../journeyAuthoredLessonBundle.ts';
+
+export const ENDGAME_HAND_SHAPE_FEEDBACK_ID = 'journey:feedback:endgame-hand-shape' as JourneyFeedbackId;
+export const ENDGAME_HAND_SHAPE_FEEDBACK: Record<string, JourneyFeedbackAsset> = {
+  kept_hand_alive: { key: 'kept_hand_alive', heading: 'Your whole hand stayed live.', explanation: 'Both remaining tiles still had a legal reply after this play. Near the end of a hand, that matters more than which tile you played first.', fritzRemark: 'A dead tile in your hand is a dead turn later.', retryExpected: false },
+  stranded_a_tile: { key: 'stranded_a_tile', heading: 'That line stranded a tile.', explanation: 'This play was legal, but it left one of your remaining tiles with no legal reply at all. You will be stuck holding it until the board changes.', fritzRemark: null, retryExpected: true },
+  recognized_shape_math: { key: 'recognized_shape_math', heading: 'You read the shape.', explanation: 'You checked what each legal play left your hand able to do next, not just what it changed on the board.', fritzRemark: 'Endgame hands are won by which tiles still work, not which one you play first.', retryExpected: false },
+  ignored_shape_math: { key: 'ignored_shape_math', heading: 'One tile went dead.', explanation: 'This play was legal, but the alternative kept both of your remaining tiles playable. This one stranded a tile instead.', fritzRemark: null, retryExpected: true },
+  valid_alternative: { key: 'valid_alternative', heading: 'That line is defensible.', explanation: 'More than one legal move can keep your remaining hand equally live.', fritzRemark: null, retryExpected: false },
+  illegal_action: { key: 'illegal_action', heading: 'That placement is not legal.', explanation: 'Choose a tile and open end that match the board.', fritzRemark: null, retryExpected: true },
+};

--- a/client/src/journey/lessons/endgameHandShape/endgameHandShapeLesson.ts
+++ b/client/src/journey/lessons/endgameHandShape/endgameHandShapeLesson.ts
@@ -1,0 +1,29 @@
+import type { JourneyContentId, JourneyLessonDefinition, JourneyNodeId, JourneySkillId } from '../../journeyContentContract.ts';
+import { CORE_JOURNEY_RULESET_ID } from '../../journeyContentContract.ts';
+import { ENDGAME_HAND_SHAPE_FEEDBACK_ID } from './endgameHandShapeFeedback.ts';
+
+export const ENDGAME_HAND_SHAPE_CONTENT_ID = 'journey:ch3:endgame-hand-shape' as JourneyContentId;
+export const ENDGAME_HAND_SHAPE_NODE_ID = 'ch3-n07' as JourneyNodeId;
+export const ENDGAME_HAND_SHAPE_SKILL_ID = 'skill:endgame-hand-shape' as JourneySkillId;
+export const ENDGAME_HAND_SHAPE_PRACTICE_VARIANT_SET_ID = 'variants:endgame-hand-shape-practice';
+export const ENDGAME_HAND_SHAPE_PROOF_VARIANT_SET_ID = 'variants:endgame-hand-shape-proof';
+const feedback = { kind: 'outcome_bundle', id: ENDGAME_HAND_SHAPE_FEEDBACK_ID } as const;
+
+export const ENDGAME_HAND_SHAPE_LESSON_DEFINITION: JourneyLessonDefinition = {
+  id: ENDGAME_HAND_SHAPE_CONTENT_ID,
+  nodeId: ENDGAME_HAND_SHAPE_NODE_ID,
+  chapterId: 'ch3-long-march',
+  skillId: ENDGAME_HAND_SHAPE_SKILL_ID,
+  contentVersion: 1,
+  ruleset: { kind: 'core_journey', id: CORE_JOURNEY_RULESET_ID },
+  prerequisites: ['journey:ch2:blocked-hand-tiebreak' as JourneyContentId],
+  presentation: { tableContextId: 'table:fritz', rivalContextId: null },
+  stages: [
+    { id: 'welcome', kind: 'frame', copyRef: 'endgame-hand-shape:welcome', evidenceRole: 'none' },
+    { id: 'shape-demo', kind: 'board_demo', scenarioRef: 'scenario:shape-demo', evidenceRole: 'none' },
+    { id: 'guided-decision', kind: 'guided_practice', scenarioRef: 'scenario:shape-guided', feedbackRef: feedback, retry: { kind: 'same_scenario' }, evidenceRole: 'none', failurePolicy: 'retry_required' },
+    { id: 'independent-practice', kind: 'independent_practice', scenarioRef: 'scenario:shape-practice-1', feedbackRef: feedback, retry: { kind: 'fresh_variant', variantSetId: ENDGAME_HAND_SHAPE_PRACTICE_VARIANT_SET_ID }, evidenceRole: 'practice', failurePolicy: 'retry_required' },
+    { id: 'proof', kind: 'mastery', scenarioRef: 'scenario:shape-proof-1', feedbackRef: feedback, retry: { kind: 'fresh_variant', variantSetId: ENDGAME_HAND_SHAPE_PROOF_VARIANT_SET_ID }, evidenceRole: 'proof', failurePolicy: 'retry_required' },
+  ],
+  completion: { kind: 'required_stages', stageIds: ['independent-practice', 'proof'], owner: 'journey_lesson_controller' },
+};

--- a/client/src/journey/lessons/endgameHandShape/endgameHandShapeScenarios.ts
+++ b/client/src/journey/lessons/endgameHandShape/endgameHandShapeScenarios.ts
@@ -1,0 +1,97 @@
+import type { BoardState, Tile } from '../../../types.ts';
+import type { JourneyAuthoredMoveAction, JourneyAuthoredScenario, JourneyBoardDemonstrationStep } from '../../journeyAuthoredLessonBundle.ts';
+import { analyzeJourneyAuthoredMove, createJourneyScenarioState } from '../../journeyAuthoredLessonBundle.ts';
+import { previewPlayMove } from '../../../modules/match/runtime/botEngine.ts';
+import { CORE_JOURNEY_RULESET_ID } from '../../journeyContentContract.ts';
+import { ENDGAME_HAND_SHAPE_PRACTICE_VARIANT_SET_ID, ENDGAME_HAND_SHAPE_PROOF_VARIANT_SET_ID } from './endgameHandShapeLesson.ts';
+
+export type EndgameHandShapeScenario = JourneyAuthoredScenario & {
+  shapeFacts: { acceptedRemainingLegal: number; temptingRemainingLegal: number };
+};
+
+const tile = (low: number, high: number): Tile => ({ low, high });
+const core = { kind: 'core_journey' as const, id: CORE_JOURNEY_RULESET_ID };
+
+function singleTileBoard(a: number, b: number): BoardState {
+  return { mainLine: [{ tile: tile(a, b), orientation: 'horizontal-normal' }], leftEnd: a, rightEnd: b, leftEndIsDouble: false, rightEndIsDouble: false, hubDoubles: [] };
+}
+
+function actionKey(action: JourneyAuthoredMoveAction): string {
+  return `${action.tile.low}-${action.tile.high}@${action.position}`;
+}
+
+function baseScenario(board: BoardState, hand: Tile[]): JourneyAuthoredScenario {
+  return { id: 'tmp', variantSetId: null, kind: 'demo', ruleset: core, board, playerHand: hand, interaction: { kind: 'move' }, acceptedActions: [], temptingActions: [], feedbackByAction: {} };
+}
+
+function scenario(
+  id: string,
+  kind: EndgameHandShapeScenario['kind'],
+  variantSetId: string | null,
+  board: BoardState,
+  hand: Tile[],
+  accepted: JourneyAuthoredMoveAction,
+  tempting: JourneyAuthoredMoveAction,
+  acceptedFeedback: string,
+  temptingFeedback: string,
+): EndgameHandShapeScenario {
+  const base = baseScenario(board, hand);
+  const acceptedRemainingLegal = analyzeJourneyAuthoredMove(base, accepted).remainingLegalActionCount;
+  const temptingRemainingLegal = analyzeJourneyAuthoredMove(base, tempting).remainingLegalActionCount;
+  if (acceptedRemainingLegal <= temptingRemainingLegal) {
+    throw new Error(`${id}: accepted action must leave strictly more remaining legal actions than the tempting one (${acceptedRemainingLegal} vs ${temptingRemainingLegal})`);
+  }
+  return {
+    id, variantSetId, kind, ruleset: core, board, playerHand: hand, interaction: { kind: 'move' },
+    acceptedActions: [accepted], temptingActions: [tempting],
+    feedbackByAction: { [actionKey(accepted)]: acceptedFeedback, [actionKey(tempting)]: temptingFeedback },
+    shapeFacts: { acceptedRemainingLegal, temptingRemainingLegal },
+  };
+}
+
+const demoBoard = singleTileBoard(2, 4);
+const demoHand = [tile(2, 6), tile(4, 1), tile(6, 3)];
+const demoAccepted = { tile: tile(2, 6), position: 'left' as const };
+const demoTempting = { tile: tile(4, 1), position: 'right' as const };
+const demoBase = baseScenario(demoBoard, demoHand);
+
+const demoSteps: JourneyBoardDemonstrationStep[] = [
+  { id: 'shape-demo-position', kind: 'position', caption: 'Three tiles, two ends.', boardDescription: 'You hold 2-6, 4-1, and 6-3. The 2 and the 4 ends are both live right now.', board: demoBoard, highlightedEnds: [2, 4] },
+  { id: 'shape-demo-tempting', kind: 'preview_move', caption: 'Play the 4-end tile.', boardDescription: 'Playing 4-1 turns the right end to 1. Your 6-3 no longer matches either end — it goes dead in your hand.', board: previewPlayMove(createJourneyScenarioState(demoBase), 'you', { type: 'play', tile: demoTempting.tile, position: demoTempting.position })!.nextBoard, action: demoTempting, highlightedEnds: [2, 4] },
+  { id: 'shape-demo-accepted', kind: 'preview_move', caption: 'Compare playing 2-6 instead.', boardDescription: 'This turns the left end to 6, and the right end stays 4. Both 4-1 and 6-3 still have a legal reply — your whole hand stays live.', board: previewPlayMove(createJourneyScenarioState(demoBase), 'you', { type: 'play', tile: demoAccepted.tile, position: demoAccepted.position })!.nextBoard, action: demoAccepted, highlightedEnds: [2, 4] },
+];
+
+export const ENDGAME_HAND_SHAPE_SCENARIOS: EndgameHandShapeScenario[] = [
+  { ...scenario('scenario:shape-demo', 'demo', null, demoBoard, demoHand, demoAccepted, demoTempting, 'kept_hand_alive', 'stranded_a_tile'), demonstrationSteps: demoSteps },
+  scenario('scenario:shape-guided', 'guided', null, demoBoard, demoHand, demoAccepted, demoTempting, 'kept_hand_alive', 'stranded_a_tile'),
+  scenario(
+    'scenario:shape-practice-1', 'independent', ENDGAME_HAND_SHAPE_PRACTICE_VARIANT_SET_ID,
+    singleTileBoard(1, 5), [tile(1, 4), tile(5, 3), tile(4, 0)],
+    { tile: tile(1, 4), position: 'left' }, { tile: tile(5, 3), position: 'right' },
+    'recognized_shape_math', 'ignored_shape_math',
+  ),
+  scenario(
+    'scenario:shape-practice-2', 'independent', ENDGAME_HAND_SHAPE_PRACTICE_VARIANT_SET_ID,
+    singleTileBoard(0, 6), [tile(0, 2), tile(6, 4), tile(2, 5)],
+    { tile: tile(0, 2), position: 'left' }, { tile: tile(6, 4), position: 'right' },
+    'recognized_shape_math', 'ignored_shape_math',
+  ),
+  scenario(
+    'scenario:shape-practice-3', 'independent', ENDGAME_HAND_SHAPE_PRACTICE_VARIANT_SET_ID,
+    singleTileBoard(4, 6), [tile(4, 1), tile(6, 5), tile(1, 3)],
+    { tile: tile(4, 1), position: 'left' }, { tile: tile(6, 5), position: 'right' },
+    'recognized_shape_math', 'ignored_shape_math',
+  ),
+  scenario(
+    'scenario:shape-proof-1', 'proof', ENDGAME_HAND_SHAPE_PROOF_VARIANT_SET_ID,
+    singleTileBoard(3, 1), [tile(3, 5), tile(1, 2), tile(5, 6)],
+    { tile: tile(3, 5), position: 'left' }, { tile: tile(1, 2), position: 'right' },
+    'recognized_shape_math', 'ignored_shape_math',
+  ),
+  scenario(
+    'scenario:shape-proof-2', 'proof', ENDGAME_HAND_SHAPE_PROOF_VARIANT_SET_ID,
+    singleTileBoard(6, 2), [tile(6, 0), tile(2, 4), tile(0, 1)],
+    { tile: tile(6, 0), position: 'left' }, { tile: tile(2, 4), position: 'right' },
+    'recognized_shape_math', 'ignored_shape_math',
+  ),
+];

--- a/client/src/journey/lessons/endgameHandShape/endgameHandShapeValidation.ts
+++ b/client/src/journey/lessons/endgameHandShape/endgameHandShapeValidation.ts
@@ -1,0 +1,35 @@
+import { getLegalMoves } from '../../../modules/match/runtime/botEngine.ts';
+import { createJourneyScenarioState } from '../../journeyAuthoredLessonBundle.ts';
+import { ENDGAME_HAND_SHAPE_CONTENT_ID, ENDGAME_HAND_SHAPE_PRACTICE_VARIANT_SET_ID, ENDGAME_HAND_SHAPE_PROOF_VARIANT_SET_ID } from './endgameHandShapeLesson.ts';
+import { ENDGAME_HAND_SHAPE_FEEDBACK } from './endgameHandShapeFeedback.ts';
+import { ENDGAME_HAND_SHAPE_SCENARIOS } from './endgameHandShapeScenarios.ts';
+
+export function validateEndgameHandShapeContent(definition: { id: string; nodeId: string }): string[] {
+  const errors: string[] = [];
+  const ids = new Set<string>();
+  for (const scenario of ENDGAME_HAND_SHAPE_SCENARIOS) {
+    if (ids.has(scenario.id)) errors.push(`duplicate scenario ${scenario.id}`);
+    ids.add(scenario.id);
+    const legal = getLegalMoves(createJourneyScenarioState(scenario), 'you');
+    const legalAction = (action: { tile: { low: number; high: number }; position: string }) =>
+      legal.some((move) => move.type === 'play' && move.tile && move.position === action.position && move.tile.low === action.tile.low && move.tile.high === action.tile.high);
+    for (const action of [...scenario.acceptedActions, ...scenario.temptingActions]) {
+      if (!legalAction(action)) errors.push(`${scenario.id}: illegal authored action ${action.tile.low}-${action.tile.high}@${action.position}`);
+      const key = `${action.tile.low}-${action.tile.high}@${action.position}`;
+      if (!scenario.feedbackByAction[key] || !ENDGAME_HAND_SHAPE_FEEDBACK[scenario.feedbackByAction[key]]) errors.push(`${scenario.id}: missing feedback for ${key}`);
+    }
+    if (scenario.shapeFacts.acceptedRemainingLegal <= scenario.shapeFacts.temptingRemainingLegal) {
+      errors.push(`${scenario.id}: accepted action must leave strictly more remaining legal actions`);
+    }
+    for (const step of scenario.demonstrationSteps ?? []) {
+      if (!step.caption.trim() || !step.boardDescription.trim()) errors.push(`${scenario.id}: demonstration copy is empty`);
+      if (step.kind === 'preview_move' && !legalAction(step.action)) errors.push(`${scenario.id}: illegal demonstration preview ${step.id}`);
+    }
+  }
+  const practice = ENDGAME_HAND_SHAPE_SCENARIOS.filter((s) => s.variantSetId === ENDGAME_HAND_SHAPE_PRACTICE_VARIANT_SET_ID);
+  const proof = ENDGAME_HAND_SHAPE_SCENARIOS.filter((s) => s.variantSetId === ENDGAME_HAND_SHAPE_PROOF_VARIANT_SET_ID);
+  if (practice.length < 3) errors.push('endgame-hand-shape practice needs at least three variants');
+  if (proof.length < 2) errors.push('endgame-hand-shape proof needs at least two variants');
+  if (definition.id !== ENDGAME_HAND_SHAPE_CONTENT_ID || definition.nodeId !== 'ch3-n07') errors.push('endgame-hand-shape definition identity mismatch');
+  return errors.sort();
+}


### PR DESCRIPTION
## Summary

PR 5 (batch A of 2) of the Journey content overhaul ([scoping doc](../blob/main/docs/scoping/journey-overhaul-2026-09-12.md) §3/§6) — 3 of the 8 finalized lesson concepts, depends on PR 1 (merged; uses the existing lesson-authoring infra, not the match-variant work).

Each lesson follows the exact pattern already established by the 3 existing lessons (frame → board_demo → guided_practice → independent_practice → mastery), attached to an existing nodeId via the resolver-override mechanism — **no `chapters/*.nodes.ts` changes**. Each targets its chapter's own `-n07` checkpoint node (today an inert placeholder briefing), mirroring `ch1-n07`'s precedent — this spreads real lesson coverage across chapters 2-4 instead of clustering everything in Chapter 1, directly addressing the gap the scoping doc flagged.

- **`blockedHandTiebreak` → `ch2-n07`**: when a hand blocks, `blockedHandRule: 'lowestPips'` decides the winner by pip total. Teaches preferring the legal move that leaves your remaining hand strictly lighter, even when the alternative looks equally natural.
- **`endgameHandShape` → `ch3-n07`**: late in a hand, prefer the legal move that keeps more of your remaining tiles playable over one that strands a tile with no legal reply.
- **`defensiveHolding` → `ch4-n07`**: prefer exposing the open-end pip with fewer unseen tiles (harder for Fritz to hold a matching reply) over one that's still mostly unaccounted for.

Every scenario's accepted-vs-tempting claim is **computed and verified against the real engine at module-load time** (the scenario builder throws if an authored pair doesn't actually satisfy its invariant — pip total, remaining legal actions, or unseen-tile count), then re-verified in each lesson's own test suite and structural validator, matching the established `doublesArentFree`/`countingWhatsLeft` precedent.

Wired into `journeyAuthoredLessonRegistry.ts`, `journeyContentResolver.ts` (definitions list + per-lesson validation dispatch), and `journeyPremiumRuntimeRegistry.ts` (host registration — required for the Journey screen to actually open the lesson sheet). Updated `journeyContentResolver.test.ts`'s three hardcoded "3 lessons" snapshot assertions to the new real totals.

## Scope

No `chapters/*.nodes.ts` or `journeyChapters.ts` changes. `qa:journey-content:summary` confirms production content (108 nodes, 48 puzzles, per-chapter trial/puzzle breakdown) is byte-for-byte unchanged — only the resolver's premium-lesson attachment moved.

## Test plan
- [x] `client`: full vitest suite, 1780/1780 passing (was 1762 before this branch; +18 new lesson tests)
- [x] `client`: `tsc -b` clean
- [x] `client`: lint — 48/50 warning budget, no new warnings
- [x] `client`: `lint:hooks` — 0 warnings
- [x] `client`: `qa:journey-content:summary` confirms production content unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AKLxC13EHnEY8PBfuHQ79i