### PR TITLE
fix(journey): correct ch1-n03's illegal claimed answer

### DIFF
--- a/client/src/journey/journeyPuzzleEngineVerification.test.ts
+++ b/client/src/journey/journeyPuzzleEngineVerification.test.ts
@@ -62,25 +62,17 @@ describe('verifyJourneyPuzzleAgainstEngine', () => {
     expect(issues).toEqual([]);
   });
 
-  it('documents a real, pre-existing bug: ch1-n03\'s claimed correct tile is not actually legal', () => {
+  it('confirms ch1-n03 is now engine-legal after the content fix', () => {
     // ch1-n03 is the one production puzzle with boardState populated today.
     // Its chain is [6,6]-[6,3]-[5,3]-[5,5]: both end tiles are doubles, so the
-    // chain's genuine open ends are 6 and 5 — not the "3 and 5" the puzzle's
-    // own scenario text and `ends` field claim. The authored correctTile
-    // (3-4) cannot legally be played against this board at all; the only
-    // hand tile that actually is legal is 5-6 — the tile the puzzle's own
-    // narrative frames as the impulsive *wrong* answer (choice "b": "Strike
-    // fast on 3-4"). This was never caught because InteractivePuzzleModal's
-    // answer check is a plain tile-equality comparison against `correctTile`,
-    // not a real engine legality check — exactly the gap this tool closes.
-    // Confirmed as a genuine content bug, not a false positive from this
-    // tool; fixing the content is out of scope here (content-only change,
-    // deferred — see docs/scoping/journey-overhaul-2026-09-12.md).
+    // chain's genuine open ends are 6 and 5. It used to claim "3 and 5" and a
+    // correctTile (3-4) that was not actually a legal move against this
+    // board — this tool caught that. The content has since been corrected
+    // (see the ch1-n03 content-fix PR) so this now asserts a clean bill of
+    // health, guarding against the same class of bug recurring.
     const puzzle = JOURNEY_PUZZLES['ch1-n03'];
     expect(puzzle).toBeDefined();
     expect(puzzle.boardState).toBeDefined();
-    expect(verifyJourneyPuzzleAgainstEngine(puzzle)).toEqual([
-      expect.objectContaining({ code: 'correct_tile_illegal' }),
-    ]);
+    expect(verifyJourneyPuzzleAgainstEngine(puzzle)).toEqual([]);
   });
 });

--- a/client/src/journey/journeyPuzzles.ts
+++ b/client/src/journey/journeyPuzzles.ts
@@ -34,20 +34,20 @@ export const JOURNEY_PUZZLES: Record<string, JourneyPuzzle> = {
     eyebrow: "Puzzle · Open Ends",
     title: "Open Ends Trial",
     scenario:
-      "The board shows open ends of 3 and 5. You hold 3-4 and 5-6. Fritz leads the race to 60 by eight points, but you still have the lead this hand.",
+      "The board shows open ends of 6 and 5. You hold 3-4 and 5-6. Fritz leads the race to 60 by eight points, but you still have the lead this hand.",
     prompt: "Before you play, what is the soundest principle?",
     choices: [
-      { id: "a", label: "Read both open ends. They are scoring lanes, not just exits." },
-      { id: "b", label: "Strike fast on 3-4—one big score closes the gap." },
+      { id: "a", label: "Play 5-6. It actually reaches the board—3-4 touches neither open end." },
+      { id: "b", label: "Play 3-4 anyway—it's the safer, smaller commitment." },
       { id: "c", label: "Pass and wait for Fritz to open a mistake." },
       { id: "d", label: "Play the tile with the highest pip total." },
     ],
     correctChoiceId: "a",
     explanation:
-      "Two live ends mean two ways to score and two ways to be punished. Count both before you commit. The right tile keeps pressure on Fritz without handing him the reply he wants.",
+      "3-4 doesn't touch either open end—it isn't a legal reply here at all. 5-6 is the only tile that actually plays, and it fits both the 6 and the 5. Read what the board will actually accept before you decide what you'd like to play.",
     rewardLabel: "Open Eye",
     boardState: {
-      ends: [3, 5],
+      ends: [6, 5],
       placedTiles: [
         { high: 6, low: 6 },
         { high: 6, low: 3 },
@@ -59,7 +59,7 @@ export const JOURNEY_PUZZLES: Record<string, JourneyPuzzle> = {
       { high: 5, low: 6 },
       { high: 3, low: 4 },
     ],
-    correctTile: { high: 3, low: 4 },
+    correctTile: { high: 5, low: 6 },
   },
   "ch1-n08": {
     nodeId: "ch1-n08",


### PR DESCRIPTION
## Summary

Fixes the content bug PR 4's engine-verification tool ([#201](../../pull/201)) surfaced: `ch1-n03` ("Open Ends Trial") claimed its board's open ends were 3 and 5 and that the correct answer was the 3-4 tile. The actual tile chain (`[6,6]-[6,3]-[5,3]-[5,5]`) is capped on both ends by doubles, so the real open ends are 6 and 5 — 3-4 touches neither and was never a legal move against this board. The only tile that actually plays is 5-6, which the puzzle's own narrative had framed as the impulsive *wrong* answer.

Fixes `journeyPuzzles.ts`'s `ch1-n03` entry:
- `boardState.ends`: `[3, 5]` → `[6, 5]`, matching the real chain
- `correctTile`: `3-4` → `5-6`, the tile that's actually legal
- `scenario`/`choices`/`explanation` copy rewritten so choice "a" (still the correct answer) and its narrative match the corrected tile, rather than contradicting it

## Scope

Content-only change — no `chapters/*.nodes.ts`, `journeyChapters.ts`, or node structure changes. `qa:journey-content:summary` confirms the puzzle-type breakdown, per-chapter node counts, and answer distribution (still `a=12` overall, ch1 unchanged at `a=1/b=0/c=1/d=1`) are unaffected, since `correctChoiceId` stays `"a"`.

## Verification

Updated `journeyPuzzleEngineVerification.test.ts`'s `ch1-n03` assertion from "reports `correct_tile_illegal`" to "reports zero issues" — watched it fail against the old content (RED) before applying the fix, then pass (GREEN).

## Test plan
- [x] `client`: full vitest suite, 1799/1799 passing (same count as before — content-only, no new tests needed beyond flipping the existing assertion)
- [x] `client`: `tsc -b` clean
- [x] `client`: lint — 48/50 warning budget, no new warnings
- [x] `client`: `lint:hooks` — 0 warnings
- [x] `client`: `qa:journey-content:summary` confirms node/puzzle structure unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AKLxC13EHnEY8PBfuHQ79i